### PR TITLE
Feature/dfuller/gift entry incorrect crud fls text

### DIFF
--- a/src/classes/FORM_ServiceGiftEntry.cls
+++ b/src/classes/FORM_ServiceGiftEntry.cls
@@ -175,6 +175,12 @@ public with sharing class FORM_ServiceGiftEntry {
                                 LIMIT 1];
         
         template = deserializeFormTemplateFromObj(templateObj);
+        
+        template = checkPermissions(template,
+                new Set<FORM_PermissionValidator.AccessLevel>{
+                    FORM_PermissionValidator.AccessLevel.VALIDATE_READ,
+                    FORM_PermissionValidator.AccessLevel.VALIDATE_CREATE,
+                    FORM_PermissionValidator.AccessLevel.VALIDATE_UPDATE});
 
         return template;
     }

--- a/src/lwc/geFormRenderer/geFormRenderer.css
+++ b/src/lwc/geFormRenderer/geFormRenderer.css
@@ -5,3 +5,6 @@
     vertical-align: middle;
     text-align: center;
 }
+.illustrationContainer {
+    margin-top: 3rem;
+}

--- a/src/lwc/geFormRenderer/geFormRenderer.html
+++ b/src/lwc/geFormRenderer/geFormRenderer.html
@@ -25,11 +25,13 @@
                     </c-util-page-level-message>
                 </div>
                 <template if:true={isPermissionError}>
-                    <c-util-illustration title={permissionErrorTitle}
-                                         message={permissionErrorMessage}
-                                         size='large'
-                                         variant='lake-mountain'>
-                    </c-util-illustration>
+                    <div class="illustrationContainer">
+                        <c-util-illustration title={permissionErrorTitle}
+                                            message={permissionErrorMessage}
+                                            size='large'
+                                            variant='lake-mountain'>
+                        </c-util-illustration>
+                    </div>
                 </template>
                 <template if:false={isPermissionError} for:each={sections} for:item='section'>
                     <c-ge-form-section key={section.id}

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -130,7 +130,6 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
         this.name = formTemplate.name;
         this.description = formTemplate.description;
         this.version = formTemplate.layout.version;
-        this.permissionErrorTitle = formTemplate.permissionErrors;
 
         if (typeof formTemplate.layout !== 'undefined'
             && Array.isArray(formTemplate.layout.sections)) {

--- a/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.js
+++ b/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.js
@@ -8,8 +8,6 @@ export default class GeGiftEntryFormApp extends LightningElement {
     @api sObjectName;
 
     @track isPermissionError;
-    @track errorTitle;
-    @track errorMessage;
 
     handleSubmit(event) {
         const table = this.template.querySelector('c-ge-batch-gift-entry-table');

--- a/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
+++ b/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
@@ -65,6 +65,8 @@ import getGiftEntrySettings from
 // relevant Donation_Donor picklist values
 const CONTACT1 = 'Contact1';
 const ACCOUNT1 = 'Account1';
+
+// cache custom labels 
 const CUSTOM_LABELS = GeLabelService.CUSTOM_LABELS;
 
 const ADVANCED_MAPPING = 'Data Import Field Mapping';
@@ -382,11 +384,11 @@ const checkPermissionErrors = (formTemplate) => {
     }
 
     if (template.permissionErrorType === CRUD_ERROR_TYPE) {
-        errorObject.errorTitle = this.CUSTOM_LABELS.geErrorObjectCRUDHeader;
-        errorObject.errorMessage = GeLabelService.format(this.CUSTOM_LABELS.geErrorObjectCRUDBody, permissionErrors);   
+        errorObject.errorTitle = CUSTOM_LABELS.geErrorObjectCRUDHeader;
+        errorObject.errorMessage = GeLabelService.format(CUSTOM_LABELS.geErrorObjectCRUDBody, permissionErrors);   
     } else if (template.permissionErrorType === FLS_ERROR_TYPE) {
-        errorObject.errorTitle = this.CUSTOM_LABELS.geErrorFLSHeader;
-        errorObject.errorMessage = GeLabelService.format(this.CUSTOM_LABELS.geErrorFLSBody, permissionErrors); 
+        errorObject.errorTitle = CUSTOM_LABELS.geErrorFLSHeader;
+        errorObject.errorMessage = GeLabelService.format(CUSTOM_LABELS.geErrorFLSBody, permissionErrors); 
     }
 
     return errorObject;

--- a/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
+++ b/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
@@ -380,11 +380,11 @@ const checkPermissionErrors = (formTemplate) => {
     }
 
     if (template.permissionErrorType === CRUD_ERROR_TYPE) {
-        errorObject.errorTitle = CUSTOM_LABELS.geErrorObjectCRUDHeader;
-        errorObject.errorMessage = GeLabelService.format                                                      (CUSTOM_LABELS.geErrorObjectCRUDBody, permissionErrors);
+        errorObject.errorTitle = this.CUSTOM_LABELS.geErrorObjectCRUDHeader;
+        errorObject.errorMessage = GeLabelService.format(this.CUSTOM_LABELS.geErrorObjectCRUDBody, permissionErrors);   
     } else if (template.permissionErrorType === FLS_ERROR_TYPE) {
-        errorObject.errorTitle = CUSTOM_LABELS.geErrorFLSHeader;
-        errorObject.errorMessage = GeLabelService.format(CUSTOM_LABELS.geErrorFLSBody,                   permissionErrors);
+        errorObject.errorTitle = this.CUSTOM_LABELS.geErrorFLSHeader;
+        errorObject.errorMessage = GeLabelService.format(this.CUSTOM_LABELS.geErrorFLSBody, permissionErrors); 
     }
 
     return errorObject;


### PR DESCRIPTION
# Critical Changes

# Changes
Display "Check Your Object Permissions" or "Check Your Field Permissions" message for the error heading instead of the error field or object names when the Single Gift Entry form is opened in batch mode.

# Issues Closed
[W-039069](https://foundation.lightning.force.com/lightning/r/agf__ADM_Work__c/a2x1E000001HrUoQAK/view)

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
