### PR TITLE
Gift Entry: Batch Mode Edit Gift

### DIFF
--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -51,40 +51,7 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
     * @return List<String> list of DataImport__c field api names
     */
     public static List<String> getDataImportFields(Id batchId) {
-        List<String> fieldNames = new List<String>();
-
-        // Query the Batch to determine which set of fields will be needed.
-        // Batches created using BGE_DataImportBatchEntry store fields used by its Data
-        // Import records in Active_Fields__c, while Batches created in geBatchGiftEntryApp
-        // use all or a subset of fields mapped in Advanced Mapping.
-        DataImportBatch__c batch = [
-                SELECT Batch_Gift_Entry_Version__c
-                FROM DataImportBatch__c
-                WHERE Id = :batchId
-        ];
-
-        if (batch.Batch_Gift_Entry_Version__c == null ||
-                batch.Batch_Gift_Entry_Version__c < 2.0) {
-            fieldNames = getDataImportFields(batchId, true);
-        } else if (batch.Batch_Gift_Entry_Version__c >= 2.0) {
-            // Lowercase the core fields list for use below to avoid duplication
-            for (String field : getCoreDataImportFields(true)) {
-                fieldNames.add(field.toLowerCase());
-            }
-
-            // Get all mapped source fields
-            // (no matter which template is used, it will be a subset of mapped fields)
-            // question: safe? or could a widget ever include fields that are not mapped?
-            for (SObjectField sObjectField :
-                    BDI_DataImportService.getDefaultMappingService()
-                            .getTargetFieldsBySourceField().keySet()) {
-                String field = String.valueOf(sObjectField).toLowerCase();
-                if (!fieldNames.contains(field)) {
-                    fieldNames.add(field);
-                }
-            }
-        }
-        return fieldNames;
+        return getDataImportFields(batchId, true);
     }
 
     /*******************************************************************************************************
@@ -100,9 +67,73 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
     * @return List<String> list of DataImport__c field api names
     */
     public static List<String> getDataImportFields(Id batchId, Boolean includeRelationshipFields) {
+        List<String> fields = new List<String>();
 
-        List<String> fields = getCoreDataImportFields(includeRelationshipFields);
-        fields.addAll(getActiveFieldNamesFromBatch(batchId));
+        // Query the Batch to determine which set of fields will be needed.
+        // Batches created using BGE_DataImportBatchEntry store fields used by its Data
+        // Import records in Active_Fields__c, while Batches created in geBatchGiftEntryApp
+        // use fields included in the Form_Template__c record related to the Batch.
+        DataImportBatch__c batch = [
+                SELECT Batch_Gift_Entry_Version__c,
+                        Form_Template__r.Template_JSON__c
+                FROM DataImportBatch__c
+                WHERE Id = :batchId
+        ];
+
+        if (batch.Batch_Gift_Entry_Version__c == null ||
+                batch.Batch_Gift_Entry_Version__c < 2.0) {
+
+            fields = getCoreDataImportFields(includeRelationshipFields);
+            fields.addAll(getActiveFieldNamesFromBatch(batchId));
+
+        } else if (batch.Batch_Gift_Entry_Version__c >= 2.0) {
+
+            for (String field : getCoreDataImportFields(includeRelationshipFields)) {
+                fields.add(field.toLowerCase());
+            }
+
+            // Must explicitly use BDI_MappingServiceAdvanced here (as opposed to
+            // BDI_DataImportService.getDefaultMappingService()) because of the need
+            // to reference the fieldMappingByDevName property.
+            Map<String,BDI_FieldMapping> fieldMappingByDevName =
+                    BDI_MappingServiceAdvanced.getInstance().fieldMappingByDevName;
+
+            FORM_Template t = (FORM_Template) JSON.deserialize(
+                    batch.Form_Template__r.Template_JSON__c,
+                    FORM_Template.class
+            );
+
+            for (FORM_Section formSection : t.layout.sections) {
+                for (FORM_Element formElement : formSection.elements) {
+
+                    // Get the field mapping, used to reference the source field
+                    String fieldMappingName = formElement.dataImportFieldMappingDevNames[0];
+                    BDI_FieldMapping fieldMapping =
+                            fieldMappingByDevName.get(fieldMappingName);
+                    if (fieldMapping == null) {
+                        continue;
+                    }
+
+                    // Add the source fields used in the Template
+                    if (!fields.contains(fieldMapping.Source_Field_API_Name.toLowerCase())) {
+                        fields.add(fieldMapping.Source_Field_API_Name.toLowerCase());
+                    }
+
+                    // Add the Name fields on the related object(s) for all Lookup fields,
+                    // used as display value(s) for Lookup fields loaded in the Form UI
+                    if (fieldMapping.Source_Field_Data_Type == 'REFERENCE') {
+                        String relatedObjNameField = String.join(new List<String>{
+                                fieldMapping.Source_Field_API_Name.replace('__c', '__r'),
+                                'Name'
+                        }, '.'
+                        ).toLowerCase();
+                        if (!fields.contains(relatedObjNameField)) {
+                            fields.add(relatedObjNameField);
+                        }
+                    }
+                }
+            }
+        }
 
         return fields;
     }

--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -67,7 +67,7 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
     * @return List<String> list of DataImport__c field api names
     */
     public static List<String> getDataImportFields(Id batchId, Boolean includeRelationshipFields) {
-        List<String> fields = new List<String>();
+        List<String> fieldApiNames = new List<String>();
 
         // Query the Batch to determine which set of fields will be needed.
         // Batches created using BGE_DataImportBatchEntry store fields used by its Data
@@ -83,13 +83,13 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
         if (batch.Batch_Gift_Entry_Version__c == null ||
                 batch.Batch_Gift_Entry_Version__c < 2.0) {
 
-            fields = getCoreDataImportFields(includeRelationshipFields);
-            fields.addAll(getActiveFieldNamesFromBatch(batchId));
+            fieldApiNames = getCoreDataImportFields(includeRelationshipFields);
+            fieldApiNames.addAll(getActiveFieldNamesFromBatch(batchId));
 
         } else if (batch.Batch_Gift_Entry_Version__c >= 2.0) {
 
             for (String field : getCoreDataImportFields(includeRelationshipFields)) {
-                fields.add(field.toLowerCase());
+                fieldApiNames.add(field.toLowerCase());
             }
 
             // Must explicitly use BDI_MappingServiceAdvanced here (as opposed to
@@ -115,8 +115,8 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
                     }
 
                     // Add the source fields used in the Template
-                    if (!fields.contains(fieldMapping.Source_Field_API_Name.toLowerCase())) {
-                        fields.add(fieldMapping.Source_Field_API_Name.toLowerCase());
+                    if (!fieldApiNames.contains(fieldMapping.Source_Field_API_Name.toLowerCase())) {
+                        fieldApiNames.add(fieldMapping.Source_Field_API_Name.toLowerCase());
                     }
 
                     // Add the Name fields on the related object(s) for all Lookup fields,
@@ -127,15 +127,15 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
                                 'Name'
                         }, '.'
                         ).toLowerCase();
-                        if (!fields.contains(relatedObjNameField)) {
-                            fields.add(relatedObjNameField);
+                        if (!fieldApiNames.contains(relatedObjNameField)) {
+                            fieldApiNames.add(relatedObjNameField);
                         }
                     }
                 }
             }
         }
 
-        return fields;
+        return fieldApiNames;
     }
 
     /*******************************************************************************************************

--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -46,6 +46,12 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
     };
 
     /*******************************************************************************************************
+    * @description Provides field mapping configuration used by BGE
+    */
+    public static Map<SObjectField, BDI_TargetFields> targetFieldsBySourceField =
+        BDI_DataImportService.getDefaultMappingService().getTargetFieldsBySourceField();
+
+    /*******************************************************************************************************
     * @description returns a list of DataImport__c fields the Batch Gift Entry UI needs in SOQL
     * @param batchId the batch for which to get all fields for soql
     * @return List<String> list of DataImport__c field api names
@@ -53,12 +59,6 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
     public static List<String> getDataImportFields(Id batchId) {
         return getDataImportFields(batchId, true);
     }
-
-    /*******************************************************************************************************
-    * @description Provides field mapping configuration used by BGE
-    */
-    public static Map<SObjectField, BDI_TargetFields> targetFieldsBySourceField = 
-        BDI_DataImportService.getDefaultMappingService().getTargetFieldsBySourceField();
 
     /*******************************************************************************************************
     * @description returns a list of DataImport__c fields the Batch Gift Entry UI needs in SOQL

--- a/src/classes/BGE_DataImportBatchEntry_CTRL.cls
+++ b/src/classes/BGE_DataImportBatchEntry_CTRL.cls
@@ -330,7 +330,11 @@ public with sharing class BGE_DataImportBatchEntry_CTRL {
     @AuraEnabled
     public static String saveAndDryRunRow(Id batchId, DataImport__c dataImport) {
         try {
-            Database.insert(dataImport);
+            if (String.isNotBlank(dataImport.Id)) {
+                Database.update(dataImport);
+            } else {
+                Database.insert(dataImport);
+            }
             return runSingleDryRun(dataImport.Id, batchId);
         } catch (Exception ex) {
             throw new AuraHandledException(ex.getMessage());

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -5173,6 +5173,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>Save</value>
     </labels>
     <labels>
+        <fullName>labelGeUpdate</fullName>
+        <categories>Gift Entry</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Gift Entry Update</shortDescription>
+        <value>Update</value>
+    </labels>
+    <labels>
         <fullName>giftProcessingAccountException</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -3503,6 +3503,13 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>Delete</value>
     </labels>
     <labels>
+        <fullName>bgeActionEdit</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Edit action for Batch Gift Entry</shortDescription>
+        <value>Edit</value>
+    </labels>
+    <labels>
         <fullName>bgeActionView</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -3503,13 +3503,6 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>Delete</value>
     </labels>
     <labels>
-        <fullName>bgeActionEdit</fullName>
-        <language>en_US</language>
-        <protected>true</protected>
-        <shortDescription>Edit action for Batch Gift Entry</shortDescription>
-        <value>Edit</value>
-    </labels>
-    <labels>
         <fullName>bgeActionView</fullName>
         <language>en_US</language>
         <protected>true</protected>
@@ -4436,6 +4429,14 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <protected>false</protected>
         <shortDescription>flsReadAccessError</shortDescription>
         <value>You do not have permissions to access {0}.</value>
+    </labels>
+    <labels>
+        <fullName>geActionOpen</fullName>
+        <categories>Gift Entry</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Open action label for Gift Entry batch mode.</shortDescription>
+        <value>Open</value>
     </labels>
     <labels>
         <fullName>geAssistiveActiveSection</fullName>

--- a/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.html
+++ b/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.html
@@ -11,5 +11,8 @@
             onsectionsretrieved={handleSectionsRetrieved}>
     </c-ge-form-renderer>
 
-    <c-ge-batch-gift-entry-table batch-id={recordId}></c-ge-batch-gift-entry-table>
+    <c-ge-batch-gift-entry-table
+            batch-id={recordId}
+            onedit={handleEdit}>
+    </c-ge-batch-gift-entry-table>
 </template>

--- a/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.html
+++ b/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.html
@@ -13,6 +13,6 @@
 
     <c-ge-batch-gift-entry-table
             batch-id={recordId}
-            onedit={handleEdit}>
+            onloaddata={handleLoadData}>
     </c-ge-batch-gift-entry-table>
 </template>

--- a/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
+++ b/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
@@ -45,7 +45,6 @@ export default class GeBatchGiftEntryApp extends LightningElement {
     getTableDataRow(formSubmission) {
         let dataImportRecord =
             GeFormService.getDataImportRecord(formSubmission.sectionsList);
-        dataImportRecord.submissionId = formSubmission.submissionId;
         return dataImportRecord;
     }
 

--- a/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
+++ b/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
@@ -8,19 +8,12 @@ export default class GeBatchGiftEntryApp extends LightningElement {
     handleSubmit(event) {
         const table = this.template.querySelector('c-ge-batch-gift-entry-table');
 
-        const displayValues = dataRow.displayValues;
-        // Apex is unable to read the dataRow (DataImport__c record) if it
-        // has this property, so it is stashed here and appended after the server call to
-        // make the display values available when loading Lookup fields in edit mode.
-        delete dataRow.displayValues;
-
         GeFormService.saveAndDryRun(
             this.recordId, event.detail.data)
             .then(
                 dataImportModel => {
                     Object.assign(dataImportModel.dataImportRows[0],
                         dataImportModel.dataImportRows[0].record);
-                    dataImportModel.dataImportRows[0].displayValues = displayValues;
                     table.upsertData(dataImportModel.dataImportRows[0], 'Id');
                     table.setTotalCount(dataImportModel.totalCountOfRows);
                     table.setTotalAmount(dataImportModel.totalAmountOfRows);

--- a/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
+++ b/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
@@ -51,7 +51,7 @@ export default class GeBatchGiftEntryApp extends LightningElement {
         table.runBatchDryRun(toggleSpinner);
     }
 
-    handleEdit(event) {
+    handleLoadData(event) {
         const form = this.template.querySelector('c-ge-form-renderer');
         form.load(event.detail);
     }

--- a/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
+++ b/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
@@ -1,7 +1,5 @@
 import {LightningElement, api, track} from 'lwc';
 import GeFormService from 'c/geFormService';
-import NPSP_DATA_IMPORT_BATCH_FIELD
-    from '@salesforce/schema/DataImport__c.NPSP_Data_Import_Batch__c';
 import {handleError} from 'c/utilTemplateBuilder';
 
 export default class GeBatchGiftEntryApp extends LightningElement {
@@ -9,13 +7,6 @@ export default class GeBatchGiftEntryApp extends LightningElement {
 
     handleSubmit(event) {
         const table = this.template.querySelector('c-ge-batch-gift-entry-table');
-        const dataRow = this.getTableDataRow(
-            event.target.submissions[event.target.submissions.length - 1]
-        );
-
-        if (!dataRow[NPSP_DATA_IMPORT_BATCH_FIELD.fieldApiName]) {
-            dataRow[NPSP_DATA_IMPORT_BATCH_FIELD.fieldApiName] = this.recordId;
-        }
 
         const displayValues = dataRow.displayValues;
         // Apex is unable to read the dataRow (DataImport__c record) if it
@@ -24,7 +15,7 @@ export default class GeBatchGiftEntryApp extends LightningElement {
         delete dataRow.displayValues;
 
         GeFormService.saveAndDryRun(
-            this.recordId, dataRow)
+            this.recordId, event.detail.data)
             .then(
                 dataImportModel => {
                     Object.assign(dataImportModel.dataImportRows[0],
@@ -40,12 +31,6 @@ export default class GeBatchGiftEntryApp extends LightningElement {
                 handleError(error);
                 event.detail.error();
             });
-    }
-
-    getTableDataRow(formSubmission) {
-        let dataImportRecord =
-            GeFormService.getDataImportRecord(formSubmission.sectionsList);
-        return dataImportRecord;
     }
 
     handleSectionsRetrieved(event) {

--- a/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
+++ b/src/lwc/geBatchGiftEntryApp/geBatchGiftEntryApp.js
@@ -17,12 +17,19 @@ export default class GeBatchGiftEntryApp extends LightningElement {
             dataRow[NPSP_DATA_IMPORT_BATCH_FIELD.fieldApiName] = this.recordId;
         }
 
+        const displayValues = dataRow.displayValues;
+        // Apex is unable to read the dataRow (DataImport__c record) if it
+        // has this property, so it is stashed here and appended after the server call to
+        // make the display values available when loading Lookup fields in edit mode.
+        delete dataRow.displayValues;
+
         GeFormService.saveAndDryRun(
             this.recordId, dataRow)
             .then(
                 dataImportModel => {
                     Object.assign(dataImportModel.dataImportRows[0],
                         dataImportModel.dataImportRows[0].record);
+                    dataImportModel.dataImportRows[0].displayValues = displayValues;
                     table.upsertData(dataImportModel.dataImportRows[0], 'Id');
                     table.setTotalCount(dataImportModel.totalCountOfRows);
                     table.setTotalAmount(dataImportModel.totalAmountOfRows);
@@ -58,5 +65,10 @@ export default class GeBatchGiftEntryApp extends LightningElement {
 
         const table = this.template.querySelector('c-ge-batch-gift-entry-table');
         table.runBatchDryRun(toggleSpinner);
+    }
+
+    handleEdit(event) {
+        const form = this.template.querySelector('c-ge-form-renderer');
+        form.load(event.detail);
     }
 }

--- a/src/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.js
+++ b/src/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.js
@@ -42,7 +42,7 @@ export default class GeBatchGiftEntryTable extends LightningElement {
             rowActions: [
                 {label: bgeActionDelete, name: 'delete'}
             ],
-            menuAlignment: 'right'
+            menuAlignment: 'auto'
         }
     };
 

--- a/src/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.js
+++ b/src/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.js
@@ -13,6 +13,7 @@ import runBatchDryRun from '@salesforce/apex/BGE_DataImportBatchEntry_CTRL.runBa
 import geDonorColumnLabel from '@salesforce/label/c.geDonorColumnLabel';
 import geDonationColumnLabel from '@salesforce/label/c.geDonationColumnLabel';
 import bgeActionDelete from '@salesforce/label/c.bgeActionDelete';
+import bgeActionEdit from '@salesforce/label/c.bgeActionEdit';
 
 export default class GeBatchGiftEntryTable extends LightningElement {
     @api batchId;
@@ -40,6 +41,7 @@ export default class GeBatchGiftEntryTable extends LightningElement {
         type: 'action',
         typeAttributes: {
             rowActions: [
+                {label: bgeActionEdit, name: 'edit'},
                 {label: bgeActionDelete, name: 'delete'}
             ],
             menuAlignment: 'auto'
@@ -159,10 +161,9 @@ export default class GeBatchGiftEntryTable extends LightningElement {
 
     handleRowActions(event) {
         switch (event.detail.action.name) {
-            // TODO: decide if going to edit inline in table or load into form
-            // case 'Edit':
-            //     this.editDIRow(event.detail.row);
-            //     break;
+            case 'edit':
+                this.editDIRow(event.detail.row);
+                break;
             case 'delete':
                 deleteRecord(event.detail.row.Id).then(() => {
                     this.deleteDIRow(event.detail.row);
@@ -231,5 +232,11 @@ export default class GeBatchGiftEntryTable extends LightningElement {
             .finally(() => {
                 callback();
             });
+    }
+
+    editDIRow(row) {
+        this.dispatchEvent(new CustomEvent('edit', {
+            detail: row
+        }));
     }
 }

--- a/src/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.js
+++ b/src/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.js
@@ -13,7 +13,7 @@ import runBatchDryRun from '@salesforce/apex/BGE_DataImportBatchEntry_CTRL.runBa
 import geDonorColumnLabel from '@salesforce/label/c.geDonorColumnLabel';
 import geDonationColumnLabel from '@salesforce/label/c.geDonationColumnLabel';
 import bgeActionDelete from '@salesforce/label/c.bgeActionDelete';
-import bgeActionEdit from '@salesforce/label/c.bgeActionEdit';
+import geActionOpen from '@salesforce/label/c.geActionOpen';
 
 export default class GeBatchGiftEntryTable extends LightningElement {
     @api batchId;
@@ -41,7 +41,7 @@ export default class GeBatchGiftEntryTable extends LightningElement {
         type: 'action',
         typeAttributes: {
             rowActions: [
-                {label: bgeActionEdit, name: 'edit'},
+                {label: geActionOpen, name: 'open'},
                 {label: bgeActionDelete, name: 'delete'}
             ],
             menuAlignment: 'auto'
@@ -161,8 +161,8 @@ export default class GeBatchGiftEntryTable extends LightningElement {
 
     handleRowActions(event) {
         switch (event.detail.action.name) {
-            case 'edit':
-                this.editDIRow(event.detail.row);
+            case 'open':
+                this.loadRow(event.detail.row);
                 break;
             case 'delete':
                 deleteRecord(event.detail.row.Id).then(() => {
@@ -234,8 +234,8 @@ export default class GeBatchGiftEntryTable extends LightningElement {
             });
     }
 
-    editDIRow(row) {
-        this.dispatchEvent(new CustomEvent('edit', {
+    loadRow(row) {
+        this.dispatchEvent(new CustomEvent('loaddata', {
             detail: row
         }));
     }

--- a/src/lwc/geFormField/geFormField.js
+++ b/src/lwc/geFormField/geFormField.js
@@ -19,6 +19,7 @@ export default class GeFormField extends LightningElement {
     @track objectDescribeInfo;
     @track richTextValid = true;
     @api element;
+    _defaultValue = null;
 
     richTextFormats = RICH_TEXT_FORMATS;
     CUSTOM_LABELS = GeLabelService.CUSTOM_LABELS;
@@ -48,6 +49,7 @@ export default class GeFormField extends LightningElement {
     connectedCallback() {
         const { defaultValue } = this.element;
         if(defaultValue) {
+            this._defaultValue = defaultValue;
             this.value = defaultValue;
         }
     }
@@ -245,7 +247,7 @@ export default class GeFormField extends LightningElement {
             const lookup = this.template.querySelector('c-ge-form-field-lookup');
             lookup.reset();
         } else {
-            this.value = null;
+            this.value = this._defaultValue;
         }
     }
 

--- a/src/lwc/geFormField/geFormField.js
+++ b/src/lwc/geFormField/geFormField.js
@@ -125,7 +125,7 @@ export default class GeFormField extends LightningElement {
         // as needed.
         // Changed 'this.element.value' references to getter 'formElementName'.
         fieldAndValue[this.formElementName] = this.value;
-        
+
         return fieldAndValue;
     }
 
@@ -220,4 +220,33 @@ export default class GeFormField extends LightningElement {
             inputField.reportValidity();
         }
     }
+
+    @api
+    load(data) {
+        const value = data[this.sourceFieldAPIName];
+
+        if (this.isLookup) {
+            const lookup = this.template.querySelector('c-ge-form-field-lookup');
+            if (value) {
+                const displayValue =
+                    data[this.sourceFieldAPIName.replace('__c', '__r')].Name;
+                lookup.setSelected({value, displayValue});
+            } else {
+                lookup.reset();
+            }
+        } else {
+            this.value = value;
+        }
+    }
+
+    @api
+    reset() {
+        if (this.isLookup) {
+            const lookup = this.template.querySelector('c-ge-form-field-lookup');
+            lookup.reset();
+        } else {
+            this.value = null;
+        }
+    }
+
 }

--- a/src/lwc/geFormFieldLookup/geFormFieldLookup.js
+++ b/src/lwc/geFormFieldLookup/geFormFieldLookup.js
@@ -142,4 +142,9 @@ export default class GeFormFieldLookup extends LightningElement {
         this.options = await doSearch({searchValue, sObjectType});
     };
 
+    @api
+    setSelected(lookupResult) {
+        this.displayValue = lookupResult.displayValue;
+        this.value = lookupResult.value;
+    }
 }

--- a/src/lwc/geFormFieldLookup/geFormFieldLookup.js
+++ b/src/lwc/geFormFieldLookup/geFormFieldLookup.js
@@ -147,4 +147,11 @@ export default class GeFormFieldLookup extends LightningElement {
         this.displayValue = lookupResult.displayValue;
         this.value = lookupResult.value;
     }
+
+    @api
+    reset() {
+        this.displayValue = null;
+        this.value = null;
+    }
+
 }

--- a/src/lwc/geFormRenderer/geFormRenderer.html
+++ b/src/lwc/geFormRenderer/geFormRenderer.html
@@ -27,7 +27,7 @@
 
     <div class="slds-docked-form-footer ge-form-footer">
         <lightning-button label={label.geCancel} title={label.geCancel} onclick={handleCancel} class="slds-m-left_x-small"></lightning-button>
-        <lightning-button variant="brand" label={label.geSave} title={label.geSave} onclick={handleSave} class="slds-m-left_x-small"></lightning-button>
+        <lightning-button variant="brand" label={saveActionLabel} title={saveActionLabel} onclick={handleSave} class="slds-m-left_x-small"></lightning-button>
     </div>
 </template>
 

--- a/src/lwc/geFormRenderer/geFormRenderer.html
+++ b/src/lwc/geFormRenderer/geFormRenderer.html
@@ -27,7 +27,14 @@
 
     <div class="slds-docked-form-footer ge-form-footer">
         <lightning-button label={label.geCancel} title={label.geCancel} onclick={handleCancel} class="slds-m-left_x-small"></lightning-button>
-        <lightning-button variant="brand" label={saveActionLabel} title={saveActionLabel} onclick={handleSave} class="slds-m-left_x-small"></lightning-button>
+        <lightning-button
+                variant="brand"
+                label={saveActionLabel}
+                title={saveActionLabel}
+                onclick={handleSave}
+                class="slds-m-left_x-small"
+                disabled={isUpdateActionDisabled}>
+        </lightning-button>
     </div>
 </template>
 

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -92,7 +92,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     }
 
     handleCancel() {
-        console.log('Form Cancel button clicked');
+        this.reset();
     }
 
     handleSave(event) {
@@ -269,4 +269,14 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
             section.load(data);
         });
     }
+
+    @api
+    reset() {
+        const sectionsList = this.template.querySelectorAll('c-ge-form-section');
+
+        sectionsList.forEach(section => {
+            section.reset();
+        });
+    }
+
 }

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -145,6 +145,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
                     // Show on top if it is a page level
                     this.hasPageLevelError = true;
                     const exceptionWrapper = JSON.parse(error.body.message);
+                    //TODO: can I use this to get the field list to query?
                     const allDisplayedFields = this.getDisplayedFieldsMappedByAPIName(sectionsList);
 
                     if (exceptionWrapper.exceptionType !== null && exceptionWrapper.exceptionType !== '') {
@@ -257,5 +258,14 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
         }
 
         this.erroredFields = [];
+    }
+
+    @api
+    load(data) {
+        const sectionsList = this.template.querySelectorAll('c-ge-form-section');
+
+        sectionsList.forEach(section => {
+            section.load(data);
+        });
     }
 }

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -107,8 +107,6 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     handleSave(event) {
         this.clearErrors();
 
-        // TODO: Pass the actual Data Import record, and navigate to the new Opportunity
-        // const OpportunityId = GeFormService.createOpportunityFromDataImport(dataImport);
         const sectionsList = this.template.querySelectorAll('c-ge-form-section');
 
         if(!this.isFormValid(sectionsList)){

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -32,7 +32,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     @track formTemplateId;
     erroredFields = [];
     @api pageLevelErrorMessageList = [];
-    @track _data; // Row being updated when in update mode
+    @track _dataRow; // Row being updated when in update mode
 
     connectedCallback() {
         if (this.batchId) {
@@ -270,18 +270,18 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     }
 
     @api
-    load(data) {
-        this._data = data;
+    load(dataRow) {
+        this._dataRow = dataRow;
         const sectionsList = this.template.querySelectorAll('c-ge-form-section');
 
         sectionsList.forEach(section => {
-            section.load(data);
+            section.load(dataRow);
         });
     }
 
     @api
     reset() {
-        this._data = undefined;
+        this._dataRow = undefined;
         const sectionsList = this.template.querySelectorAll('c-ge-form-section');
 
         sectionsList.forEach(section => {
@@ -290,7 +290,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     }
 
     get mode() {
-        return this._data ? mode.UPDATE : mode.CREATE;
+        return this._dataRow ? mode.UPDATE : mode.CREATE;
     }
 
     @api
@@ -306,7 +306,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
 
     @api
     get isUpdateActionDisabled() {
-        return this._data && this._data[STATUS_FIELD.fieldApiName] === 'Imported';
+        return this._dataRow && this._dataRow[STATUS_FIELD.fieldApiName] === 'Imported';
     }
 
     getData(sections) {
@@ -317,8 +317,8 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
             dataImportRecord[NPSP_DATA_IMPORT_BATCH_FIELD.fieldApiName] = this.batchId;
         }
 
-        if (this._data) {
-            dataImportRecord.Id = this._data.Id;
+        if (this._dataRow) {
+            dataImportRecord.Id = this._dataRow.Id;
         }
 
         return dataImportRecord;

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -9,6 +9,7 @@ import { showToast, handleError } from 'c/utilTemplateBuilder';
 import { getRecord } from 'lightning/uiRecordApi';
 import FORM_TEMPLATE_FIELD from '@salesforce/schema/DataImportBatch__c.Form_Template__c';
 import TEMPLATE_JSON_FIELD from '@salesforce/schema/Form_Template__c.Template_JSON__c';
+import STATUS_FIELD from '@salesforce/schema/DataImport__c.Status__c';
 
 const mode = {
     CREATE: 'create',
@@ -301,6 +302,11 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
             default:
                 return geSave;
         }
+    }
+
+    @api
+    get isUpdateActionDisabled() {
+        return this._data && this._data[STATUS_FIELD.fieldApiName] === 'Imported';
     }
 
 }

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -4,10 +4,16 @@ import { NavigationMixin } from 'lightning/navigation';
 import messageLoading from '@salesforce/label/c.labelMessageLoading';
 import geSave from '@salesforce/label/c.labelGeSave';
 import geCancel from '@salesforce/label/c.labelGeCancel';
+import geUpdate from '@salesforce/label/c.labelGeUpdate';
 import { showToast, handleError } from 'c/utilTemplateBuilder';
 import { getRecord } from 'lightning/uiRecordApi';
 import FORM_TEMPLATE_FIELD from '@salesforce/schema/DataImportBatch__c.Form_Template__c';
 import TEMPLATE_JSON_FIELD from '@salesforce/schema/Form_Template__c.Template_JSON__c';
+
+const mode = {
+    CREATE: 'create',
+    UPDATE: 'update'
+}
 
 export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     @api sections = [];
@@ -24,6 +30,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     @track formTemplateId;
     erroredFields = [];
     @api pageLevelErrorMessageList = [];
+    @track _data; // Row being updated when in update mode
 
     connectedCallback() {
         if (this.batchId) {
@@ -263,6 +270,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
 
     @api
     load(data) {
+        this._data = data;
         const sectionsList = this.template.querySelectorAll('c-ge-form-section');
 
         sectionsList.forEach(section => {
@@ -272,11 +280,27 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
 
     @api
     reset() {
+        this._data = undefined;
         const sectionsList = this.template.querySelectorAll('c-ge-form-section');
 
         sectionsList.forEach(section => {
             section.reset();
         });
+    }
+
+    get mode() {
+        return this._data ? mode.UPDATE : mode.CREATE;
+    }
+
+    @api
+    get saveActionLabel() {
+        switch (this.mode) {
+            case mode.UPDATE:
+                return geUpdate;
+                break;
+            default:
+                return geSave;
+        }
     }
 
 }

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -10,6 +10,8 @@ import { getRecord } from 'lightning/uiRecordApi';
 import FORM_TEMPLATE_FIELD from '@salesforce/schema/DataImportBatch__c.Form_Template__c';
 import TEMPLATE_JSON_FIELD from '@salesforce/schema/Form_Template__c.Template_JSON__c';
 import STATUS_FIELD from '@salesforce/schema/DataImport__c.Status__c';
+import NPSP_DATA_IMPORT_BATCH_FIELD
+    from '@salesforce/schema/DataImport__c.NPSP_Data_Import_Batch__c';
 
 const mode = {
     CREATE: 'create',
@@ -25,7 +27,6 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     @track version = '';
     @api showSpinner = false;
     @api batchId;
-    @api submissions = [];
     @api hasPageLevelError = false;
     label = { messageLoading, geSave, geCancel };
     @track formTemplateId;
@@ -127,12 +128,11 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
         const toggleSpinner = () => this.toggleSpinner();
 
         if (this.batchId) {
-            const submission = {
-                sectionsList: sectionsList
-            };
-            this.submissions.push(submission);
+            const data = this.getData(sectionsList);
+
             this.dispatchEvent(new CustomEvent('submit', {
                 detail: {
+                    data: data,
                     success: function () {
                         enableSaveButton();
                         toggleSpinner();
@@ -307,6 +307,21 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     @api
     get isUpdateActionDisabled() {
         return this._data && this._data[STATUS_FIELD.fieldApiName] === 'Imported';
+    }
+
+    getData(sections) {
+        let dataImportRecord =
+            GeFormService.getDataImportRecord(sections);
+
+        if (!dataImportRecord[NPSP_DATA_IMPORT_BATCH_FIELD.fieldApiName]) {
+            dataImportRecord[NPSP_DATA_IMPORT_BATCH_FIELD.fieldApiName] = this.batchId;
+        }
+
+        if (this._data) {
+            dataImportRecord.Id = this._data.Id;
+        }
+
+        return dataImportRecord;
     }
 
 }

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -125,6 +125,8 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
         // callback used to toggle spinner after save
         const toggleSpinner = () => this.toggleSpinner();
 
+        const reset = () => this.reset();
+
         if (this.batchId) {
             const data = this.getData(sectionsList);
 
@@ -134,6 +136,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
                     success: function () {
                         enableSaveButton();
                         toggleSpinner();
+                        reset();
                     },
                     error: function() {
                         enableSaveButton();

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -155,7 +155,6 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
                     // Show on top if it is a page level
                     this.hasPageLevelError = true;
                     const exceptionWrapper = JSON.parse(error.body.message);
-                    //TODO: can I use this to get the field list to query?
                     const allDisplayedFields = this.getDisplayedFieldsMappedByAPIName(sectionsList);
 
                     if (exceptionWrapper.exceptionType !== null && exceptionWrapper.exceptionType !== '') {

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -96,11 +96,6 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     }
 
     handleSave(event) {
-        event.target.disabled = true;
-        const enableSaveButton = function() {
-            this.disabled = false;
-        }.bind(event.target);
-
         this.clearErrors();
 
         // TODO: Pass the actual Data Import record, and navigate to the new Opportunity
@@ -110,6 +105,12 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
         if(!this.isFormValid(sectionsList)){
             return;
         }
+
+        // disable the Save button
+        event.target.disabled = true;
+        const enableSaveButton = function() {
+            this.disabled = false;
+        }.bind(event.target);
 
         // show the spinner
         this.toggleSpinner();

--- a/src/lwc/geFormSection/geFormSection.js
+++ b/src/lwc/geFormSection/geFormSection.js
@@ -90,4 +90,13 @@ export default class GeFormSection extends LightningElement {
 
         return fieldMappedByAPIName;
     }
+
+    @api
+    load(data){
+        const fields = this.template.querySelectorAll('c-ge-form-field');
+
+        fields.forEach(field => {
+            field.load(data);
+        });
+    }
 }

--- a/src/lwc/geFormSection/geFormSection.js
+++ b/src/lwc/geFormSection/geFormSection.js
@@ -99,4 +99,14 @@ export default class GeFormSection extends LightningElement {
             field.load(data);
         });
     }
+
+    @api
+    reset() {
+        const fields = this.template.querySelectorAll('c-ge-form-field');
+
+        fields.forEach(field => {
+            field.reset();
+        });
+    }
+
 }

--- a/src/lwc/geFormService/geFormService.js
+++ b/src/lwc/geFormService/geFormService.js
@@ -134,9 +134,13 @@ class GeFormService {
         // Build the DI Record
         let diRecord = {};
 
+        let displayValues = {};
         for (let key in fieldData) {
             if (fieldData.hasOwnProperty(key)) {
-                let value = fieldData[key];
+                let value = fieldData[key].value;
+                if (fieldData[key].displayValue) {
+                    displayValues[value] = fieldData[key].displayValue;
+                }
 
                 // Get the field mapping wrapper with the CMT record name (this is the key variable).
                 let fieldWrapper = this.getFieldMappingWrapper(key);
@@ -144,7 +148,7 @@ class GeFormService {
                 diRecord[fieldWrapper.Source_Field_API_Name] = value;
             }
         }
-
+        diRecord.displayValues = displayValues;
         return diRecord;
     }
 

--- a/src/lwc/geFormService/geFormService.js
+++ b/src/lwc/geFormService/geFormService.js
@@ -134,13 +134,9 @@ class GeFormService {
         // Build the DI Record
         let diRecord = {};
 
-        let displayValues = {};
         for (let key in fieldData) {
             if (fieldData.hasOwnProperty(key)) {
-                let value = fieldData[key].value;
-                if (fieldData[key].displayValue) {
-                    displayValues[value] = fieldData[key].displayValue;
-                }
+                let value = fieldData[key];
 
                 // Get the field mapping wrapper with the CMT record name (this is the key variable).
                 let fieldWrapper = this.getFieldMappingWrapper(key);
@@ -148,7 +144,7 @@ class GeFormService {
                 diRecord[fieldWrapper.Source_Field_API_Name] = value;
             }
         }
-        diRecord.displayValues = displayValues;
+
         return diRecord;
     }
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -1757,7 +1757,6 @@
         <members>bdiTime</members>
         <members>bdiUpdated</members>
         <members>bgeActionDelete</members>
-        <members>bgeActionEdit</members>
         <members>bgeActionView</members>
         <members>bgeBatchAvailableFields</members>
         <members>bgeBatchBatchProcessSizeHelp</members>
@@ -1879,6 +1878,7 @@
         <members>exceptionValidationRule</members>
         <members>flsError</members>
         <members>flsReadAccessError</members>
+        <members>geActionOpen</members>
         <members>geAssistiveActiveSection</members>
         <members>geAssistiveBatchHeaderRemoveField</members>
         <members>geAssistiveFieldDown</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1757,6 +1757,7 @@
         <members>bdiTime</members>
         <members>bdiUpdated</members>
         <members>bgeActionDelete</members>
+        <members>bgeActionEdit</members>
         <members>bgeActionView</members>
         <members>bgeBatchAvailableFields</members>
         <members>bgeBatchBatchProcessSizeHelp</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -2106,6 +2106,7 @@
         <members>isARequiredField</members>
         <members>labelGeCancel</members>
         <members>labelGeSave</members>
+        <members>labelGeUpdate</members>
         <members>labelListViewFirst</members>
         <members>labelListViewLast</members>
         <members>labelListViewNext</members>


### PR DESCRIPTION
This PR implements edit functionality when in Batch mode.  Gifts that have been entered into the table can be loaded back into the form using the "Open" row action.  Gifts that have not yet been processed will be editable in the form.  Gifts that have been processed/imported will load back into the form but will be prevented from being edited further by disabling the "Update" button.  

The "Cancel" button will reset the form, clearing fields or loading their default value if specified in the Template.

# Critical Changes

# Changes

# Issues Closed

# New Metadata
geActionOpen (label)
labelGeUpdate (label)

# Deleted Metadata
