### PR TITLE
HGE: Adjust css classes and styles for form layout

### DIFF
--- a/src/lwc/geFormRenderer/geFormRenderer.css
+++ b/src/lwc/geFormRenderer/geFormRenderer.css
@@ -1,6 +1,3 @@
-.ge-form-container {
-    padding-bottom: 65px;
-}
 .ge-form-footer {
     height: 50px;
 }

--- a/src/lwc/geFormRenderer/geFormRenderer.html
+++ b/src/lwc/geFormRenderer/geFormRenderer.html
@@ -1,5 +1,5 @@
 <template>
-    <lightning-layout multiple-rows='true' class='ge-form-container'>
+    <lightning-layout multiple-rows='true' class='ge-form-container slds-p-bottom_medium'>
         <lightning-layout-item size='12' class='slds-card'>
             <div if:true={hasPageLevelError} class="slds-size_1-of-1 slds-card slds-p-around_small">
                 <c-util-page-level-message variant='error'>

--- a/src/lwc/geFormSection/geFormSection.html
+++ b/src/lwc/geFormSection/geFormSection.html
@@ -4,6 +4,7 @@
             onclick={toggleExpand}>
         <h2>
             <lightning-icon icon-name={iconName} 
+                class='slds-p-right_x-small'    
                 size='x-small'
                 alternative-text='{altTextLabel}'>
             </lightning-icon>


### PR DESCRIPTION
This pull removes a 65px padding from the bottom of the GE form that was adding a visually strange gap between the form and the table of entered rows when viewing in batch mode. It also adds a small gap beween the the ">" used to expand a section and the section label. 

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
