### PR TITLE
Gift Entry: Added validation on template save

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4678,6 +4678,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>You must include all required fields in your template. Review the source fields (NPSP Data Import object) for the following fields:</value>
     </labels>
     <labels>
+        <fullName>geErrorPageLevelMissingRequiredGroupFields</fullName>
+        <categories>Gift Entry</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>geErrorPageLevelMissingRequiredGroupFields</shortDescription>
+        <value>At least one of the following fields is required: {0}</value>
+    </labels>
+    <labels>
         <fullName>geErrorRequiredField</fullName>
         <categories>Gift Entry</categories>
         <language>en_US</language>

--- a/src/lwc/geLabelService/geLabelService.js
+++ b/src/lwc/geLabelService/geLabelService.js
@@ -52,6 +52,7 @@ import geErrorPageLevelAdvancedMappingHeader from '@salesforce/label/c.geErrorPa
 import geErrorPageLevelFieldPermission1 from '@salesforce/label/c.geErrorPageLevelFieldPermission1';
 import geErrorPageLevelFieldPermission2 from '@salesforce/label/c.geErrorPageLevelFieldPermission2';
 import geErrorPageLevelMissingRequiredFields from '@salesforce/label/c.geErrorPageLevelMissingRequiredFields';
+import geErrorPageLevelMissingRequiredGroupFields from '@salesforce/label/c.geErrorPageLevelMissingRequiredGroupFields';
 import geErrorRequiredField from '@salesforce/label/c.geErrorRequiredField';
 import geHeaderBatchHeaderLeftCol from '@salesforce/label/c.geHeaderBatchHeaderLeftCol';
 import geHeaderBatchHeaderRightCol from '@salesforce/label/c.geHeaderBatchHeaderRightCol';
@@ -143,6 +144,7 @@ class GeLabelService {
         geErrorPageLevelFieldPermission1,
         geErrorPageLevelFieldPermission2,
         geErrorPageLevelMissingRequiredFields,
+        geErrorPageLevelMissingRequiredGroupFields,
         geErrorRequiredField,
         geHeaderBatchHeaderLeftCol,
         geHeaderBatchHeaderRightCol,

--- a/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.html
+++ b/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.html
@@ -73,6 +73,7 @@
                                                      class="slds-truncate slds-p-bottom_xxx-small"
                                                      title={fieldMapping.DeveloperName}
                                                      required={fieldMapping.Is_Required}
+                                                     data-source-api-name={fieldMapping.Source_Field_API_Name}
                                                      data-object-mapping-label={objectMapping.MasterLabel}
                                                      data-field-mapping={fieldMapping.DeveloperName}
                                                      data-object-mapping={objectMapping.DeveloperName}>

--- a/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.html
+++ b/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.html
@@ -73,7 +73,6 @@
                                                      class="slds-truncate slds-p-bottom_xxx-small"
                                                      title={fieldMapping.DeveloperName}
                                                      required={fieldMapping.Is_Required}
-                                                     data-source-api-name={fieldMapping.Source_Field_API_Name}
                                                      data-object-mapping-label={objectMapping.MasterLabel}
                                                      data-field-mapping={fieldMapping.DeveloperName}
                                                      data-object-mapping={objectMapping.DeveloperName}>

--- a/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
+++ b/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
@@ -1,5 +1,4 @@
 import { LightningElement, track, api, wire } from 'lwc';
-import { findIndexByProperty, mutable, generateId, dispatch, showToast } from 'c/utilTemplateBuilder';
 import { generateId, dispatch, showToast } from 'c/utilTemplateBuilder';
 import { mutable, findIndexByProperty } from 'c/utilCommon';
 import TemplateBuilderService from 'c/geTemplateBuilderService';

--- a/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
+++ b/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
@@ -86,8 +86,7 @@ export default class geTemplateBuilderFormFields extends LightningElement {
             if (REQUIRED_FORM_FIELDS.includes(el.getAttribute('data-source-api-name')) && el.checked) {
               countOfConditionallyRequiredFormFields++;
             }
-            if (!el.checked && (el.required ||
-                el.getAttribute('data-source-api-name') === DONATION_DONOR_INFO.fieldApiName)) {
+            if (el.required && !el.checked) {
                 objectMappingsWithMissingRequiredFields.add(el.getAttribute('data-object-mapping'));
                 let objectMappingLabel = el.getAttribute('data-object-mapping-label');
                 missingRequiredFieldMappings.push(`${objectMappingLabel}: ${el.label}`);
@@ -371,6 +370,8 @@ export default class geTemplateBuilderFormFields extends LightningElement {
             this.handleRemoveFormElement(name);
         }
 
+        fieldMapping.Is_Required =
+            fieldMapping.Target_Field_Label === DONATION_DONOR_LABEL ? true : fieldMapping.Is_Required;
         if (fieldMapping.Is_Required) {
             this.validate();
         }
@@ -655,7 +656,7 @@ export default class geTemplateBuilderFormFields extends LightningElement {
             let character;
             if (i < REQUIRED_FORM_FIELDS.length - 1) {
                 character = COMMA_CHARACTER;
-            }else if ( i === REQUIRED_FORM_FIELDS.length - 1) {
+            } else if ( i === REQUIRED_FORM_FIELDS.length - 1) {
                 character = PERIOD_CHARACTER;
             }
             REQUIRED_FORM_FIELDS_MESSAGE += objectData.fields[REQUIRED_FORM_FIELDS[i]].label + character;

--- a/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
+++ b/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
@@ -150,8 +150,8 @@ export default class geTemplateBuilderFormFields extends LightningElement {
                 this.objectMappingNames = [...this.objectMappingNames, objMappingDevName];
 
                 let fieldMappings = TemplateBuilderService.fieldMappingsByObjMappingDevName[objMappingDevName];
-                fieldMappings.forEach(fieldMapping => {
-                    if(fieldMapping.Target_Field_Label === DONATION_DONOR_LABEL){
+                fieldMappings.forEach (fieldMapping => {
+                    if (fieldMapping.Target_Field_Label === DONATION_DONOR_LABEL) {
                         //Forcing the requiredness of the Donation Donor field mapping
                         fieldMapping.Is_Required = true;
                     }

--- a/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
+++ b/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
@@ -20,6 +20,9 @@ import CONTACT1_LASTNAME_INFO from '@salesforce/schema/DataImport__c.Contact1_La
 import ACCOUNT1_NAME_INFO from '@salesforce/schema/DataImport__c.Account1_Name__c';
 
 const WARNING = 'warning';
+const DONATION_DONOR_LABEL = 'Donation Donor';
+const REQUIRED_FORM_FIELDS_MESSAGE = 'Account1 Imported, Account1 Name, Contact1 Imported, Contact1 Last Name';
+
 
 // Default form fields to add to new templates
 const DEFAULT_FORM_FIELDS = {
@@ -84,10 +87,10 @@ export default class geTemplateBuilderFormFields extends LightningElement {
             this.validateGiftField(el);
         });
         if (counter === 0) {
-            let requireMessageLabel = 'Required Fields';
-            let requiredMessage = 'At least one of the following fields are required: Account Imported, ' +
-                'Account Name, Contact Imported, Contact Last Name.';
-            missingRequiredFieldMappings.push(`${requireMessageLabel}: ${requiredMessage}`);
+            let requiredGroupFieldsMessage = GeLabelService.format(
+                this.CUSTOM_LABELS.geErrorPageLevelMissingRequiredGroupFields,
+                [REQUIRED_FORM_FIELDS_MESSAGE]);
+            missingRequiredFieldMappings.push(`${requiredGroupFieldsMessage}`);
         }
 
         if (missingRequiredFieldMappings.length > 0) {
@@ -147,6 +150,12 @@ export default class geTemplateBuilderFormFields extends LightningElement {
                 this.objectMappingNames = [...this.objectMappingNames, objMappingDevName];
 
                 let fieldMappings = TemplateBuilderService.fieldMappingsByObjMappingDevName[objMappingDevName];
+                fieldMappings.forEach(fieldMapping => {
+                    if(fieldMapping.Target_Field_Label === DONATION_DONOR_LABEL){
+                        //Forcing the requiredness of the Donation Donor field mapping
+                        fieldMapping.Is_Required = true;
+                    }
+                });
                 let objectMapping = {
                     ...TemplateBuilderService.objectMappingByDevName[objMappingDevName],
                     Field_Mappings: fieldMappings

--- a/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
+++ b/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
@@ -16,6 +16,8 @@ import PAYMENT_METHOD_INFO from '@salesforce/schema/DataImport__c.Payment_Method
 import ACCOUNT1_IMPORTED_INFO from '@salesforce/schema/DataImport__c.Account1Imported__c';
 import CONTACT1_IMPORTED_INFO from '@salesforce/schema/DataImport__c.Contact1Imported__c';
 import DONATION_DONOR_INFO from '@salesforce/schema/DataImport__c.Donation_Donor__c';
+import CONTACT1_LASTNAME_INFO from '@salesforce/schema/DataImport__c.Contact1_Lastname__c';
+import ACCOUNT1_NAME_INFO from '@salesforce/schema/DataImport__c.Account1_Name__c';
 
 const WARNING = 'warning';
 
@@ -29,6 +31,14 @@ const DEFAULT_FORM_FIELDS = {
     [PAYMENT_CHECK_REF_NUM_INFO.fieldApiName]: PAYMENT_INFO.objectApiName,
     [PAYMENT_METHOD_INFO.fieldApiName]: PAYMENT_INFO.objectApiName,
 }
+
+// Required form fields for template save validation
+const REQUIRED_FORM_FIELDS = [
+    ACCOUNT1_IMPORTED_INFO.fieldApiName,
+    ACCOUNT1_NAME_INFO.fieldApiName,
+    CONTACT1_IMPORTED_INFO.fieldApiName,
+    CONTACT1_LASTNAME_INFO.fieldApiName
+];
 
 export default class geTemplateBuilderFormFields extends LightningElement {
 
@@ -58,8 +68,14 @@ export default class geTemplateBuilderFormFields extends LightningElement {
         let missingRequiredFieldMappings = [];
 
         const elements = this.template.querySelectorAll('lightning-input');
+        let counter = 0;
+
         elements.forEach(el => {
-            if (el.required && !el.checked) {
+            if (REQUIRED_FORM_FIELDS.includes(el.getAttribute('data-source-api-name')) && el.checked) {
+              counter++;
+            }
+            if (el.required && !el.checked ||
+                el.getAttribute('data-source-api-name') === DONATION_DONOR_INFO.fieldApiName && !el.checked) {
                 objectMappingsWithMissingRequiredFields.add(el.getAttribute('data-object-mapping'));
                 let objectMappingLabel = el.getAttribute('data-object-mapping-label');
                 missingRequiredFieldMappings.push(`${objectMappingLabel}: ${el.label}`);
@@ -67,6 +83,12 @@ export default class geTemplateBuilderFormFields extends LightningElement {
 
             this.validateGiftField(el);
         });
+        if (counter === 0) {
+            let requireMessageLabel = 'Required Fields';
+            let requiredMessage = 'At least one of the following fields are required: Account Imported, ' +
+                'Account Name, Contact Imported, Contact Last Name.';
+            missingRequiredFieldMappings.push(`${requireMessageLabel}: ${requiredMessage}`);
+        }
 
         if (missingRequiredFieldMappings.length > 0) {
             const lightningAccordion = this.template.querySelector('lightning-accordion');

--- a/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
+++ b/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
@@ -652,6 +652,7 @@ export default class geTemplateBuilderFormFields extends LightningElement {
      * @param {object} objectData: Returned Object Schema
      */
     buildRequiredFieldsMessage(objectData){
+        REQUIRED_FORM_FIELDS_MESSAGE = ''; // Clear out required fields placeholder
         for (let i= 0; i< REQUIRED_FORM_FIELDS.length; i++) {
             let character;
             if (i < REQUIRED_FORM_FIELDS.length - 1) {

--- a/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
+++ b/src/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
@@ -68,9 +68,9 @@ export default class geTemplateBuilderFormFields extends LightningElement {
 
 
     @wire(getObjectInfo, { objectApiName: DATA_IMPORT_INFO })
-        dataImportObjectInfo({ objectData, error }) {
-            if (objectData) {
-                this.buildRequiredFieldsMessage(objectData);
+        dataImportObjectInfo({ data, error }) {
+            if (data) {
+                this.buildRequiredFieldsMessage(data);
             }
         }
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -1906,6 +1906,7 @@
         <members>geErrorPageLevelFieldPermission1</members>
         <members>geErrorPageLevelFieldPermission2</members>
         <members>geErrorPageLevelMissingRequiredFields</members>
+        <members>geErrorPageLevelMissingRequiredGroupFields</members>
         <members>geErrorRequiredField</members>
         <members>geHeaderBatchHeaderLeftCol</members>
         <members>geHeaderBatchHeaderRightCol</members>


### PR DESCRIPTION
# Critical Changes

# Changes

- Made changes to the template save validation logic to enforce the Donation Donor and one of the follow fields: Account1 Imported, Account1 Name, Contact1 Imported, Contact1 Last Name on template save.

# Issues Closed

# New Metadata

- Custom Label : `geErrorPageLevelMissingRequiredGroupFields`

# Deleted Metadata
