### PR TITLE
Handle widgets when building query string for batch mode UI

### DIFF
--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -105,30 +105,37 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
 
             for (FORM_Section formSection : t.layout.sections) {
                 for (FORM_Element formElement : formSection.elements) {
-
-                    // Get the field mapping, used to reference the source field
-                    String fieldMappingName = formElement.dataImportFieldMappingDevNames[0];
-                    BDI_FieldMapping fieldMapping =
-                            fieldMappingByDevName.get(fieldMappingName);
-                    if (fieldMapping == null) {
+                    if (formElement.dataImportFieldMappingDevNames == null) {
                         continue;
                     }
+                    // Get the field mappings, used to reference the source fields
+                    for (String fieldMappingName :
+                            formElement.dataImportFieldMappingDevNames) {
 
-                    // Add the source fields used in the Template
-                    if (!fieldApiNames.contains(fieldMapping.Source_Field_API_Name.toLowerCase())) {
-                        fieldApiNames.add(fieldMapping.Source_Field_API_Name.toLowerCase());
-                    }
+                        BDI_FieldMapping fieldMapping =
+                                fieldMappingByDevName.get(fieldMappingName);
+                        if (fieldMapping == null) {
+                            continue;
+                        }
 
-                    // Add the Name fields on the related object(s) for all Lookup fields,
-                    // used as display value(s) for Lookup fields loaded in the Form UI
-                    if (fieldMapping.Source_Field_Data_Type == 'REFERENCE') {
-                        String relatedObjNameField = String.join(new List<String>{
-                                fieldMapping.Source_Field_API_Name.replace('__c', '__r'),
-                                'Name'
-                        }, '.'
-                        ).toLowerCase();
-                        if (!fieldApiNames.contains(relatedObjNameField)) {
-                            fieldApiNames.add(relatedObjNameField);
+                        // Add the source fields used in the Template
+                        if (!fieldApiNames.contains(
+                                fieldMapping.Source_Field_API_Name.toLowerCase())) {
+                            fieldApiNames.add(
+                                    fieldMapping.Source_Field_API_Name.toLowerCase());
+                        }
+
+                        // Add the Name fields on the related object(s) for all Lookup fields,
+                        // used as display value(s) for Lookup fields loaded in the Form UI
+                        if (fieldMapping.Source_Field_Data_Type == 'REFERENCE') {
+                            String relatedObjNameField = String.join(new List<String>{
+                                    fieldMapping.Source_Field_API_Name.replace('__c', '__r'),
+                                    'Name'
+                            }, '.'
+                            ).toLowerCase();
+                            if (!fieldApiNames.contains(relatedObjNameField)) {
+                                fieldApiNames.add(relatedObjNameField);
+                            }
                         }
                     }
                 }

--- a/src/classes/BGE_BatchGiftEntry_UTIL_TEST.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL_TEST.cls
@@ -86,4 +86,55 @@ private with sharing class BGE_BatchGiftEntry_UTIL_TEST {
         }
     }
 
+    @isTest
+    static void shouldIncludeWidgetFields() {
+        FORM_Element widgetElement =
+                new FORM_Element(
+                        'widget', '', '', '',
+                        new String[]{
+                                UTIL_Namespace.alignSchemaNSWithEnvironment(
+                                        'Account_2_Country'),
+                                UTIL_Namespace.alignSchemaNSWithEnvironment(
+                                        'Account_2_City')
+                        });
+
+        FORM_Section formSection =
+                new FORM_Section('', '', '', '',
+                        new FORM_Element[]{
+                                widgetElement
+                        });
+
+        FORM_Layout formLayout =
+                new FORM_Layout('', new FORM_Section[]{
+                        formSection
+                });
+
+        FORM_Template formTemplate =
+                new FORM_Template(
+                        'testTemplate', '', '', formLayout);
+
+        Form_Template__c template = new Form_Template__c(
+                Template_JSON__c = JSON.serialize(formTemplate),
+                Format_Version__c = '1.0');
+        insert template;
+
+        DataImportBatch__c batch = new DataImportBatch__c(
+                Form_Template__c = template.Id,
+                Batch_Gift_Entry_Version__c = 2.0
+        );
+        insert batch;
+
+        List<String> queryFields =
+                BGE_BatchGiftEntry_UTIL.getDataImportFields(
+                        batch.Id, true
+                );
+
+        System.assert(
+                queryFields.contains(
+                        String.valueOf(DataImport__c.Account2_Country__c).toLowerCase()));
+        System.assert(
+                queryFields.contains(
+                        String.valueOf(DataImport__c.Account2_City__c).toLowerCase()));
+    }
+
 }

--- a/src/classes/BGE_BatchGiftEntry_UTIL_TEST.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL_TEST.cls
@@ -92,10 +92,8 @@ private with sharing class BGE_BatchGiftEntry_UTIL_TEST {
                 new FORM_Element(
                         'widget', '', '', '',
                         new String[]{
-                                UTIL_Namespace.alignSchemaNSWithEnvironment(
-                                        'Account_2_Country'),
-                                UTIL_Namespace.alignSchemaNSWithEnvironment(
-                                        'Account_2_City')
+                                'Account_2_Country',
+                                'Account_2_City'
                         });
 
         FORM_Section formSection =


### PR DESCRIPTION
Widgets might reference multiple field mappings.  This change handles
that scenario so that all source fields used by the widget are included
in the query used in the form UI.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
