### PR TITLE
Gift Entry: Hide buttons from GE and Single Gift form when missing permissions

### DIFF
--- a/src/lwc/geBatchGiftEntryHeader/geBatchGiftEntryHeader.html
+++ b/src/lwc/geBatchGiftEntryHeader/geBatchGiftEntryHeader.html
@@ -18,7 +18,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="slds-col slds-no-flex slds-grid slds-align-top slds-p-bottom_xx-small headerButtonActions">
+                <div if:false={isPermissionError} class="slds-col slds-no-flex slds-grid slds-align-top slds-p-bottom_xx-small headerButtonActions">
                     <lightning-button-group>
                         <lightning-button label={batchDryRunLabel}
                                           onclick={handleClick}

--- a/src/lwc/geBatchGiftEntryHeader/geBatchGiftEntryHeader.js
+++ b/src/lwc/geBatchGiftEntryHeader/geBatchGiftEntryHeader.js
@@ -21,6 +21,7 @@ export default class GeBatchGiftEntryHeader extends NavigationMixin(LightningEle
     bdiDataImportPageName;
 
     @api batchId;
+    @api isPermissionError;
 
     @wire(getRecord, {
         recordId: '$batchId',

--- a/src/lwc/geFormRenderer/geFormRenderer.html
+++ b/src/lwc/geFormRenderer/geFormRenderer.html
@@ -68,7 +68,7 @@
                     </c-ge-form-section>
                 </template>
 
-                <article class='slds-align_absolute-center slds-p-vertical_small'>
+                <article if:false={isPermissionError} class='slds-align_absolute-center slds-p-vertical_small'>
                     <lightning-button label={cancelButtonText}
                                       title={cancelButtonText}
                                       onclick={handleCancel}

--- a/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.html
+++ b/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.html
@@ -3,10 +3,12 @@
         <c-ge-batch-gift-entry-header
                 batch-id={recordId}
                 onbatchdryrun={handleBatchDryRun}
-                onedit={handleEditBatch}>
+                onedit={handleEditBatch}
+                is-permission-error={isPermissionError}>
         </c-ge-batch-gift-entry-header>
         <br/>
     </template>
+    
 
     <c-ge-form-renderer
             batch-id={recordId}

--- a/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.html
+++ b/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.html
@@ -2,9 +2,9 @@
     <template if:true={isBatchMode}>
         <c-ge-batch-gift-entry-header
                 batch-id={recordId}
+                is-permission-error={isPermissionError}
                 onbatchdryrun={handleBatchDryRun}
-                onedit={handleEditBatch}
-                is-permission-error={isPermissionError}>
+                onedit={handleEditBatch}>
         </c-ge-batch-gift-entry-header>
         <br/>
     </template>

--- a/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.html
+++ b/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.html
@@ -9,7 +9,6 @@
         <br/>
     </template>
     
-
     <c-ge-form-renderer
             batch-id={recordId}
             onsubmit={handleSubmit}


### PR DESCRIPTION
# Critical Changes

# Changes
 - when the CRUD/FLS permission message is displayed make sure all the buttons are hidden so the user can't take any action in both single and batch modes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
