### PR TITLE
Gift Entry: Prevent deletion of Form Templates in Use

### DIFF
--- a/src/classes/FORM_Service.cls
+++ b/src/classes/FORM_Service.cls
@@ -56,8 +56,8 @@ public virtual with sharing class FORM_Service {
     * @description Method deletes a Form_Template__c record by id.
     * @param id: Form_Template__c record id
     */
-    public virtual void deleteFormTemplates(String[] ids) {
-        FORM_ServiceGiftEntry.deleteFormTemplates(ids);
+    public virtual Boolean deleteFormTemplates(String[] ids) {
+        return FORM_ServiceGiftEntry.deleteFormTemplates(ids);
     }
 
     /*******************************************************************************************************

--- a/src/classes/FORM_ServiceGiftEntry.cls
+++ b/src/classes/FORM_ServiceGiftEntry.cls
@@ -103,9 +103,23 @@ public with sharing class FORM_ServiceGiftEntry {
     * @param id: Form_Template__c record id
     */
     @AuraEnabled
-    public static void deleteFormTemplates(String[] ids) {
-        Form_Template__c[] templates = [SELECT Id FROM Form_Template__c WHERE Id IN :ids];
-        delete templates;
+    public static Boolean deleteFormTemplates(String[] ids) {
+        List<DataImportBatch__c> batches = [
+                SELECT Id
+                FROM DataImportBatch__c
+                WHERE Form_Template__c IN: ids
+        ];
+
+        if (batches.isEmpty()) {
+            Form_Template__c[] templates = [
+                    SELECT Id
+                    FROM Form_Template__c
+                    WHERE Id IN :ids
+            ];
+            delete templates;
+            return true;
+        }
+        return false;
     }
 
     /*******************************************************************************************************

--- a/src/classes/FORM_ServiceGiftEntry.cls
+++ b/src/classes/FORM_ServiceGiftEntry.cls
@@ -51,10 +51,9 @@ public with sharing class FORM_ServiceGiftEntry {
 
         for (Form_Template__c formTemplate : allTemplates) {
             FORM_Template deserializedFormTemplate = deserializeFormTemplateFromObj(formTemplate);
-            if (formTemplate.id != null) {
-                deserializedFormTemplate.id = formTemplate.id;
+            if (formTemplate.Id != null) {
+                deserializedFormTemplate.id = formTemplate.Id;
             }
-
             formTemplates.add(deserializedFormTemplate);
         }
 
@@ -99,7 +98,8 @@ public with sharing class FORM_ServiceGiftEntry {
     }
 
     /*******************************************************************************************************
-    * @description Method deletes a Form_Template__c record by id.
+    * @description Method deletes a Form_Template__c record by id. Deletes a Form_Template__c
+    * if it is not used by any Data Import Batch
     * @param id: Form_Template__c record id
     */
     @AuraEnabled

--- a/src/classes/FORM_ServiceGiftEntry_TEST.cls
+++ b/src/classes/FORM_ServiceGiftEntry_TEST.cls
@@ -73,10 +73,11 @@ public with sharing class FORM_ServiceGiftEntry_TEST {
         Form_Template__c[] formTemplates = [SELECT Id, Name FROM Form_Template__c];
 
         System.assertEquals(2, formTemplates.size());
-        fs.deleteFormTemplates(new String[]{ formTemplates[0].id, formTemplates[1].id });
+        Boolean isFormTemplateDeleted = fs.deleteFormTemplates(new String[]{ formTemplates[0].id, formTemplates[1].id });
 
         formTemplates = [SELECT Id, Name FROM Form_Template__c];
         System.assertEquals(0, formTemplates.size());
+        System.assertEquals(true, isFormTemplateDeleted, 'Form Template should be deleted');
     }
 
     /*******************************************************************************************************
@@ -119,7 +120,6 @@ public with sharing class FORM_ServiceGiftEntry_TEST {
 
         String templateJSON = JSON.serialize(template);
         fs.storeFormTemplate(null, template.name, template.description, template.version, templateJSON);
-
         FORM_Template templateResult = fs.retrieveDefaultSGEFormTemplate();
         String templateResultJSON = JSON.serialize(templateResult);
 
@@ -155,6 +155,36 @@ public with sharing class FORM_ServiceGiftEntry_TEST {
             'New template names should return true from `FORM_ServiceGiftEntry.checkNameUniqueness`');
     }
 
+    /**************************************************************************************************
+     * @description Confirms that a form template used by any Data Import Batch cannot be deleted.
+     */
+    @IsTest
+    static void shouldPreventDeletionOfTemplateInUse() {
+        FORM_Service fs = new FORM_Service();
+
+        FORM_Template template = createSampleTemplate();
+        String templateJSON = JSON.serialize(template);
+        fs.storeFormTemplate(null,
+                template.name,
+                template.description,
+                template.version,
+                templateJSON);
+
+        Form_Template__c[] formTemplates = [
+                SELECT Id, Name, Template_JSON__c
+                FROM Form_Template__c
+        ];
+
+        DataImportBatch__c batch = createBatch('Test Batch', false);
+        batch.Form_Template__c = formTemplates[0].Id;
+
+        insert batch;
+
+        Boolean isFormTemplateDeleted =  fs.deleteFormTemplates(new String[]{ formTemplates[0].Id});
+
+        System.assertEquals(false, isFormTemplateDeleted, 'A Form Template in use should not be deleted');
+    }
+
     //Utility method for creating a sample template.
     public static FORM_Template createSampleTemplate () {
         
@@ -186,5 +216,26 @@ public with sharing class FORM_ServiceGiftEntry_TEST {
                                                 '1.0',
                                                 layout);
         return template;
+    }
+
+
+    /**********************************************************************************************
+     * @description Utility method that creates an NPSP Data Import Batch
+     *
+     * @param name
+     * @param autoProcess
+     *
+     * @return DataImportBatch__c
+     */
+    public static DataImportBatch__c createBatch (String name, Boolean autoProcess) {
+        DataImportBatch__c batch = new DataImportBatch__c();
+        batch.Name = name;
+        batch.Batch_Process_Size__c = 200;
+        batch.Contact_Matching_Rule__c = 'Firstname,Lastname,Email';
+        batch.Donation_Matching_Rule__c = UTIL_Namespace.StrTokenNSPrefix('Donation_Amount__c') + ';' +
+                UTIL_Namespace.StrTokenNSPrefix('Donation_Date__c');
+        batch.Donation_Matching_Behavior__c = BDI_DataImport_API.BestMatchOrCreate;
+        batch.Process_Using_Scheduled_Job__c = autoProcess;
+        return batch;
     }
 }

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4890,6 +4890,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>The {0} template was created.</value>
     </labels>
     <labels>
+         <fullName>geToastTemplateDeleteError</fullName>
+         <categories>Gift Entry</categories>
+         <language>en_US</language>
+         <protected>true</protected>
+         <shortDescription>Body for toast error if deleting template used by a batch or is set as default</shortDescription>
+         <value>This template is in use and cannot be deleted.</value>
+    </labels>
+    <labels>
         <fullName>geToastSaveFailed</fullName>
         <categories>Gift Entry</categories>
         <language>en_US</language>

--- a/src/lwc/geLabelService/geLabelService.js
+++ b/src/lwc/geLabelService/geLabelService.js
@@ -78,6 +78,7 @@ import geTabTemplateInfo from '@salesforce/label/c.geTabTemplateInfo';
 import geToastSaveFailed from '@salesforce/label/c.geToastSaveFailed';
 import geToastSelectActiveSection from '@salesforce/label/c.geToastSelectActiveSection';
 import geToastTemplateCreateSuccess from '@salesforce/label/c.geToastTemplateCreateSuccess';
+import geToastTemplateDeleteError from '@salesforce/label/c.geToastTemplateDeleteError';
 import geToastTemplateTabError from '@salesforce/label/c.geToastTemplateTabError';
 import geToastTemplateTabsError from '@salesforce/label/c.geToastTemplateTabsError';
 import geToastTemplateUpdateSuccess from '@salesforce/label/c.geToastTemplateUpdateSuccess';
@@ -169,6 +170,7 @@ class GeLabelService {
         geToastSaveFailed,
         geToastSelectActiveSection,
         geToastTemplateCreateSuccess,
+        geToastTemplateDeleteError,
         geToastTemplateTabError,
         geToastTemplateTabsError,
         geToastTemplateUpdateSuccess,

--- a/src/lwc/geTemplates/geTemplates.js
+++ b/src/lwc/geTemplates/geTemplates.js
@@ -5,7 +5,7 @@ import deleteFormTemplates from '@salesforce/apex/FORM_ServiceGiftEntry.deleteFo
 import cloneFormTemplate from '@salesforce/apex/FORM_ServiceGiftEntry.cloneFormTemplate';
 import getDataImportSettings from '@salesforce/apex/UTIL_CustomSettingsFacade.getDataImportSettings';
 import TemplateBuilderService from 'c/geTemplateBuilderService';
-import { findIndexByProperty } from 'c/utilTemplateBuilder';
+import {findIndexByProperty, showToast} from 'c/utilTemplateBuilder';
 import GeLabelService from 'c/geLabelService';
 import FIELD_MAPPING_METHOD_FIELD_INFO from '@salesforce/schema/Data_Import_Settings__c.Field_Mapping_Method__c';
 
@@ -89,14 +89,23 @@ export default class GeTemplates extends NavigationMixin(LightningElement) {
                 });
                 break;
             case 'delete':
-                deleteFormTemplates({ ids: [row.id] }).then(() => {
-                    const index = findIndexByProperty(this.templates, 'id', row.id);
-                    this.templates.splice(index, 1);
-                    this.templates = [...this.templates];
-                    this.isLoading = false;
-                });
+                this.handleTemplateDeletion(row);
                 break;
             default:
+        }
+    }
+
+
+    handleTemplateDeletion(row){
+        let deleted = deleteFormTemplates({ ids: [row.id] }).then(() => {
+            const index = findIndexByProperty(this.templates, 'id', row.id);
+            this.templates.splice(index, 1);
+            this.templates = [...this.templates];
+            this.isLoading = false;
+        });
+        if(!deleted){
+            showToast( 'Template still in use', 'The template you are trying to delete is ' +
+                'currently used in a batch ', 'warning', 'dismissable');
         }
     }
 

--- a/src/lwc/geTemplates/geTemplates.js
+++ b/src/lwc/geTemplates/geTemplates.js
@@ -16,6 +16,7 @@ const actions = [
 ];
 
 const ADVANCED_MAPPING = 'Data Import Field Mapping';
+const TOAST_MODE_DISMISSABLE = 'dismissable';
 
 const columns = [
     { label: 'Template Name', fieldName: 'name' },
@@ -89,24 +90,31 @@ export default class GeTemplates extends NavigationMixin(LightningElement) {
                 });
                 break;
             case 'delete':
-                this.handleTemplateDeletion(row);
+                this.handleTemplateDeletion(row.id);
                 break;
             default:
         }
     }
 
 
-    handleTemplateDeletion(row){
-        let deleted = deleteFormTemplates({ ids: [row.id] }).then(() => {
-            const index = findIndexByProperty(this.templates, 'id', row.id);
-            this.templates.splice(index, 1);
-            this.templates = [...this.templates];
+    /*******************************************************************************************************
+     * @description Handles Form Template Deletion. Currently prevents deletion if Form Templates used by a
+     * Data Import Batch
+     * @param {Id} recordId : Record id of the Form_Template__c to be deleted
+     */
+    handleTemplateDeletion(recordId){
+        deleteFormTemplates({ ids: [recordId] }).then((deleted) => {
+            if (!deleted) {
+                showToast(this.CUSTOM_LABELS.commonError, this.CUSTOM_LABELS.geToastTemplateDeleteError,
+                    this.CUSTOM_LABELS.commonAssistiveError, TOAST_MODE_DISMISSABLE);
+            } else {
+                const index = findIndexByProperty(this.templates, 'id', recordId);
+                this.templates.splice(index, 1);
+                this.templates = [...this.templates];
+            }
             this.isLoading = false;
         });
-        if(!deleted){
-            showToast( 'Template still in use', 'The template you are trying to delete is ' +
-                'currently used in a batch ', 'warning', 'dismissable');
-        }
+
     }
 
     /*******************************************************************************

--- a/src/package.xml
+++ b/src/package.xml
@@ -1932,6 +1932,7 @@
         <members>geToastSaveFailed</members>
         <members>geToastSelectActiveSection</members>
         <members>geToastTemplateCreateSuccess</members>
+        <members>geToastTemplateDeleteError</members>
         <members>geToastTemplateTabError</members>
         <members>geToastTemplateTabsError</members>
         <members>geToastTemplateUpdateSuccess</members>


### PR DESCRIPTION
# Critical Changes

# Changes
- Prevents the deletion of Form Templates in use (used in a Data Import Batch)

# Issues Closed

# New Metadata
- Custom Label - `geToastTemplateDeleteError`

# Deleted Metadata
