### PR TITLE
Gift Entry: Batch Mode Required Field Validation

### DIFF
--- a/src/classes/GE_FormServiceController.cls
+++ b/src/classes/GE_FormServiceController.cls
@@ -1,0 +1,63 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group HGE
+* @group-content
+* @description Controller for the geFormService lightning web component.
+*/
+public with sharing class GE_FormServiceController {
+
+    /**
+     * @description Returns a render wrapper containing the Advanced Mapping field and
+     * object mappings and a Gift Entry form template, which is either the default
+     * or the one whose Id is passed in as templateId.
+     *
+     * @param templateId Id of the target Form_Template__c.
+     *
+     * @return The render wrapper containing the target template or the default
+     * template if templateId is null.
+     */
+    @AuraEnabled(cacheable=true)
+    public static FORM_RenderWrapper getFormRenderWrapper(Id templateId) {
+        try {
+            if (templateId != null) {
+                return GE_FormRendererService.getRenderWrapperById(templateId);
+            } else {
+                return GE_FormRendererService.getDefaultSGERenderWrapper();
+            }
+        } catch (Exception e) {
+            AuraHandledException ex = new AuraHandledException(e.getMessage());
+            ex.initCause(e);
+            throw ex;
+        }
+    }
+}

--- a/src/classes/GE_FormServiceController.cls-meta.xml
+++ b/src/classes/GE_FormServiceController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -15,7 +15,6 @@ import { getQueryParameters, isEmpty, isNotEmpty, format } from 'c/utilCommon';
 import TemplateBuilderService from 'c/geTemplateBuilderService';
 import { getRecord } from 'lightning/uiRecordApi';
 import FORM_TEMPLATE_FIELD from '@salesforce/schema/DataImportBatch__c.Form_Template__c';
-import TEMPLATE_JSON_FIELD from '@salesforce/schema/Form_Template__c.Template_JSON__c';
 import STATUS_FIELD from '@salesforce/schema/DataImport__c.Status__c';
 import NPSP_DATA_IMPORT_BATCH_FIELD from '@salesforce/schema/DataImport__c.NPSP_Data_Import_Batch__c';
 
@@ -120,36 +119,19 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
         recordId: '$batchId',
         fields: FORM_TEMPLATE_FIELD
     })
-    wiredBatch({ data, error }) {
+    wiredBatch({data, error}) {
         if (data) {
             this.formTemplateId = data.fields[FORM_TEMPLATE_FIELD.fieldApiName].value;
+            GeFormService.getFormTemplateById(this.formTemplateId)
+                .then(template => {
+                    this.initializeForm(template);
+                })
+                .catch(err => {
+                    handleError(err);
+                });
         } else if (error) {
             handleError(error);
         }
-    }
-
-    @wire(getRecord, {
-        recordId: '$formTemplateId',
-        fields: TEMPLATE_JSON_FIELD
-    })
-    wiredTemplate({ data, error }) {
-        if (data) {
-            this.loadTemplate(
-                JSON.parse(data.fields[TEMPLATE_JSON_FIELD.fieldApiName].value));
-        } else if (error) {
-            handleError(error);
-        }
-    }
-
-    async loadTemplate(formTemplate) {
-        // With the change to using a Lookup field to connect a Batch to a Template,
-        // we can use getRecord to get the Template JSON.  But the GeFormService
-        // component still needs to be initialized with the field mappings, and the
-        // call to getFormTemplate() does that.
-        // TODO: Maybe initialize GeFormService with the field mappings in its connected
-        //       callback instead?
-        await GeFormService.getFormTemplate();
-        this.initializeForm(formTemplate);
     }
 
     handleCancel() {

--- a/src/lwc/geFormService/geFormService.js
+++ b/src/lwc/geFormService/geFormService.js
@@ -4,6 +4,8 @@ import { handleError } from 'c/utilTemplateBuilder';
 import saveAndDryRunRow
     from '@salesforce/apex/BGE_DataImportBatchEntry_CTRL.saveAndDryRunRow';
 import {api} from "lwc";
+import getFormRenderWrapper
+    from '@salesforce/apex/GE_FormServiceController.getFormRenderWrapper';
 
 // https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_enum_Schema_DisplayType.htm
 // this list only includes fields that can be handled by lightning-input
@@ -156,6 +158,35 @@ class GeFormService {
                 })
                 .catch(error => {
                     reject(error);
+                });
+        });
+    }
+
+    getFormRenderWrapper(templateId) {
+        return new Promise((resolve, reject) => {
+            getFormRenderWrapper({templateId: templateId})
+                .then(renderWrapper => {
+                    this.fieldMappings =
+                        renderWrapper.fieldMappingSetWrapper.fieldMappingByDevName;
+                    this.objectMappings =
+                        renderWrapper.fieldMappingSetWrapper.objectMappingByDevName;
+                    resolve(renderWrapper);
+                })
+                .catch(err => {
+                    reject(err);
+                });
+        });
+
+    }
+
+    getFormTemplateById(templateId) {
+        return new Promise((resolve, reject) => {
+            this.getFormRenderWrapper(templateId)
+                .then(renderWrapper => {
+                    resolve(renderWrapper.formTemplate);
+                })
+                .catch(err => {
+                    reject(err);
                 });
         });
     }

--- a/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
+++ b/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
@@ -304,6 +304,8 @@ const handleError = (error) => {
             Array.isArray(error.detail.output.errors)) {
             message = error.detail.output.errors.map(e => e.message).join(', ');
         }
+    } else if (error.body.message) {
+        message = error.body.message;
     }
 
     showToast(commonError, message, 'error', 'sticky');

--- a/src/package.xml
+++ b/src/package.xml
@@ -274,6 +274,7 @@
         <members>GE_BatchGiftEntryController</members>
         <members>GE_FormRendererService</members>
         <members>GE_FormRendererService_TEST</members>
+        <members>GE_FormServiceController</members>
         <members>GE_LookupController</members>
         <members>GE_LookupController_TEST</members>
         <members>GE_TemplateBuilderCtrl</members>


### PR DESCRIPTION
This set of changes makes the form show and validate required fields in batch mode the same way it does in single gift entry mode by retrieving the Template from Apex the same way that the template is retrieved for single mode. 

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata
- GE_FormServiceController.cls
# Deleted Metadata
