### PR TITLE
RD2: Create next Opportunity for RD having Closed Lost Opp in migration

### DIFF
--- a/src/classes/RD2_DataMigrationBase_BATCH.cls
+++ b/src/classes/RD2_DataMigrationBase_BATCH.cls
@@ -41,7 +41,12 @@ public abstract class RD2_DataMigrationBase_BATCH implements Database.Batchable<
     public static final String LOG_CONTEXT_DRY_RUN = 'RDValidateMigration:';
     public static final String LOG_EXCEPTION_ERROR_TYPE = 'Data Migration Exception';
 
-    public static final Integer MIGRATION_INSTALLMENT_NUMBER = RD2_OpportunityService.MIGRATION_INSTALLMENT_NUMBER;
+    /**
+     * @description A flag to mark Closed Lost Opps that are voided by the data migration. 
+     * The flag is used to exclude (ignore) such Opps by the Opp service
+     * when determining if the next Opp with the same Close Date can be created.
+     */
+    public static final Integer MIGRATION_INSTALLMENT_NUMBER_FLAG = RD2_OpportunityService.MIGRATION_INSTALLMENT_NUMBER_FLAG;
 
     /**
     * @description Contains Recurring Donation custom settings
@@ -318,7 +323,11 @@ public abstract class RD2_DataMigrationBase_BATCH implements Database.Batchable<
         } else if (rdSettings.npe03__Open_Opportunity_Behavior__c == RD2_Constants.CloseActions.Mark_Opportunities_Closed_Lost.name()) {
             for (Opportunity opp : opps) {
                 opp.StageName = System.Label.npe03.RecurringDonationClosedLostOpportunityStage;
-                opp.Recurring_Donation_Installment_Number__c = MIGRATION_INSTALLMENT_NUMBER;
+
+                //Overwrite the Opp Installment Number so this Opp can be recognized and excluded 
+                //by RD2 Opp processing services when determining the next Opp with the same Close Date on the Recurring Donation
+                opp.Recurring_Donation_Installment_Number__c = MIGRATION_INSTALLMENT_NUMBER_FLAG;
+                //Indicate the Opp was set as Closed Lost due to switching to the new enhanced (RD2) processing
                 opp.Closed_Lost_Reason__c = logContext;
             }
 

--- a/src/classes/RD2_DataMigrationBase_BATCH.cls
+++ b/src/classes/RD2_DataMigrationBase_BATCH.cls
@@ -41,6 +41,8 @@ public abstract class RD2_DataMigrationBase_BATCH implements Database.Batchable<
     public static final String LOG_CONTEXT_DRY_RUN = 'RDValidateMigration:';
     public static final String LOG_EXCEPTION_ERROR_TYPE = 'Data Migration Exception';
 
+    public static final Integer MIGRATION_INSTALLMENT_NUMBER = RD2_OpportunityService.MIGRATION_INSTALLMENT_NUMBER;
+
     /**
     * @description Contains Recurring Donation custom settings
     */
@@ -316,6 +318,8 @@ public abstract class RD2_DataMigrationBase_BATCH implements Database.Batchable<
         } else if (rdSettings.npe03__Open_Opportunity_Behavior__c == RD2_Constants.CloseActions.Mark_Opportunities_Closed_Lost.name()) {
             for (Opportunity opp : opps) {
                 opp.StageName = System.Label.npe03.RecurringDonationClosedLostOpportunityStage;
+                opp.Recurring_Donation_Installment_Number__c = MIGRATION_INSTALLMENT_NUMBER;
+                opp.Closed_Lost_Reason__c = logContext;
             }
 
             dmlResults = Database.update(opps, false);

--- a/src/classes/RD2_DataMigration_TEST.cls
+++ b/src/classes/RD2_DataMigration_TEST.cls
@@ -41,7 +41,7 @@ private class RD2_DataMigration_TEST {
     private static final Date DATE_ESTABLISHED = TODAY.addMonths(-3);
     private static final Decimal AMOUNT_VALUE = 100;
     private static String LOG_CONTEXT = 'RunDataMigrationTest';
-    private static Integer MIGRATION_INSTALLMENT_NUMBER = RD2_OpportunityService.MIGRATION_INSTALLMENT_NUMBER;
+    private static Integer MIGRATION_INSTALLMENT_NUMBER_FLAG = RD2_OpportunityService.MIGRATION_INSTALLMENT_NUMBER_FLAG;
 
     private static final TEST_SObjectGateway.RecurringDonationScheduleGateway rdScheduleGateway = new TEST_SObjectGateway.RecurringDonationScheduleGateway();
     private static final TEST_SObjectGateway.OpportunityGateway oppGateway = new TEST_SObjectGateway.OpportunityGateway();
@@ -1163,7 +1163,7 @@ private class RD2_DataMigration_TEST {
 
         opp = oppById.get(opps[3].Id);
         System.assertEquals(true, opp.IsClosed && !opp.IsWon, 'The next future Open Opp should be Closed Lost');
-        System.assertEquals(MIGRATION_INSTALLMENT_NUMBER, opp.Recurring_Donation_Installment_Number__c, 
+        System.assertEquals(MIGRATION_INSTALLMENT_NUMBER_FLAG, opp.Recurring_Donation_Installment_Number__c, 
             'The Closed Lost Opp should have the Installment Number overriden');
         System.assertEquals(getLogContextMigration(jobId), opp.Closed_Lost_Reason__c, 'Closed Lost Reason should indicate migration');
 
@@ -1233,7 +1233,7 @@ private class RD2_DataMigration_TEST {
 
         opp = oppById.get(opps[3].Id);
         System.assertEquals(true, opp.IsClosed && !opp.IsWon, 'The next future Open Opp should be Closed Lost');
-        System.assertEquals(MIGRATION_INSTALLMENT_NUMBER, opp.Recurring_Donation_Installment_Number__c, 
+        System.assertEquals(MIGRATION_INSTALLMENT_NUMBER_FLAG, opp.Recurring_Donation_Installment_Number__c, 
             'The Closed Lost Opp should have the Installment Number overriden');
         System.assertEquals(getLogContextMigration(jobId), opp.Closed_Lost_Reason__c, 'Closed Lost Reason should indicate migration');
 

--- a/src/classes/RD2_DataMigration_TEST.cls
+++ b/src/classes/RD2_DataMigration_TEST.cls
@@ -41,6 +41,7 @@ private class RD2_DataMigration_TEST {
     private static final Date DATE_ESTABLISHED = TODAY.addMonths(-3);
     private static final Decimal AMOUNT_VALUE = 100;
     private static String LOG_CONTEXT = 'RunDataMigrationTest';
+    private static Integer MIGRATION_INSTALLMENT_NUMBER = RD2_OpportunityService.MIGRATION_INSTALLMENT_NUMBER;
 
     private static final TEST_SObjectGateway.RecurringDonationScheduleGateway rdScheduleGateway = new TEST_SObjectGateway.RecurringDonationScheduleGateway();
     private static final TEST_SObjectGateway.OpportunityGateway oppGateway = new TEST_SObjectGateway.OpportunityGateway();
@@ -1016,7 +1017,7 @@ private class RD2_DataMigration_TEST {
      * @description Verifies Recurring Donation with no Open Opportunity is converted successfully
      */
     @IsTest
-    private static void shouldNotChangeAlreadyClosedOpps() {
+    private static void shouldNotVoidClosedWonOpps() {
         setCloseActionSettingsToClosedLost();
 
         npe03__Recurring_Donation__c rd = createLegacyRecurringDonationNoOpps();
@@ -1110,21 +1111,25 @@ private class RD2_DataMigration_TEST {
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withName()
+                .withInstallmentNumber(1)
                 .withCloseDate(DATE_ESTABLISHED)
                 .withClosedWonStage()
                 .build(),
             oppBuilder
                 .withName()
+                .withInstallmentNumber(2)
                 .withCloseDate(TODAY.addDays(-1))
                 .withOpenStage()
                 .build(),
             oppBuilder
                 .withName()
+                .withInstallmentNumber(3)
                 .withCloseDate(TODAY)
                 .withOpenStage()
                 .build(),
             oppBuilder
                 .withName()
+                .withInstallmentNumber(4)
                 .withCloseDate(TODAY.addDays(1))
                 .withOpenStage()
                 .build()
@@ -1140,12 +1145,27 @@ private class RD2_DataMigration_TEST {
 
         Map<Id, Opportunity> oppById = new Map<Id, Opportunity>(oppGateway.getRecords(rd));
         System.assertEquals(opps.size(), oppById.size(), 'Number of Opportunities should match');
-        System.assertEquals(true, oppById.get(opps[0].Id).IsClosed && oppById.get(opps[0].Id).IsWon, 'Already Closed Won Opp should be unchanged');
-        System.assertEquals(false, oppById.get(opps[1].Id).IsClosed, 'Open Opp with Close Date in the past should stay open');
-        System.assertEquals(false, oppById.get(opps[2].Id).IsClosed, 'Open Opp with Close Date equal to today should stay open');
 
-        System.assertEquals(true, oppById.get(opps[3].Id).IsClosed && !oppById.get(opps[3].Id).IsWon,
-            'The next future Open Opp should be Closed Lost');
+        Opportunity opp = oppById.get(opps[0].Id);
+        System.assertEquals(true, opp.IsClosed && opp.IsWon, 'Already Closed Won Opp should be unchanged');
+        System.assertEquals(opps[0].Recurring_Donation_Installment_Number__c, opp.Recurring_Donation_Installment_Number__c, 
+            'The Opp Installment Number should be unchanged');
+
+        opp = oppById.get(opps[1].Id);
+        System.assertEquals(false, opp.IsClosed, 'Open Opp with Close Date in the past should stay open');
+        System.assertEquals(opps[1].Recurring_Donation_Installment_Number__c, opp.Recurring_Donation_Installment_Number__c, 
+            'The Opp Installment Number should be unchanged');
+
+        opp = oppById.get(opps[2].Id);
+        System.assertEquals(false, opp.IsClosed, 'Open Opp with Close Date equal to today should stay open');
+        System.assertEquals(opps[2].Recurring_Donation_Installment_Number__c, opp.Recurring_Donation_Installment_Number__c, 
+            'The Opp Installment Number should be unchanged');
+
+        opp = oppById.get(opps[3].Id);
+        System.assertEquals(true, opp.IsClosed && !opp.IsWon, 'The next future Open Opp should be Closed Lost');
+        System.assertEquals(MIGRATION_INSTALLMENT_NUMBER, opp.Recurring_Donation_Installment_Number__c, 
+            'The Closed Lost Opp should have the Installment Number overriden');
+        System.assertEquals(getLogContextMigration(jobId), opp.Closed_Lost_Reason__c, 'Closed Lost Reason should indicate migration');
 
         assertBatchSummarySuccess(jobId, 1);
     }
@@ -1169,21 +1189,25 @@ private class RD2_DataMigration_TEST {
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withName()
+                .withInstallmentNumber(1)
                 .withCloseDate(DATE_ESTABLISHED)
                 .withClosedWonStage()
                 .build(),
             oppBuilder
                 .withName()
+                .withInstallmentNumber(2)
                 .withCloseDate(TODAY.addDays(-1))
                 .withOpenStage()
                 .build(),
             oppBuilder
                 .withName()
+                .withInstallmentNumber(3)
                 .withCloseDate(TODAY.addDays(1))
                 .withOpenStage()
                 .build(),
             oppBuilder
                 .withName()
+                .withInstallmentNumber(4)
                 .withCloseDate(TODAY.addDays(2))
                 .withOpenStage()
                 .build()
@@ -1201,10 +1225,17 @@ private class RD2_DataMigration_TEST {
         System.assertEquals(opps.size(), oppById.size(), 'Number of Opportunities should match');
         System.assertEquals(true, oppById.get(opps[0].Id).IsClosed && oppById.get(opps[0].Id).IsWon, 'Already Closed Won Opp should be unchanged');
         System.assertEquals(false, oppById.get(opps[1].Id).IsClosed, 'Open Opp with Close Date in the past should stay open');
-        System.assertEquals(false, oppById.get(opps[2].Id).IsClosed, 'The first future Open Opp should stay open');
 
-        System.assertEquals(true, oppById.get(opps[3].Id).IsClosed && !oppById.get(opps[3].Id).IsWon,
-            'The next future Open Opp should be Closed Lost');
+        Opportunity opp = oppById.get(opps[2].Id);
+        System.assertEquals(false, opp.IsClosed, 'The first future Open Opp should stay open');
+        System.assertEquals(opps[2].Recurring_Donation_Installment_Number__c, opp.Recurring_Donation_Installment_Number__c, 
+            'The Opp Installment Number should be unchanged');
+
+        opp = oppById.get(opps[3].Id);
+        System.assertEquals(true, opp.IsClosed && !opp.IsWon, 'The next future Open Opp should be Closed Lost');
+        System.assertEquals(MIGRATION_INSTALLMENT_NUMBER, opp.Recurring_Donation_Installment_Number__c, 
+            'The Closed Lost Opp should have the Installment Number overriden');
+        System.assertEquals(getLogContextMigration(jobId), opp.Closed_Lost_Reason__c, 'Closed Lost Reason should indicate migration');
 
         assertBatchSummarySuccess(jobId, 1);
     }
@@ -1268,7 +1299,7 @@ private class RD2_DataMigration_TEST {
      * @description Verifies Recurring Donations and their Open Opportunities are migrated together successfully
      */
     @IsTest
-    private static void shouldConvertRecurringDonationsAndVoidOpenOppsInBulk() {
+    private static void shouldVoidOpenOppsInBulk() {
         setCloseActionSettingsToClosedLost();
 
         List<npe03__Recurring_Donation__c> rds = createLegacyRecurringDonationsNoOpps(2);

--- a/src/classes/RD2_OpportunityEvaluation_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluation_TEST.cls
@@ -44,6 +44,8 @@ private class RD2_OpportunityEvaluation_TEST {
 
     private static final Date START_DATE = Date.newInstance(2019, 9, 15);
 
+    public static final Integer MIGRATION_INSTALLMENT_NUMBER = RD2_OpportunityService.MIGRATION_INSTALLMENT_NUMBER;
+
     /****
     * @description Creates data required for unit tests
     */
@@ -110,7 +112,7 @@ private class RD2_OpportunityEvaluation_TEST {
      * @description Verifies an Opp with Close Date today is not created if it already exists
      */
     @IsTest
-    private static void shouldNotCreateDuplicateOppWhenCloseDateIsToday() {
+    private static void shouldNotCreateDuplicateOppWhenNextCloseDateIsToday() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         final Date today = START_DATE.addMonths(1);
@@ -140,7 +142,7 @@ private class RD2_OpportunityEvaluation_TEST {
      * @description Verifies an Opp with Close Date in future is not created if it already exists
      */
     @IsTest
-    private static void shouldNotCreateDuplicateOppWhenCloseDateIsInFuture() {
+    private static void shouldNotCreateDuplicateOppWhenNextCloseDateIsInFuture() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         final Date today = START_DATE.addMonths(1).addDays(1);
@@ -423,6 +425,74 @@ private class RD2_OpportunityEvaluation_TEST {
         List<Error__c> errors = errorGateway.getRecords();
         System.assertEquals(1, errors.size(), 'An error should be created: ' + errors);
     }
+
+    /**
+     * @description Verifies an Opp with the next Close Date is created
+     * when the same Close Date Opp is Closed Lost in data migration
+     */
+    @IsTest
+    private static void shouldCreateNextOppWhenSameCloseDateOppIsClosedLostInMigration() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        final Date today = START_DATE.addDays(1);
+        final Date nextCloseDate = START_DATE.addMonths(1);
+        RD2_ScheduleService.currentDate = today;
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
+        insert rd;
+
+        insert getOpportunityBuilder(rd)
+            .withInstallmentNumber(MIGRATION_INSTALLMENT_NUMBER)
+            .withClosedLostStage()
+            .withCloseDate(nextCloseDate)
+            .build();
+        
+        List<Opportunity> opps = oppGateway.getRecords(rd);
+        System.assertEquals(1, opps.size(), 'An Opp should exist: ' + opps);
+
+        runBatch(new RD2_OpportunityEvaluation_BATCH(today));
+
+        Map<Id, Opportunity> oppById = new Map<Id, Opportunity>(oppGateway.getRecords(rd));
+        System.assertEquals(2, oppById.size(), 'New Opp should be created: ' + oppById.values());
+
+        for (Opportunity opp : oppById.values()) {
+            System.assertEquals(nextCloseDate, opp.CloseDate, 'Both Opps should have the same next Close Date');
+
+            if (opp.Id == opps[0].Id) {
+                System.assertEquals(true, opp.isClosed && !opp.isWon, 'Existing Closed Lost Opp should stay closed');
+            } else {
+                System.assertEquals(false, opp.isClosed, 'New Opp should be open');
+            }
+        }
+    }
+
+    /**
+     * @description Verifies an Opp with the next Close Date is not created
+     * when the same Close Date Opp is Closed Lost outside of data migration
+     */
+    @IsTest
+    private static void shouldNotCreateNextOppWhenSameCloseDateOppIsClosedLostOutsideMigration() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        final Date today = START_DATE.addDays(1);
+        final Date nextCloseDate = START_DATE.addMonths(1);
+        RD2_ScheduleService.currentDate = today;
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
+        insert rd;
+
+        insert getOpportunityBuilder(rd)
+            .withClosedLostStage()
+            .withCloseDate(nextCloseDate)
+            .build();
+
+        runBatch(new RD2_OpportunityEvaluation_BATCH(today));
+
+        List<Opportunity> opps = oppGateway.getRecords(rd);
+        System.assertEquals(1, opps.size(), 'No new Opp should be created: ' + opps);        
+        System.assertEquals(true, opps[0].isClosed && !opps[0].isWon, 'Existing Closed Lost Opp should stay closed');
+    }
+
     
 
     // Helpers

--- a/src/classes/RD2_OpportunityEvaluation_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluation_TEST.cls
@@ -44,7 +44,7 @@ private class RD2_OpportunityEvaluation_TEST {
 
     private static final Date START_DATE = Date.newInstance(2019, 9, 15);
 
-    public static final Integer MIGRATION_INSTALLMENT_NUMBER = RD2_OpportunityService.MIGRATION_INSTALLMENT_NUMBER;
+    public static final Integer MIGRATION_INSTALLMENT_NUMBER_FLAG = RD2_OpportunityService.MIGRATION_INSTALLMENT_NUMBER_FLAG;
 
     /****
     * @description Creates data required for unit tests
@@ -442,7 +442,7 @@ private class RD2_OpportunityEvaluation_TEST {
         insert rd;
 
         insert getOpportunityBuilder(rd)
-            .withInstallmentNumber(MIGRATION_INSTALLMENT_NUMBER)
+            .withInstallmentNumber(MIGRATION_INSTALLMENT_NUMBER_FLAG)
             .withClosedLostStage()
             .withCloseDate(nextCloseDate)
             .build();

--- a/src/classes/RD2_OpportunityService.cls
+++ b/src/classes/RD2_OpportunityService.cls
@@ -36,7 +36,12 @@
 */
 public with sharing class RD2_OpportunityService {
 
-    public static final Integer MIGRATION_INSTALLMENT_NUMBER = 0;
+    /***
+     * @description A flag to mark Closed Lost Opps that are voided by the data migration. 
+     * The flag is used to exclude (ignore) such Opps by the Opp service
+     * when determining if the next Opp with the same Close Date can be created.
+     */
+    public static final Integer MIGRATION_INSTALLMENT_NUMBER_FLAG = 0;
 
     /***
     * @description Recurring Donation custom settings
@@ -143,7 +148,11 @@ public with sharing class RD2_OpportunityService {
 
 
     /***
-    * @description Indicates if the Opportunity should be created
+    * @description Indicates if the Opportunity can be created. The Opp gets the green light
+    * when there is no open/closed Opp with the same Close Date *except* when
+    * the Opp was Closed Lost during data migration to the enhanced (RD2) format. In that case,
+    * the Closed Lost Opp will be ignored and the new Opp with the same Close Date can be created.
+    *
     * @param newOpp Opportunity just built but not created yet
     * @param existingOpps Existing Opportunities on the Recurring Donation
     * @return Boolean
@@ -153,7 +162,7 @@ public with sharing class RD2_OpportunityService {
             if (newOpp.CloseDate == opp.CloseDate) {
 
                 Boolean isClosedLostInMigration = opp.isClosed && !opp.IsWon 
-                    && opp.Recurring_Donation_Installment_Number__c == MIGRATION_INSTALLMENT_NUMBER;
+                    && opp.Recurring_Donation_Installment_Number__c == MIGRATION_INSTALLMENT_NUMBER_FLAG;
 
                 return isClosedLostInMigration;
             }

--- a/src/classes/RD2_OpportunityService.cls
+++ b/src/classes/RD2_OpportunityService.cls
@@ -36,6 +36,8 @@
 */
 public with sharing class RD2_OpportunityService {
 
+    public static final Integer MIGRATION_INSTALLMENT_NUMBER = 0;
+
     /***
     * @description Recurring Donation custom settings
     */
@@ -141,7 +143,7 @@ public with sharing class RD2_OpportunityService {
 
 
     /***
-    * @description Indicates if the Opportunity already exists
+    * @description Indicates if the Opportunity should be created
     * @param newOpp Opportunity just built but not created yet
     * @param existingOpps Existing Opportunities on the Recurring Donation
     * @return Boolean
@@ -149,7 +151,11 @@ public with sharing class RD2_OpportunityService {
     private Boolean isNewOpportunity(Opportunity newOpp, List<Opportunity> existingOpps) {
         for (Opportunity opp : existingOpps) {
             if (newOpp.CloseDate == opp.CloseDate) {
-                return false;
+
+                Boolean isClosedLostInMigration = opp.isClosed && !opp.IsWon 
+                    && opp.Recurring_Donation_Installment_Number__c == MIGRATION_INSTALLMENT_NUMBER;
+
+                return isClosedLostInMigration;
             }
         }
 

--- a/src/classes/TEST_SObjectGateway.cls
+++ b/src/classes/TEST_SObjectGateway.cls
@@ -192,8 +192,11 @@ public class TEST_SObjectGateway {
                     Name, AccountId, RecordTypeId,
                     Amount, CampaignId, CloseDate,
                     StageName, isClosed, isWon,
-                    npe03__Recurring_Donation__c, Recurring_Donation_Installment_Number__c,
-                    npe01__Contact_Id_for_Role__c, Primary_Contact__c
+                    Closed_Lost_Reason__c,
+                    npe03__Recurring_Donation__c, 
+                    Recurring_Donation_Installment_Number__c,
+                    npe01__Contact_Id_for_Role__c, 
+                    Primary_Contact__c
                 FROM Opportunity
                 WHERE npe03__Recurring_Donation__c IN :rds
             ];


### PR DESCRIPTION
Enable automated next Opportunity creation when the same next Close Date Opp is Closed Lost in data migration.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
