### PR TITLE
Ensure Reports Are Still Enabled for Recurring Donations

### DIFF
--- a/unpackaged/config/rd2_post_config/objects/npe03__Recurring_Donation__c.object
+++ b/unpackaged/config/rd2_post_config/objects/npe03__Recurring_Donation__c.object
@@ -333,6 +333,12 @@
     </fields>
     <deploymentStatus>Deployed</deploymentStatus>
     <description>Recurring Donations track charitable giving where a donor specifies an amount of money to be given on a regular basis.</description>
+    <enableActivities>true</enableActivities>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>true</enableHistory>
+    <enableReports>true</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
     <label>Recurring Donations</label>
     <nameField>
         <label>Recurring Donation Name</label>


### PR DESCRIPTION
- When installing the unmanaged metadata for RD2, ensure that Reports and Activity Tracking are still enabled as they are in the RD managed package.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
