### PR TITLE
Clean forms after submission on BGE and SGE - fix needed

### DIFF
--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -449,6 +449,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     clearErrors() {
 
         // Clear the page level error
+        this.hasPageLevelError = false;
         this.pageLevelErrorMessageList = [];
 
         // Clear the field level errors


### PR DESCRIPTION
[W-038566](https://foundation.lightning.force.com/lightning/r/agf__ADM_Work__c/a2x1E000001Hqc9QAC/view): Clear form after submission on BGE or SGE.

- On SGE form is redirected to Opportunity. 
- On BGE if validation or required field error message displayed before saving, then page-level error header didn't hide. That behavior was fixed as part of this ticket and is the only change included.
 
# Critical Changes

# Changes
- missing init property on clearError() function of geFormRenderer lwc component.

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
