### PR TITLE
Gift-Entry: bug fix in reset method for lookup fields on BGE mode

### DIFF
--- a/src/lwc/geAutocomplete/geAutocomplete.js
+++ b/src/lwc/geAutocomplete/geAutocomplete.js
@@ -98,6 +98,19 @@ export default class GeAutocomplete extends LightningElement {
         this.valid = true;
     }
 
+    @api
+    reset() {
+        this.displayValue = '';
+        this.value = null;
+        const payload = {
+            detail: {
+                value: this.value,
+                displayValue: this.displayValue
+            }
+        };
+        this.dispatchEvent(new CustomEvent('select', payload));
+    }
+
     /*******************************************
      Dynamic CSS/Id / Display Attributes below here
      *******************************************/

--- a/src/lwc/geFormFieldLookup/geFormFieldLookup.js
+++ b/src/lwc/geFormFieldLookup/geFormFieldLookup.js
@@ -170,8 +170,8 @@ export default class GeFormFieldLookup extends LightningElement {
 
     @api
     reset() {
-        this.displayValue = null;
-        this.value = null;
+        let autocomplete = this.template.querySelector('c-ge-autocomplete');
+        autocomplete.reset();
     }
 
 }


### PR DESCRIPTION
[W-038566](https://foundation.lightning.force.com/lightning/r/agf__ADM_Work__c/a2x1E000001Hqc9QAC/view): bug fix to reset values from autocomplete fields after save on batch gift entry mode. 

# Critical Changes

# Changes
- created new reset() method on autocomplete component, calling that method from geFormFieldLookup instead of changing obj properties

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
