### PR TITLE
Gift Entry: Fix list view default order by error

### DIFF
--- a/src/lwc/geListView/geListView.js
+++ b/src/lwc/geListView/geListView.js
@@ -258,13 +258,15 @@ export default class geListView extends LightningElement {
                 const columnEntry = this.columnEntriesByName[this.sortedBy];
                 let orderedByFieldApiName;
 
-                if (checkNestedProperty(this.columnEntriesByName[this.sortedBy],
-                    'typeAttributes', 'label', 'fieldName')) {
-                    orderedByFieldApiName = columnEntry.typeAttributes.label.fieldName;
-                } else {
-                    orderedByFieldApiName = columnEntry.fieldName;
+                if (columnEntry) {
+                    if (checkNestedProperty(this.columnEntriesByName[this.sortedBy],
+                        'typeAttributes', 'label', 'fieldName')) {
+                        orderedByFieldApiName = columnEntry.typeAttributes.label.fieldName;
+                    } else {
+                        orderedByFieldApiName = columnEntry.fieldName;
+                    }
+                    orderBy = `${orderedByFieldApiName} ${this.sortedDirection}`;
                 }
-                orderBy = `${orderedByFieldApiName} ${this.sortedDirection}`;
             }
 
             let formTemplates = await retrieveRecords({


### PR DESCRIPTION
# Critical Changes

# Changes
- Fixes an error when the default 'order by' field is removed from the table as a column
# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
