### PR TITLE
Renamed references to BDI_FieldMappingCustomMetadata and getDefaultMa…

### DIFF
--- a/src/classes/BDI_DataImportFLSService_TEST.cls
+++ b/src/classes/BDI_DataImportFLSService_TEST.cls
@@ -203,9 +203,9 @@ private class BDI_DataImportFLSService_TEST {
                 CampaignMember.CampaignId);
         mock.mapField(DataImport__c.Campaign_Member_Status__c, CampaignMember.SObjectType,
                 CampaignMember.Status);
-        BDI_FieldMappingCustomMetadata stub = (BDI_FieldMappingCustomMetadata) Test.createStub(
-                BDI_FieldMappingCustomMetadata.class, mock);
-        BDI_FieldMappingCustomMetadata.setInstance(stub);
+        BDI_MappingServiceAdvanced stub = (BDI_MappingServiceAdvanced) Test.createStub(
+                BDI_MappingServiceAdvanced.class, mock);
+        BDI_MappingServiceAdvanced.setInstance(stub);
 
         Campaign campaign = new Campaign(Name = 'Test Campaign');
         insert campaign;
@@ -219,7 +219,7 @@ private class BDI_DataImportFLSService_TEST {
                 new List<DataImport__c> {
                         dataImport
                 },
-                BDI_DataImportService.getDefaultFieldMapping(),
+                BDI_DataImportService.getDefaultMappingService(),
                 accessLevels
         );
 


### PR DESCRIPTION
…pping

# Critical Changes

# Changes
- Renamed references to `BDI_FieldMappingCustomMetadata` and `getDefaultMapping` to 
`BDI_MappingServiceAdvanced` and `getDefaultMappingService` accordingly in the `BDI_DataImportFLSService_TEST` test class

# Issues Closed

# New Metadata

# Deleted Metadata
