### PR TITLE
Allocations Widget: 4 column layout, hide error if no rows present

### DIFF
--- a/src/lwc/geFormSection/geFormSection.html
+++ b/src/lwc/geFormSection/geFormSection.html
@@ -12,7 +12,6 @@
                     Maybe size numbers should be passed as part of the "element"? -->
                 <template if:false={element.componentName}>
                     <lightning-layout-item key={element.id}
-                                           class={sectionClassName}
                                            size='6'
                                            medium-device-size='3'>
                         <article class='slds-p-horizontal_small slds-p-vertical_xx-small'>
@@ -25,7 +24,6 @@
                 </template>
                 <template if:true={element.componentName}>
                     <lightning-layout-item key={element.id}
-                                           class={sectionClassName}
                                            padding='around-small'
                                            size='12'
                                            medium-device-size='12'>

--- a/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
+++ b/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
@@ -266,6 +266,10 @@ export default class GeFormWidgetAllocation extends LightningElement {
         }
     }
 
+    hasAllocations() {
+        return Array.isArray(this.rowList) && this.rowList.length > 0;
+    }
+
     /**
      * @return {boolean} TRUE when the total amount allocated is more then the total donation
      */
@@ -311,7 +315,8 @@ export default class GeFormWidgetAllocation extends LightningElement {
      * @return {boolean}
      */
     get showRemainingAmount() {
-        return (this.hasDefaultGAU === false && this.remainingAmount > 0) || this.remainingAmount < 0;
+        return this.hasAllocations() &&
+            ((this.hasDefaultGAU === false && this.remainingAmount > 0) || this.remainingAmount < 0);
     }
 
     /**
@@ -332,7 +337,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
     }
 
     get hasAlert() {
-        return isNotEmpty(this.alertBanner.message);
+        return this.hasAllocations() && isNotEmpty(this.alertBanner.message);
     }
 
     get alertIcon() {

--- a/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.html
+++ b/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.html
@@ -2,14 +2,14 @@
     <lightning-layout>
         <template for:each={mergedFieldList} for:item='field'>
             <lightning-layout-item key={field.mappedField}
-                                   class='slds-p-right_large'
-                                   size='6'
-                                   medium-device-size={field.size}>
-                <c-ge-form-field target-field-name={field.mappedField}
-                                 onvaluechange={handleChange}
-                                 element={field.element}
-                                 data-fieldname={field.mappedField}>
-                </c-ge-form-field>
+                                   size='3'>
+                <article class='slds-p-horizontal_small'>
+                    <c-ge-form-field target-field-name={field.mappedField}
+                                     onvaluechange={handleChange}
+                                     element={field.element}
+                                     data-fieldname={field.mappedField}>
+                    </c-ge-form-field>
+                </article>
             </lightning-layout-item>
         </template>
         <lightning-layout-item size='3' class='slds-align-bottom'>


### PR DESCRIPTION
# Critical Changes

# Changes
- Updated Allocations widget to use 4 column layout
- Error message when allocations do not align with total amount donated should only appear when at least one allocation row is present
- Only show remaining amount when at least one allocation row is present
# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
