### PR TITLE
Recurring Donation Label Refactor into Apex Constants

### DIFF
--- a/src/classes/RD2_DataMigrationMapper.cls
+++ b/src/classes/RD2_DataMigrationMapper.cls
@@ -128,13 +128,13 @@ public class RD2_DataMigrationMapper {
     private void setInstallmentFields(npe03__Recurring_Donation__c rd) {
 
         Set<String> frequencyOneInstallmentPeriods = new Set<String>{
-            System.Label.npe03.RecurringDonationInstallmentPeriodYearly,
-            System.Label.npe03.RecurringDonationInstallmentPeriodMonthly,
-            System.Label.npe03.RecurringDonationInstallmentPeriodWeekly,
-            System.Label.npe03.RecurringDonationInstallmentPeriod1stand15th
+            RD_Constants.INSTALLMENT_PERIOD_YEARLY,
+            RD_Constants.INSTALLMENT_PERIOD_MONTHLY,
+            RD_Constants.INSTALLMENT_PERIOD_WEEKLY,
+            RD_Constants.INSTALLMENT_PERIOD_FIRST_AND_FIFTEENTH
         };
 
-        if (rd.npe03__Installment_Period__c == System.Label.npe03.RecurringDonationInstallmentPeriodQuarterly) {
+        if (rd.npe03__Installment_Period__c == RD_Constants.INSTALLMENT_PERIOD_QUARTERLY) {
             rd.npe03__Installment_Period__c = RD2_Constants.INSTALLMENT_PERIOD_MONTHLY;
             rd.InstallmentFrequency__c = 3;
 
@@ -147,7 +147,7 @@ public class RD2_DataMigrationMapper {
             handleCustomInstallmentPeriod(rd);
         }
 
-        if (rd.npe03__Schedule_Type__c == System.Label.npe03.RecurringDonationDivideValue
+        if (rd.npe03__Schedule_Type__c == RD_Constants.SCHEDULE_TYPE_DIVIDE_BY
             && rd.npe03__Installment_Amount__c != null
             && rd.npe03__Installment_Amount__c != 0
         ) {
@@ -278,9 +278,9 @@ public class RD2_DataMigrationMapper {
         String openEndedStatus = rd.npe03__Open_Ended_Status__c;
 
         if (String.isNotBlank(openEndedStatus)
-            && openEndedStatus != System.Label.npe03.RecurringDonationOpenStatus
-            && openEndedStatus != System.Label.npe03.RecurringDonationClosedStatus
-            && openEndedStatus != 'None'
+            && openEndedStatus != RD_Constants.OPEN_ENDED_STATUS_OPEN
+            && openEndedStatus != RD_Constants.OPEN_ENDED_STATUS_CLOSED
+            && openEndedStatus != RD_Constants.OPEN_ENDED_STATUS_NONE
         ) {
             throw new MigrationException(
                 String.format(
@@ -290,7 +290,7 @@ public class RD2_DataMigrationMapper {
             );
         }
 
-        if (openEndedStatus == System.Label.npe03.RecurringDonationClosedStatus) {
+        if (openEndedStatus == RD_Constants.OPEN_ENDED_STATUS_CLOSED) {
             rd.Status__c = RD2_Constants.STATUS_CLOSED;
 
         } else {
@@ -317,7 +317,7 @@ public class RD2_DataMigrationMapper {
         List<Opportunity> opps = new List<Opportunity>();
 
         if (allRelatedOpps == null || allRelatedOpps.isEmpty()
-            || rd.npe03__Open_Ended_Status__c != System.Label.npe03.RecurringDonationOpenStatus        
+            || rd.npe03__Open_Ended_Status__c != RD_Constants.OPEN_ENDED_STATUS_OPEN
         ) {
             return opps;
         }

--- a/src/classes/RD2_DataMigration_TEST.cls
+++ b/src/classes/RD2_DataMigration_TEST.cls
@@ -96,7 +96,7 @@ private class RD2_DataMigration_TEST {
             .withId(null)
             .build();
 
-        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled, 
+        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled,
             'Enhanced RDs should not be enabled');
 
         Exception jobException;
@@ -110,7 +110,7 @@ private class RD2_DataMigration_TEST {
             jobException = ex;
         }
 
-        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled, 
+        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled,
             'Enhanced RDs should not be enabled *by* Dry Run migration');
 
         System.assertEquals(null, jobException,
@@ -392,7 +392,7 @@ private class RD2_DataMigration_TEST {
 
         npe03__Recurring_Donation__c convertedRD = new RD2_DataMigrationMapper(
             getLegacyRecurringDonationBuilder()
-                .withInstallmentPeriod(System.Label.npe03.RecurringDonationInstallmentPeriod1stand15th)
+                .withInstallmentPeriod(RD_Constants.INSTALLMENT_PERIOD_FIRST_AND_FIFTEENTH)
                 .build()
         ).convertToEnhancedRD();
 
@@ -503,7 +503,7 @@ private class RD2_DataMigration_TEST {
             .withId(null)
             .withInstallmentPeriodYearly()
             .withInstallments(installments)
-            .withScheduleType(System.Label.npe03.RecurringDonationDivideValue)
+            .withScheduleType(RD_Constants.SCHEDULE_TYPE_DIVIDE_BY)
             .withOpenEndedStatusNone()
             .build();
         insert rd;
@@ -1538,15 +1538,15 @@ private class RD2_DataMigration_TEST {
         }
         insert opps;
 
-        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled, 
+        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled,
             'Enhanced RDs should not be enabled');
 
         UTIL_BatchJobService_TEST.MockBatchableContext batchContext = new UTIL_BatchJobService_TEST.MockBatchableContext();
         RD2_DataMigrationDryRun_BATCH batch = new RD2_DataMigrationDryRun_BATCH();
         batch.execute(batchContext, getRecords());
-        batch.finish(batchContext);      
+        batch.finish(batchContext);
 
-        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled, 
+        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled,
             'Enhanced RDs should not be enabled *by* Dry Run migration');
 
         List<Error__c> errors = errorGateway.getRecords();
@@ -1594,16 +1594,16 @@ private class RD2_DataMigration_TEST {
         //reset custom settings static var
         UTIL_ListCustomSettingsFacade.mapCustomInstallmentSettings = null;
 
-        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled, 
+        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled,
             'Enhanced RDs should not be enabled');
 
         UTIL_BatchJobService_TEST.MockBatchableContext batchContext = new UTIL_BatchJobService_TEST.MockBatchableContext();
         RD2_DataMigrationDryRun_BATCH batch = new RD2_DataMigrationDryRun_BATCH();
         batch.execute(batchContext, getRecords());
-        batch.finish(batchContext);   
-        Id jobId = batchContext.getJobId();   
+        batch.finish(batchContext);
+        Id jobId = batchContext.getJobId();
 
-        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled, 
+        System.assertEquals(false, RD2_EnablementService.isRecurringDonations2Enabled,
             'Enhanced RDs should not be enabled *by* the Dry Run batch');
 
         List<Error__c> errors = errorGateway.getRecords();
@@ -1627,7 +1627,7 @@ private class RD2_DataMigration_TEST {
      * when migration is run in a dry run mode
      */
     @IsTest
-    private static void shouldNotLogErrorWhenDayOfMonthIsLastDayInDryRunMode() { 
+    private static void shouldNotLogErrorWhenDayOfMonthIsLastDayInDryRunMode() {
         final String dayOfMonth = '29';
         npe03__Recurring_Donation__c rd = getLegacyRecurringDonationBuilder(getContact().Id)
             .withId(null)
@@ -1638,7 +1638,7 @@ private class RD2_DataMigration_TEST {
         try {
             insert rd;
         } catch (Exception e) {
-            if (e.getMessage().contains('INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST')) {                
+            if (e.getMessage().contains('INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST')) {
                 return; //do not execute the test when the org has RD2 config deployed
             } else {
                 actualException = e;
@@ -1650,8 +1650,8 @@ private class RD2_DataMigration_TEST {
         UTIL_BatchJobService_TEST.MockBatchableContext batchContext = new UTIL_BatchJobService_TEST.MockBatchableContext();
         RD2_DataMigrationDryRun_BATCH batch = new RD2_DataMigrationDryRun_BATCH();
         batch.execute(batchContext, getRecords());
-        batch.finish(batchContext);   
-        Id jobId = batchContext.getJobId();   
+        batch.finish(batchContext);
+        Id jobId = batchContext.getJobId();
 
         List<Error__c> errors = errorGateway.getRecords();
         System.assertEquals(0, errors.size(), 'No error should be logged: ' + errors);
@@ -1659,7 +1659,7 @@ private class RD2_DataMigration_TEST {
         List<npe03__Recurring_Donation__c> rds = getRecords();
         System.assertEquals(dayOfMonth, rds[0].Day_of_Month__c, 'Day of Month should not change');
         assertLegacyFormat(rds);
-        
+
         assertBatchSummarySuccess(batchContext.getJobId(), 1);
     }
 

--- a/src/classes/RD_Constants.cls
+++ b/src/classes/RD_Constants.cls
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2019 Salesforce.org
+    Copyright (c) 2020 Salesforce.org
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
 */
 /**
 * @author Salesforce.org
-* @date 2019
+* @date 2020
 * @group Recurring Donations
 * @description Legacy Recurring Donations constants for specific picklist values. This is necessary to
 * allow the legacy custom labels for picklist values in the NPE03 (RecurringDonations) package to be

--- a/src/classes/RD_Constants.cls
+++ b/src/classes/RD_Constants.cls
@@ -1,0 +1,64 @@
+/*
+    Copyright (c) 2019 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2019
+* @group Recurring Donations
+* @description Legacy Recurring Donations constants for specific picklist values. This is necessary to
+* allow the legacy custom labels for picklist values in the NPE03 (RecurringDonations) package to be
+* fully deprecated.
+*
+*/
+public class RD_Constants {
+
+    /**
+    * @description Recurring Donation "Schedule Type" picklist API values
+    */
+    public static final String SCHEDULE_TYPE_DIVIDE_BY = 'Divide By';
+    public static final String SCHEDULE_TYPE_MULTIPLY_BY = 'Multiply By';
+
+    /**
+    * @description Recurring Donation "Schedule Type" picklist API values
+    */
+    public static final String OPEN_ENDED_STATUS_OPEN = 'Open';
+    public static final String OPEN_ENDED_STATUS_CLOSED = 'Closed';
+    public static final String OPEN_ENDED_STATUS_NONE = 'None';
+
+    /**
+    * @description Recurring Donation "Installment Period" picklist API values
+    */
+    public static final String INSTALLMENT_PERIOD_YEARLY = 'Yearly';
+    public static final String INSTALLMENT_PERIOD_MONTHLY = 'Monthly';
+    public static final String INSTALLMENT_PERIOD_WEEKLY = 'Weekly';
+    public static final String INSTALLMENT_PERIOD_FIRST_AND_FIFTEENTH = '1st and 15th';
+    public static final String INSTALLMENT_PERIOD_DAILY = 'Daily';
+    public static final String INSTALLMENT_PERIOD_QUARTERLY = 'Quarterly';
+
+}

--- a/src/classes/RD_Constants.cls-meta.xml
+++ b/src/classes/RD_Constants.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/RD_RecurringDonations.cls
+++ b/src/classes/RD_RecurringDonations.cls
@@ -199,7 +199,7 @@ public class RD_RecurringDonations {
         Map<Id, npe03__Recurring_Donation__c> updateMap = new Map<Id, npe03__Recurring_Donation__c>();
 
         //Get the closed label for opps
-        String closedLabel = System.Label.npe03.RecurringDonationClosedStatus;
+        String closedLabel = RD_Constants.OPEN_ENDED_STATUS_CLOSED;
 
         //before we query for any RD's, we must make sure that all previous changes to them have been committed!
         if (dmlWrapper != null) {
@@ -250,7 +250,7 @@ public class RD_RecurringDonations {
                 }
 
                 //if this is the summary row for this rd only update installments for open ended opportunities
-                if (isClosed == null && isWon == null && rd.npe03__open_ended_status__c == System.Label.npe03.RecurringDonationOpenStatus) {
+                if (isClosed == null && isWon == null && rd.npe03__open_ended_status__c == RD_Constants.OPEN_ENDED_STATUS_OPEN) {
                     rd.npe03__Installments__c = (Integer) obj.get('oppcount');
                     updateMap.put(rdid, rd);
                 }
@@ -392,7 +392,7 @@ public class RD_RecurringDonations {
         //Loop through the Recurring Donations and create the appropriate number of Opportunities
         for (npe03__Recurring_Donation__c r : recurringDonations) {
             //if we're not looking at an open-ended type donation, handle it the 'old' way
-            if (r.npe03__Open_Ended_Status__c != System.Label.npe03.RecurringDonationOpenStatus && r.npe03__Open_Ended_Status__c != System.Label.npe03.RecurringDonationClosedStatus) {
+            if (r.npe03__Open_Ended_Status__c != RD_Constants.OPEN_ENDED_STATUS_OPEN && r.npe03__Open_Ended_Status__c != RD_Constants.OPEN_ENDED_STATUS_CLOSED) {
 
                 Decimal installs = r.npe03__Installments__c;
                 Integer installments = (installs == null ? 0 : installs.intValue());
@@ -503,7 +503,7 @@ public class RD_RecurringDonations {
             //this is an open-ended rd that needs opptys
             else {
                 //if its not 'open', we're not doing anything to it
-                if (r.npe03__Open_Ended_Status__c == System.Label.npe03.RecurringDonationOpenStatus) {
+                if (r.npe03__Open_Ended_Status__c == RD_Constants.OPEN_ENDED_STATUS_OPEN) {
                     //get settings so we can figure out how many donations to create
                     Date oppCloseDate = getStartDate(r);
 
@@ -721,7 +721,7 @@ public class RD_RecurringDonations {
     */
     public static void updateExistingOpps(Set<Id> recIDs, TDTM_Runnable.DmlWrapper dmlWrapper) {
         npe03__Recurring_Donations_Settings__c rds = UTIL_CustomSettingsFacade.getRecurringDonationsSettings();
-        String closedLabel = System.Label.npe03.RecurringDonationClosedStatus;
+        String closedLabel = RD_Constants.OPEN_ENDED_STATUS_CLOSED;
 
         String rdQuery = strQueryRDNoWhere();
         rdQuery+=' where npe03__Open_Ended_Status__c <> :closedLabel ';
@@ -829,8 +829,8 @@ public class RD_RecurringDonations {
         // closed an open recurring donation
         List<npe03__Recurring_Donation__c> newlycloseddonations = new List<npe03__Recurring_Donation__c>();
 
-        String openlabel = System.Label.npe03.RecurringDonationOpenStatus;
-        String closedlabel = System.Label.npe03.RecurringDonationClosedStatus;
+        String openlabel = RD_Constants.OPEN_ENDED_STATUS_OPEN;
+        String closedlabel = RD_Constants.OPEN_ENDED_STATUS_CLOSED;
 
         for (npe03__Recurring_Donation__c r : recurringDonations) {
             npe03__Recurring_Donation__c oldRD = oldRecurringDonations.get(r.id);
@@ -913,8 +913,8 @@ public class RD_RecurringDonations {
             TDTM_Config_API.disableAllRollupTriggers();
         }
 
-        String openlabel = System.Label.npe03.RecurringDonationOpenStatus;
-        String closedlabel = System.Label.npe03.RecurringDonationClosedStatus;
+        String openlabel = RD_Constants.OPEN_ENDED_STATUS_OPEN;
+        String closedlabel = RD_Constants.OPEN_ENDED_STATUS_CLOSED;
 
         // non open-ended rd's are handled strictly by the insert rd code.
         List<npe03__Recurring_Donation__c> listRDNonOpen = new List<npe03__Recurring_Donation__c>();
@@ -1167,8 +1167,8 @@ public class RD_RecurringDonations {
             ? r.npe03__Next_Payment_Date__c
             : dateEstablished;
 
-        if (r.npe03__Installment_Period__c == System.Label.npe03.RecurringDonationInstallmentPeriodMonthly
-            || r.npe03__Installment_Period__c == System.Label.npe03.RecurringDonationInstallmentPeriodQuarterly
+        if (r.npe03__Installment_Period__c == RD_Constants.INSTALLMENT_PERIOD_MONTHLY
+            || r.npe03__Installment_Period__c == RD_Constants.INSTALLMENT_PERIOD_QUARTERLY
         ) {
             // For monthly or quarterly installments only, the initial date needs to be tweaked
             // to be the appropriate start date in the *current month*
@@ -1257,21 +1257,21 @@ public class RD_RecurringDonations {
         npe03__Recurring_Donations_Settings__c rds = UTIL_CustomSettingsFacade.getRecurringDonationsSettings();
         String InstallmentType = rd.npe03__Installment_Period__c;
 
-        if (InstallmentType == System.Label.npe03.RecurringDonationInstallmentPeriodYearly) {
+        if (InstallmentType == RD_Constants.INSTALLMENT_PERIOD_YEARLY) {
             calcDate = calcDate.addYears(1);
 
-        } else if (InstallmentType == System.Label.npe03.RecurringDonationInstallmentPeriodQuarterly) {
+        } else if (InstallmentType == RD_Constants.INSTALLMENT_PERIOD_QUARTERLY) {
             calcDate = calcDate.addMonths(3);
             calcDate = adjustDayOfMonth(calcDate, rd);
 
-        } else if (InstallmentType == System.Label.npe03.RecurringDonationInstallmentPeriodMonthly) {
+        } else if (InstallmentType == RD_Constants.INSTALLMENT_PERIOD_MONTHLY) {
             calcDate = calcDate.addMonths(1);
             calcDate = adjustDayOfMonth(calcDate, rd);
 
-        } else if (InstallmentType == System.Label.npe03.RecurringDonationInstallmentPeriodWeekly) {
+        } else if (InstallmentType == RD_Constants.INSTALLMENT_PERIOD_WEEKLY) {
             calcDate = calcDate.addDays(7);
 
-        } else if (InstallmentType == System.Label.npe03.RecurringDonationInstallmentPeriod1stand15th) {
+        } else if (InstallmentType == RD_Constants.INSTALLMENT_PERIOD_FIRST_AND_FIFTEENTH) {
             //increment it by one day until we hit either the 1st or 15th
             do {
                 calcDate = calcDate.addDays(1);

--- a/src/classes/RD_RecurringDonations_BATCH.cls
+++ b/src/classes/RD_RecurringDonations_BATCH.cls
@@ -68,7 +68,7 @@ Schedulable {
     */
     public RD_RecurringDonations_BATCH() {
         query = RD_RecurringDonations.strQueryRDNoWhere();
-        query += ' where npe03__Open_Ended_Status__c = \'' + system.Label.npe03.RecurringDonationOpenStatus + '\'';
+        query += ' where npe03__Open_Ended_Status__c = \'' + RD_Constants.OPEN_ENDED_STATUS_OPEN + '\'';
         RD_RecurringDonations_BATCH.isBatchButton = true;
     }
 

--- a/src/classes/RD_RecurringDonations_Opp_TDTM.cls
+++ b/src/classes/RD_RecurringDonations_Opp_TDTM.cls
@@ -1,10 +1,10 @@
 /*
     Copyright (c) 2012,2013,2014 Salesforce.org
     All rights reserved.
-    
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
-    
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -13,72 +13,72 @@
     * Neither the name of Salesforce.org nor the names of
       its contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
- 
+
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 */
 /**
 * @author Salesforce.org
 * @date 2013
 * @group Recurring Donations
-* @description Trigger Handler on Opportunity for managing Recurring Donations 
+* @description Trigger Handler on Opportunity for managing Recurring Donations
 */
 public class RD_RecurringDonations_Opp_TDTM extends TDTM_Runnable {
-    
+
     /*******************************************************************************************************
     * @description Trigger Handler for Recurring Donations called on an Opportunity trigger AfterUpdate.
     * Needs to see if the Opp is changing to closed, and if it has open RD's, update them.
-    * @param newlist the list of Opportunities from trigger new. 
-    * @param oldlist the list of Opportunities from trigger old. 
-    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.). 
-    * @param objResult the describe for Opportunity 
-    * @return dmlWrapper. 
+    * @param newlist the list of Opportunities from trigger new.
+    * @param oldlist the list of Opportunities from trigger old.
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.).
+    * @param objResult the describe for Opportunity
+    * @return dmlWrapper.
     ********************************************************************************************************/
-    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
 
         if (RD2_EnablementService.isRecurringDonations2Enabled) {
             return null;
         }
-            
+
         TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.flag.RD, true);
         DmlWrapper dmlWrapper = new DmlWrapper();
-        
-        set<id> rdIDs = new set<id>();        
+
+        set<id> rdIDs = new set<id>();
         if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
             integer i = 0;
             for (SObject sobj : newlist) {
                 Opportunity o = (Opportunity)sobj;
-                
+
                 // Has the Opportunity's closed state, amount, or recurring donation changed?
                 Opportunity oppOld = (Opportunity)oldlist[i];
-                if (o.isClosed != oppOld.isClosed 
+                if (o.isClosed != oppOld.isClosed
                     || o.Amount != oppOld.Amount
                     || o.npe03__Recurring_Donation__c != oppOld.npe03__Recurring_Donation__c) {
-                    
-                    // If the Recurring Donation has changed, also update the Recurring Donation 
+
+                    // If the Recurring Donation has changed, also update the Recurring Donation
                     // associated with the old (previous) version of the Opportunity
                     if (oppOld.npe03__Recurring_Donation__c != null
                         && o.npe03__Recurring_Donation__c != oppOld.npe03__Recurring_Donation__c) {
                         rdIds.add(oppOld.npe03__Recurring_Donation__c);
                     }
-                
+
                     if (o.npe03__Recurring_Donation__c != null) {
-                        rdIds.add(o.npe03__Recurring_Donation__c);  
+                        rdIds.add(o.npe03__Recurring_Donation__c);
                     }
                 }
                 i++;
-            }                        
+            }
         }
 
         if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
@@ -91,23 +91,23 @@ public class RD_RecurringDonations_Opp_TDTM extends TDTM_Runnable {
                     rdIds.add(o.npe03__Recurring_Donation__c);
                 }
                 i++;
-            }                  
-        }           
-        
+            }
+        }
+
         //Get the open label for opps
-        string closedLabel = system.label.npe03.RecurringDonationClosedStatus;
+        string closedLabel = RD_Constants.OPEN_ENDED_STATUS_CLOSED;
         Integer rdcount = 0;
         if (RDids.size() > 0) {
             rdcount = [select count() from npe03__Recurring_Donation__c where npe03__Open_Ended_Status__c <> :closedLabel and id IN :RDids];
         }
-                                                                                          
-        //recurring donations that need to be updated      
+
+        //recurring donations that need to be updated
         if (rdcount > 0) {
             if (rdcount == 1 || system.isBatch() || system.isFuture() || RD_RecurringDonations_BATCH.isBatchButton) {
-                RD_RecurringDonations.updateRecurringDonationOnOppChange(rdIds, dmlWrapper); 
+                RD_RecurringDonations.updateRecurringDonationOnOppChange(rdIds, dmlWrapper);
             }
             else {
-                RD_RecurringDonations.updateRecurringDonationOnOppChangeFuture(rdIds);                                        
+                RD_RecurringDonations.updateRecurringDonationOnOppChangeFuture(rdIds);
             }
         }
 

--- a/src/classes/RD_RecurringDonations_TDTM.cls
+++ b/src/classes/RD_RecurringDonations_TDTM.cls
@@ -1,10 +1,10 @@
 /*
     Copyright (c) 2012,2013,2014 Salesforce.org
     All rights reserved.
-    
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
-    
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -13,38 +13,38 @@
     * Neither the name of Salesforce.org nor the names of
       its contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
- 
+
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 */
 /**
 * @author Salesforce.org
 * @date 2012 (2.0)
 * @group Recurring Donations
-* @description Trigger Handler on Recurring Donations 
+* @description Trigger Handler on Recurring Donations
 */
 public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
 
     /*******************************************************************************************************
     * @description Trigger Handler on Recurring Donations.  Deals with creating/updating/deleting the opps
     * related to the Recurring Donations.
-    * @param newlist the list of RD's from trigger new. 
-    * @param oldlist the list of RD's from trigger old. 
-    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.). 
-    * @param objResult the describe for Recurring Donation 
-    * @return dmlWrapper. 
+    * @param newlist the list of RD's from trigger new.
+    * @param oldlist the list of RD's from trigger old.
+    * @param triggerAction which trigger event (BeforeInsert, AfterInsert, etc.).
+    * @param objResult the describe for Recurring Donation
+    * @return dmlWrapper.
     ********************************************************************************************************/
-    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist, 
+    public override DmlWrapper run(List<SObject> newlist, List<SObject> oldlist,
         TDTM_Runnable.Action triggerAction, Schema.DescribeSObjectResult objResult) {
 
         if (RD2_EnablementService.isRecurringDonations2Enabled) {
@@ -58,7 +58,7 @@ public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
         if (TDTM_ProcessControl.isRecursive(TDTM_ProcessControl.flag.RD)) {
             return null;
         }
-            
+
         map<string, npe03__Custom_Installment_Settings__c> customInstallmentsMap
             = UTIL_ListCustomSettingsFacade.getMapCustomInstallmentSettings();
 
@@ -71,15 +71,15 @@ public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
             newlist = RD_RecurringDonations.requeryListRD(setRDId);
             // since we recreate newlist, we can't assume it is same order as oldlist.
             // luckily we don't need oldlist for the AfterInsert scenario.
-            oldlist = null; 
+            oldlist = null;
         } else if (triggerAction == TDTM_Runnable.Action.BeforeDelete) {
             // newlist will be null.  copy over oldlist, so we can use common loop below.
             newlist = oldlist;
         }
 
         if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
-            new RD2_NamingService().autogenerateNames(newlist);            
-        } 
+            new RD2_NamingService().autogenerateNames(newlist);
+        }
 
         if (triggerAction != TDTM_Runnable.Action.BeforeInsert && triggerAction != TDTM_Runnable.Action.BeforeUpdate) {
             TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.flag.RD, true);
@@ -87,11 +87,11 @@ public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
         DmlWrapper dmlWrapper = new DmlWrapper();
 
         for (SObject sobj : newlist) {
-            npe03__Recurring_Donation__c r = (npe03__Recurring_Donation__c)sobj;                   
+            npe03__Recurring_Donation__c r = (npe03__Recurring_Donation__c)sobj;
 
             if (triggerAction == TDTM_Runnable.Action.BeforeInsert || triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
                 validateRecurringDonationData(r, rds);
-                
+
                 if (shouldResetAlwaysUseLastDayOfMonth(r, customInstallmentsMap)) {
                     r.Always_Use_Last_Day_Of_Month__c = false;
                 }
@@ -104,11 +104,11 @@ public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
 
             }
         }
-        
+
         if (listRDUpdates.size() > 0) {
-            RD_RecurringDonations.handleRecurringDonationUpdate(listRDUpdates, new map<Id,npe03__Recurring_Donation__c>((list<npe03__Recurring_Donation__c>)oldlist), dmlWrapper); 
+            RD_RecurringDonations.handleRecurringDonationUpdate(listRDUpdates, new map<Id,npe03__Recurring_Donation__c>((list<npe03__Recurring_Donation__c>)oldlist), dmlWrapper);
         }
-        
+
         if (!mapIdRDInserts.isEmpty()) {
             if (mapIdRDInserts.keySet().size() == 1 || system.isFuture() || system.isBatch()) {
                 RD_RecurringDonations.insertOppsOnRecurringDonationInsert(mapIdRDInserts.values());
@@ -139,9 +139,9 @@ public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
         if (r.npe03__Organization__c != null && r.npe03__Contact__c != null) {
             r.addError(system.label.RecurringDonationAccountAndContactError);
         }
-        if (r.npe03__Installments__c > rds.npe03__Maximum_Donations__c && 
-            (r.npe03__Open_Ended_Status__c != system.label.npe03.RecurringDonationOpenStatus && 
-                r.npe03__Open_Ended_Status__c != system.label.npe03.RecurringDonationClosedStatus)) {
+        if (r.npe03__Installments__c > rds.npe03__Maximum_Donations__c &&
+            (r.npe03__Open_Ended_Status__c != RD_Constants.OPEN_ENDED_STATUS_OPEN &&
+                r.npe03__Open_Ended_Status__c != RD_Constants.OPEN_ENDED_STATUS_CLOSED)) {
             r.addError(system.label.npe03.RecurringDonationTooManyInstallmentsError);
         }
     }
@@ -154,9 +154,9 @@ public class RD_RecurringDonations_TDTM extends TDTM_Runnable {
     ********************************************************************************************************/
     private Boolean shouldResetAlwaysUseLastDayOfMonth(npe03__Recurring_Donation__c r, map<string, npe03__Custom_Installment_Settings__c> customInstallmentsMap) {
         return
-            r.Always_Use_Last_Day_Of_Month__c == true 
-            && r.npe03__Installment_Period__c != system.label.npe03.RecurringDonationInstallmentPeriodMonthly
-            && r.npe03__Installment_Period__c != system.label.npe03.RecurringDonationInstallmentPeriodQuarterly
+            r.Always_Use_Last_Day_Of_Month__c == true
+            && r.npe03__Installment_Period__c != RD_Constants.INSTALLMENT_PERIOD_MONTHLY
+            && r.npe03__Installment_Period__c != RD_Constants.INSTALLMENT_PERIOD_QUARTERLY
             && !customInstallmentsMap.containsKey(r.npe03__Installment_Period__c);
     }
 

--- a/src/classes/RD_RecurringDonations_TEST.cls
+++ b/src/classes/RD_RecurringDonations_TEST.cls
@@ -46,8 +46,8 @@ public class RD_RecurringDonations_TEST {
     @isTest
     private static void insertOpportunities()
     {
-        UTIL_Debug.debug('multiply: ' + System.Label.npe03.RecurringDonationMultiplyValue);
-        UTIL_Debug.debug('divide: ' + System.Label.npe03.RecurringDonationDivideValue);
+        UTIL_Debug.debug('multiply: ' + RD_Constants.SCHEDULE_TYPE_MULTIPLY_BY);
+        UTIL_Debug.debug('divide: ' + RD_Constants.SCHEDULE_TYPE_DIVIDE_BY);
         Account a = buildAccount();
         insert a;
 
@@ -235,7 +235,7 @@ public class RD_RecurringDonations_TEST {
         r2.npe03__Installments__c = 3;
         r2.npe03__Organization__c = a.Id;
         r2.npe03__Date_Established__c = Date.newInstance(1970,6,30);
-        r2.npe03__Schedule_Type__c = System.Label.npe03.RecurringDonationDivideValue;
+        r2.npe03__Schedule_Type__c = RD_Constants.SCHEDULE_TYPE_DIVIDE_BY;
         insert r2;
 
         Opportunity[] installments2 = getOpps(r2.id);
@@ -482,7 +482,7 @@ public class RD_RecurringDonations_TEST {
         insert c;
 
         npe03__Recurring_Donation__c rd = buildRecurringDonationWeeklyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         insert rd;
 
@@ -493,7 +493,7 @@ public class RD_RecurringDonations_TEST {
         System.assertEquals(100, originalOpps[0].Amount);
 
         Test.startTest();
-        rd.npe03__Installment_Period__c = System.Label.npe03.RecurringDonationInstallmentPeriodMonthly;
+        rd.npe03__Installment_Period__c = RD2_Constants.INSTALLMENT_PERIOD_MONTHLY;
         update rd;
         Test.stopTest();
 
@@ -511,9 +511,9 @@ public class RD_RecurringDonations_TEST {
         insert c;
 
         npe03__Recurring_Donation__c rd = buildRecurringDonation(
-            c.Id, System.Label.npe03.RecurringDonationInstallmentPeriod1stand15th
+            c.Id, RD_Constants.INSTALLMENT_PERIOD_FIRST_AND_FIFTEENTH
         );
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
 
         Test.startTest();
@@ -538,7 +538,7 @@ public class RD_RecurringDonations_TEST {
         insert c;
 
         npe03__Recurring_Donation__c rd = buildRecurringDonationWeeklyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         insert rd;
 
@@ -549,7 +549,7 @@ public class RD_RecurringDonations_TEST {
         System.assertEquals(100, originalOpps[0].Amount);
 
         Test.startTest();
-        rd.npe03__Installment_Period__c = System.Label.npe03.RecurringDonationInstallmentPeriodYearly;
+        rd.npe03__Installment_Period__c = RD_Constants.INSTALLMENT_PERIOD_YEARLY;
         update rd;
         Test.stopTest();
 
@@ -567,7 +567,7 @@ public class RD_RecurringDonations_TEST {
         insert c;
 
         npe03__Recurring_Donation__c rd = buildRecurringDonationMonthlyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         insert rd;
 
@@ -577,7 +577,7 @@ public class RD_RecurringDonations_TEST {
         System.assertEquals(100, originalOpps[0].Amount);
 
         Test.startTest();
-        rd.npe03__Installment_Period__c = System.Label.npe03.RecurringDonationInstallmentPeriodWeekly;
+        rd.npe03__Installment_Period__c = RD_Constants.INSTALLMENT_PERIOD_WEEKLY;
         update rd;
         Test.stopTest();
 
@@ -597,7 +597,7 @@ public class RD_RecurringDonations_TEST {
         insert c;
 
         npe03__Recurring_Donation__c rd = buildRecurringDonationWeeklyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         insert rd;
 
@@ -607,7 +607,7 @@ public class RD_RecurringDonations_TEST {
         System.assert(cOpp == 52 || cOpp == 53);
         System.assertEquals(100, originalOpps[0].Amount);
         Test.startTest();
-        rd.npe03__Installment_Period__c = System.Label.npe03.RecurringDonationInstallmentPeriodQuarterly;
+        rd.npe03__Installment_Period__c = RD_Constants.INSTALLMENT_PERIOD_QUARTERLY;
         update rd;
         Test.stopTest();
 
@@ -626,7 +626,7 @@ public class RD_RecurringDonations_TEST {
         insert c;
 
         npe03__Recurring_Donation__c rd = buildRecurringDonationWeeklyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         rd.OwnerId = system.Userinfo.getUserId();
         insert rd;
@@ -660,7 +660,7 @@ public class RD_RecurringDonations_TEST {
         insert c;
 
         npe03__Recurring_Donation__c rd = buildRecurringDonationYearlyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         rd.OwnerId = system.Userinfo.getUserId();
         insert rd;
@@ -698,7 +698,7 @@ public class RD_RecurringDonations_TEST {
         insert c;
 
         npe03__Recurring_Donation__c rd = buildRecurringDonationQuarterlyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         rd.OwnerId = system.Userinfo.getUserId();
         insert rd;
@@ -742,7 +742,7 @@ public class RD_RecurringDonations_TEST {
 
         npe03__Recurring_Donation__c rd = buildRecurringDonation(null, customInstallment.Name);
         rd.npe03__Organization__c = a.id;
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         rd.OwnerId = system.Userinfo.getUserId();
         insert rd;
@@ -785,7 +785,7 @@ public class RD_RecurringDonations_TEST {
 
         npe03__Recurring_Donation__c rd = buildRecurringDonation(null, customInstallment.Name);
         rd.npe03__Organization__c = a.id;
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         insert rd;
 
@@ -827,7 +827,7 @@ public class RD_RecurringDonations_TEST {
         npe03__Recurring_Donation__c rd = buildRecurringDonation(null, customInstallment.Name);
         rd.npe03__Organization__c = a.id;
         rd.npe03__Date_Established__c = Date.newInstance(2000,1,1);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         rd.OwnerId = system.Userinfo.getUserId();
         insert rd;
@@ -869,7 +869,7 @@ public class RD_RecurringDonations_TEST {
 
         npe03__Recurring_Donation__c rd = buildRecurringDonation(null, customInstallment.Name);
         rd.npe03__Organization__c = a.id;
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         rd.OwnerId = system.Userinfo.getUserId();
         insert rd;
@@ -920,7 +920,7 @@ public class RD_RecurringDonations_TEST {
     * @return npe03__Recurring_Donation__c
     */
     public static npe03__Recurring_Donation__c buildRecurringDonationYearlyInstallment(Id contactId) {
-        return buildRecurringDonation(contactId, System.Label.npe03.RecurringDonationInstallmentPeriodYearly);
+        return buildRecurringDonation(contactId, RD_Constants.INSTALLMENT_PERIOD_YEARLY);
     }
 
     /*******************************************************************************************************
@@ -929,7 +929,7 @@ public class RD_RecurringDonations_TEST {
     * @return npe03__Recurring_Donation__c
     */
     public static npe03__Recurring_Donation__c buildRecurringDonationQuarterlyInstallment(Id contactId) {
-        return buildRecurringDonation(contactId, System.Label.npe03.RecurringDonationInstallmentPeriodQuarterly);
+        return buildRecurringDonation(contactId, RD_Constants.INSTALLMENT_PERIOD_QUARTERLY);
     }
 
     /*******************************************************************************************************
@@ -938,7 +938,7 @@ public class RD_RecurringDonations_TEST {
     * @return npe03__Recurring_Donation__c
     */
     public static npe03__Recurring_Donation__c buildRecurringDonationMonthlyInstallment(Id contactId) {
-        return buildRecurringDonation(contactId, System.Label.npe03.RecurringDonationInstallmentPeriodMonthly);
+        return buildRecurringDonation(contactId, RD_Constants.INSTALLMENT_PERIOD_MONTHLY);
     }
 
     /*******************************************************************************************************
@@ -947,7 +947,7 @@ public class RD_RecurringDonations_TEST {
     * @return npe03__Recurring_Donation__c
     */
     public static npe03__Recurring_Donation__c buildRecurringDonationWeeklyInstallment(Id contactId) {
-        return buildRecurringDonation(contactId, System.Label.npe03.RecurringDonationInstallmentPeriodWeekly);
+        return buildRecurringDonation(contactId, RD_Constants.INSTALLMENT_PERIOD_WEEKLY);
     }
 
     /*******************************************************************************************************

--- a/src/classes/RD_RecurringDonations_TEST2.cls
+++ b/src/classes/RD_RecurringDonations_TEST2.cls
@@ -54,7 +54,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
 
         npe03__Recurring_Donation__c rd = RD_RecurringDonations_TEST.buildRecurringDonationYearlyInstallment(null);
         rd.npe03__Organization__c = a.id;
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         rd.OwnerId = System.UserInfo.getUserId();
         insert rd;
@@ -87,7 +87,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         insert c;
 
         npe03__Recurring_Donation__c rd = RD_RecurringDonations_TEST.buildRecurringDonationWeeklyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         insert rd;
 
@@ -96,7 +96,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         System.assert(cOpp == 52 || cOpp == 53);
 
         Test.startTest();
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationClosedStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_CLOSED;
         update rd;
         Test.stopTest();
 
@@ -116,7 +116,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         insert c;
 
         npe03__Recurring_Donation__c rd = RD_RecurringDonations_TEST.buildRecurringDonationWeeklyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         insert rd;
 
@@ -130,7 +130,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         rd.npe03__Last_Payment_Date__c = TODAY;
         update rd;
         Test.startTest();
-        rd.npe03__Installment_Period__c = System.Label.npe03.RecurringDonationInstallmentPeriodYearly;
+        rd.npe03__Installment_Period__c = RD_Constants.INSTALLMENT_PERIOD_YEARLY;
         update rd;
         Test.stopTest();
 
@@ -238,7 +238,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         npe03__Recurring_Donation__c rd = RD_RecurringDonations_TEST.buildRecurringDonationYearlyInstallment(null);
         rd.npe03__Organization__c = a.id;
         rd.npe03__Recurring_Donation_Campaign__c = camp.id;
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         insert rd;
 
@@ -276,14 +276,14 @@ private with sharing class RD_RecurringDonations_TEST2 {
         npe03__Recurring_Donation__c rd = RD_RecurringDonations_TEST.buildRecurringDonationYearlyInstallment(null);
         rd.npe03__Organization__c = a.id;
         rd.npe03__Recurring_Donation_Campaign__c = camp.id;
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         insert rd;
 
         System.assertNotEquals(0, RD_RecurringDonations_TEST.getOpenOppCount(rd.Id));
         //reset the semaphore
         Test.startTest();
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationClosedStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_CLOSED;
         update rd;
         Test.stopTest();
 
@@ -311,12 +311,12 @@ private with sharing class RD_RecurringDonations_TEST2 {
 
         List<npe03__Recurring_Donation__c> rdlist = new List<npe03__Recurring_Donation__c>();
         npe03__Recurring_Donation__c rd = RD_RecurringDonations_TEST.buildRecurringDonationYearlyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         rdlist.add(rd);
 
         npe03__Recurring_Donation__c r2 = RD_RecurringDonations_TEST.buildRecurringDonationMonthlyInstallment(c.Id);
-        r2.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        r2.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         r2.npe03__Next_Payment_Date__c = TODAY.toStartOfMonth();
         rdlist.add(r2);
 
@@ -378,12 +378,12 @@ private with sharing class RD_RecurringDonations_TEST2 {
         insert c;
 
         npe03__Recurring_Donation__c rd = RD_RecurringDonations_TEST.buildRecurringDonationYearlyInstallment(c.Id);
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         insert rd;
 
         npe03__Recurring_Donation__c r2 = RD_RecurringDonations_TEST.buildRecurringDonationMonthlyInstallment(c.Id);
-        r2.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        r2.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         r2.npe03__Next_Payment_Date__c = TODAY;
         insert r2;
 
@@ -545,7 +545,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
 
         npe03__Recurring_Donation__c rd = RD_RecurringDonations_TEST.buildRecurringDonationWeeklyInstallment(null);
         rd.npe03__Organization__c = a.id;
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         insert rd;
 
@@ -644,7 +644,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         insert a;
         npe03__Recurring_Donation__c rd = RD_RecurringDonations_TEST.buildRecurringDonationWeeklyInstallment(null);
         rd.npe03__Organization__c = a.Id;
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         insert rd;
 
@@ -697,8 +697,8 @@ private with sharing class RD_RecurringDonations_TEST2 {
     */
     @isTest
     private static void testRDCustomFieldMappingFixedRD() {
-        UTIL_Debug.debug('multiply: ' + System.Label.npe03.RecurringDonationMultiplyValue);
-        UTIL_Debug.debug('divide: ' + System.Label.npe03.RecurringDonationDivideValue);
+        UTIL_Debug.debug('multiply: ' + RD_Constants.SCHEDULE_TYPE_MULTIPLY_BY);
+        UTIL_Debug.debug('divide: ' + RD_Constants.SCHEDULE_TYPE_DIVIDE_BY);
         Account a = buildAccount();
         insert a;
 
@@ -745,8 +745,8 @@ private with sharing class RD_RecurringDonations_TEST2 {
     */
     @isTest
     private static void testRDCustomFieldMappingOpenRD() {
-        UTIL_Debug.debug('multiply: ' + System.Label.npe03.RecurringDonationMultiplyValue);
-        UTIL_Debug.debug('divide: ' + System.Label.npe03.RecurringDonationDivideValue);
+        UTIL_Debug.debug('multiply: ' + RD_Constants.SCHEDULE_TYPE_MULTIPLY_BY);
+        UTIL_Debug.debug('divide: ' + RD_Constants.SCHEDULE_TYPE_DIVIDE_BY);
         Account a = buildAccount();
         insert a;
 
@@ -813,7 +813,7 @@ private with sharing class RD_RecurringDonations_TEST2 {
         rd.npe03__Installments__c = 10;
         rd.npe03__Organization__c = a.id;
         rd.npe03__Recurring_Donation_Campaign__c = camp.id;
-        rd.npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus;
+        rd.npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         rd.npe03__Next_Payment_Date__c = TODAY;
         insert rd;
 

--- a/src/classes/STG_PanelRD_CTRL.cls
+++ b/src/classes/STG_PanelRD_CTRL.cls
@@ -113,7 +113,7 @@ public with sharing class STG_PanelRD_CTRL extends STG_Panel {
     */
     private void trimOpportunities(){
         date limitDate = system.today().addMonths((integer)STG_Panel.stgService.stgRD.npe03__Opportunity_Forecast_Months__c);
-        string openlabel = system.label.npe03.RecurringDonationOpenStatus;
+        string openlabel = RD_Constants.OPEN_ENDED_STATUS_OPEN;
         delete [select id from Opportunity
                where CloseDate > :limitDate
                and isClosed != true

--- a/src/classes/TEST_RecurringDonationBuilder.cls
+++ b/src/classes/TEST_RecurringDonationBuilder.cls
@@ -324,7 +324,7 @@ public without sharing class TEST_RecurringDonationBuilder {
     * @return TEST_RecurringDonationBuilder Builder instance
     */
     public TEST_RecurringDonationBuilder withInstallmentPeriodYearly() {
-        return withInstallmentPeriod(System.Label.npe03.RecurringDonationInstallmentPeriodYearly);
+        return withInstallmentPeriod(RD_Constants.INSTALLMENT_PERIOD_YEARLY);
     }
 
     /***
@@ -334,7 +334,7 @@ public without sharing class TEST_RecurringDonationBuilder {
     public TEST_RecurringDonationBuilder withInstallmentPeriodQuarterly() {
         validateMode(Mode.Legacy);
 
-        return withInstallmentPeriod(System.Label.npe03.RecurringDonationInstallmentPeriodQuarterly);
+        return withInstallmentPeriod(RD_Constants.INSTALLMENT_PERIOD_QUARTERLY);
     }
 
     /***
@@ -342,7 +342,7 @@ public without sharing class TEST_RecurringDonationBuilder {
     * @return TEST_RecurringDonationBuilder Builder instance
     */
     public TEST_RecurringDonationBuilder withInstallmentPeriodMonthly() {
-        return withInstallmentPeriod(System.Label.npe03.RecurringDonationInstallmentPeriodMonthly);
+        return withInstallmentPeriod(RD_Constants.INSTALLMENT_PERIOD_MONTHLY);
     }
 
     /***
@@ -350,7 +350,7 @@ public without sharing class TEST_RecurringDonationBuilder {
     * @return TEST_RecurringDonationBuilder Builder instance
     */
     public TEST_RecurringDonationBuilder withInstallmentPeriodWeekly() {
-        return withInstallmentPeriod(System.Label.npe03.RecurringDonationInstallmentPeriodWeekly);
+        return withInstallmentPeriod(RD_Constants.INSTALLMENT_PERIOD_WEEKLY);
     }
 
     /***
@@ -368,7 +368,7 @@ public without sharing class TEST_RecurringDonationBuilder {
     * @return TEST_RecurringDonationBuilder Builder instance
     */
     public TEST_RecurringDonationBuilder withScheduleTypeMultiplyValue() {
-        return withScheduleType(System.Label.npe03.RecurringDonationMultiplyValue);
+        return withScheduleType(RD_Constants.SCHEDULE_TYPE_MULTIPLY_BY);
     }
 
     /***
@@ -388,7 +388,7 @@ public without sharing class TEST_RecurringDonationBuilder {
     * @return TEST_RecurringDonationBuilder Builder instance
     */
     public TEST_RecurringDonationBuilder withOpenEndedStatusOpen() {
-        return withOpenEndedStatus(System.Label.npe03.RecurringDonationOpenStatus);
+        return withOpenEndedStatus(RD_Constants.OPEN_ENDED_STATUS_OPEN);
     }
 
     /***
@@ -396,7 +396,7 @@ public without sharing class TEST_RecurringDonationBuilder {
     * @return TEST_RecurringDonationBuilder Builder instance
     */
     public TEST_RecurringDonationBuilder withOpenEndedStatusClosed() {
-        return withOpenEndedStatus(System.Label.npe03.RecurringDonationClosedStatus);
+        return withOpenEndedStatus(RD_Constants.OPEN_ENDED_STATUS_CLOSED);
     }
 
     /***

--- a/src/classes/UTIL_OrgTelemetry_SObject_BATCH.cls
+++ b/src/classes/UTIL_OrgTelemetry_SObject_BATCH.cls
@@ -99,7 +99,7 @@ public class UTIL_OrgTelemetry_SObject_BATCH implements Database.Batchable<SObje
     @TestVisible
     private Integer oppsWithPayments = 0;
 
-    private final String recurringDonationOpenStatusValue = System.Label.npe03.RecurringDonationOpenStatus;
+    private final String recurringDonationOpenStatusValue = RD_Constants.OPEN_ENDED_STATUS_OPEN;
 
     /**
      * @description Constructor

--- a/src/classes/UTIL_OrgTelemetry_SObject_BATCH_TEST.cls
+++ b/src/classes/UTIL_OrgTelemetry_SObject_BATCH_TEST.cls
@@ -49,12 +49,12 @@ private class UTIL_OrgTelemetry_SObject_BATCH_TEST {
 
         npe03__Recurring_Donation__c openRd = new npe03__Recurring_Donation__c(
             npe03__Amount__c = 100,
-            npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationOpenStatus
+            npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_OPEN
         );
 
         npe03__Recurring_Donation__c closedRd = new npe03__Recurring_Donation__c(
             npe03__Amount__c = 1200,
-            npe03__Open_Ended_Status__c = System.Label.npe03.RecurringDonationClosedStatus
+            npe03__Open_Ended_Status__c = RD_Constants.OPEN_ENDED_STATUS_CLOSED
         );
 
         insert new List<npe03__Recurring_Donation__c>{ openRd, closedRd };

--- a/src/package.xml
+++ b/src/package.xml
@@ -369,6 +369,7 @@
         <members>RD_BulkTests_TEST</members>
         <members>RD_CascadeDeleteLookups_TDTM</members>
         <members>RD_CascadeDeleteLookups_TEST</members>
+        <members>RD_Constants</members>
         <members>RD_InstallScript_BATCH</members>
         <members>RD_RecurringDonations</members>
         <members>RD_RecurringDonations_BATCH</members>

--- a/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls
+++ b/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls
@@ -810,9 +810,9 @@ public class CRLP_TEST_VALIDATE_ROLLUPS {
             npe03__Contact__c = rdContact.Id,
             /*npe03__Organization__c = rdContact.AccountId,*/
             npe03__Amount__c = RD_AMOUNT_USD,
-            npe03__Installment_Period__c = System.Label.npe03.RecurringDonationInstallmentPeriodMonthly,
+            npe03__Installment_Period__c = RD_Constants.INSTALLMENT_PERIOD_MONTHLY,
             npe03__Date_Established__c = Date.Today().addMonths(-12),
-            npe03__Schedule_Type__c = System.Label.npe03.RecurringDonationMultiplyValue,
+            npe03__Schedule_Type__c = RD_Constants.SCHEDULE_TYPE_MULTIPLY_BY,
             npe03__Open_Ended_Status__c = 'Open'
         );
         insert rd;


### PR DESCRIPTION
- Remove all uses of legacy Recurring Donation custom labels with hardcoded Apex Constants. This addresses an issue with labels that are not supposed to be translated in our underlying packages, but due to a packaging limitation the translations still exist in the package even though they were remove two years ago.

# Critical Changes

# Changes

- Deprecate legacy custom labels that were previously used by a much older version of Recurring Donations. These labels have not been needed since Salesforce introduced Picklist Api Values in the Spring '17 release, however they have still exist in the package and could cause issues if the values were translated.

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
