### PR TITLE
Gift Entry: Hide closed opps from donation matching modal

### DIFF
--- a/src/classes/GE_FormRendererService.cls
+++ b/src/classes/GE_FormRendererService.cls
@@ -277,7 +277,7 @@ public with sharing class GE_FormRendererService {
                     'AND npe01__Paid__c = false)' +
                 'FROM Opportunity ' +
                 'WHERE ' + relationshipField + ' = :donorId ' +
-                'AND (IsClosed = false OR Id in :oppIdsWithUnpaidPayments) ' +
+                'AND IsClosed = false ' +
                 'ORDER BY CloseDate ASC ';
 
             // CRUD / FLS of this operation already verified by checkCRUDFLS()


### PR DESCRIPTION
# Critical Changes

# Changes
- Hide closed opportunities from appearing in the donation matching modal.
# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
