### PR TITLE
Feature/gift entry  ptewson ge org telemetry

### DIFF
--- a/src/classes/STG_SettingsService.cls
+++ b/src/classes/STG_SettingsService.cls
@@ -255,6 +255,19 @@ public with sharing class STG_SettingsService {
     }
 
     /*********************************************************************************************************
+    * @description The Data Import Settings object
+    */
+    public Gift_Entry_Settings__c stgGiftEntry {
+        get {
+            if (stgGiftEntry == null) {
+                stgGiftEntry = UTIL_CustomSettingsFacade.getGiftEntrySettings();
+            }
+            return stgGiftEntry;
+        }
+        private set;
+    }
+
+    /*********************************************************************************************************
     * @description Saves all settings objects to the database
     * @return void
     */

--- a/src/classes/UTIL_OrgTelemetry_SVC.cls
+++ b/src/classes/UTIL_OrgTelemetry_SVC.cls
@@ -60,7 +60,8 @@ public without sharing class UTIL_OrgTelemetry_SVC {
         Data_CountPaymentOpps,
         Data_CountErrorLog,
         Data_CountBDIRows,
-        Data_CountBGERows
+        Data_CountBGERows,
+        Data_CountGERowsBatch
     }
 
     /**
@@ -73,6 +74,7 @@ public without sharing class UTIL_OrgTelemetry_SVC {
         IsEnabled_BDICMT,
         IsEnabled_CustomizableRollups,
         IsEnabled_DefaultGAU,
+        IsEnabled_GiftEntry,
         IsEnabled_PaymentAllocations,
         IsEnabled_RecurringDonations2,
         Data_CountErrorLog,
@@ -86,6 +88,7 @@ public without sharing class UTIL_OrgTelemetry_SVC {
         Data_CountRecurringDonationsAll,
         Data_CountBDIRowsLast30Days,
         Data_CountBGERowsLast30Days,
+        Data_CountGERowsLast30DaysBatch,
         Data_MaxNumRelatedOpps,
         DataCount_ONETIME_Use,
         HasUserManagedTDTM,
@@ -211,6 +214,10 @@ public without sharing class UTIL_OrgTelemetry_SVC {
                 handleBGECount();
             }
 
+            when Data_CountGERowsBatch {
+                handleGEBatchCount();
+            }
+
             when Data_CountErrorLog {
                 handleErrorLogCount();
             }
@@ -246,7 +253,9 @@ public without sharing class UTIL_OrgTelemetry_SVC {
         featureManager.setPackageBooleanValue(TelemetryParameterName.IsEnabled_CustomizableRollups.name(),
                 (stgSvc.stgCRLP.Customizable_Rollups_Enabled__c == true));
         featureManager.setPackageBooleanValue(TelemetryParameterName.IsEnabled_BDICMT.name(),
-                (stgSvc.stgDI.Field_Mapping_Method__c == DATA_IMPORT_FIELD_MAPPING ? true : false));
+                (stgSvc.stgDI.Field_Mapping_Method__c == DATA_IMPORT_FIELD_MAPPING ? true : false));   
+        featureManager.setPackageBooleanValue(TelemetryParameterName.IsEnabled_GiftEntry.name(),
+                (stgSvc.stgGiftEntry.Enable_Gift_Entry__c == true));
         featureManager.setPackageBooleanValue(TelemetryParameterName.IsEnabled_RecurringDonations2.name(),
                 (stgSvc.stgRD.IsRecurringDonations2Enabled__c == true));
         featureManager.setPackageBooleanValue(TelemetryParameterName.IsEnabled_PaymentAllocations.name(), 
@@ -419,6 +428,25 @@ public without sharing class UTIL_OrgTelemetry_SVC {
             featuremanager.setPackageIntegerValue(TelemetryParameterName.Data_CountBGERowsLast30Days.name(), bgeCount);
         } catch (Exception ex) {
             featuremanager.setPackageIntegerValue(TelemetryParameterName.Data_CountBGERowsLast30Days.name(), -1);
+        }
+    }
+
+    /**
+     * @description Total number of Gift Entry Data Import records connected to a new GE batch (version = 2)
+     * created in the last 30 days
+     */
+    private void handleGEBatchCount() {
+        try {
+            Integer geBatchDataImportCount = Database.countQuery(
+                'SELECT count() FROM DataImport__c '+
+                'WHERE CreatedDate = Last_n_days:30 '+
+                'AND NPSP_Data_Import_Batch__r.GiftBatch__c = true '+
+                'AND NPSP_Data_Import_Batch__r.Batch_Gift_Entry_Version__c >= 2'
+            );
+            featuremanager.setPackageIntegerValue(TelemetryParameterName.Data_CountGERowsLast30DaysBatch.name(), 
+                geBatchDataImportCount);
+        } catch (Exception ex) {
+            featuremanager.setPackageIntegerValue(TelemetryParameterName.Data_CountGERowsLast30DaysBatch.name(), -1);
         }
     }
 

--- a/src/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/src/classes/UTIL_OrgTelemetry_TEST.cls
@@ -190,6 +190,14 @@ private class UTIL_OrgTelemetry_TEST {
         System.assertNotEquals(
             null,
             featureManagementMock.packageBooleanValuesByName.get(
+                UTIL_OrgTelemetry_SVC.TelemetryParameterName.IsEnabled_GiftEntry.name()
+            ),
+            'setPackageBooleanValue should have been called with the feature IsEnabled_GiftEntry'
+        );        
+
+        System.assertNotEquals(
+            null,
+            featureManagementMock.packageBooleanValuesByName.get(
                 UTIL_OrgTelemetry_SVC.TelemetryParameterName.IsEnabled_RecurringDonations2.name()
             ),
             'setPackageBooleanValue should have been called with the feature IsEnabled_RecurringDonations2'
@@ -541,7 +549,7 @@ private class UTIL_OrgTelemetry_TEST {
         Test.stopTest();
 
         System.assertEquals(
-            NUM_BGE_ROWS_30_DAYS_AGO,
+            NUM_BGE_ROWS_30_DAYS_AGO + NUM_NEWGE_BGE_ROWS_30_DAYS_AGO,
             featureManagementMock.packageIntegerValuesByName.get(
                 UTIL_OrgTelemetry_SVC.TelemetryParameterName.Data_CountBGERowsLast30Days.name()
             ),

--- a/src/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/src/classes/UTIL_OrgTelemetry_TEST.cls
@@ -39,6 +39,12 @@ private class UTIL_OrgTelemetry_TEST {
     private static UTIL_FeatureManagement_TEST.Mock featureManagementMock = new UTIL_FeatureManagement_TEST.Mock();
 
     /**
+     * @description Number of new Gift-Entry BGE related Data Import records created within the last 30 days
+     */
+    private static final Integer NUM_NEWGE_BGE_ROWS_30_DAYS_AGO = 2;
+
+
+    /**
      * @description Number of BGE related Data Import records created within the last 30 days
      */
     private static final Integer NUM_BGE_ROWS_30_DAYS_AGO = 2;
@@ -84,15 +90,20 @@ private class UTIL_OrgTelemetry_TEST {
         insert rd;
 
         DataImportBatch__c diBatch = new DataImportBatch__c(GiftBatch__c = true);
+        DataImportBatch__c newDIBatch = new DataImportBatch__c(GiftBatch__c = true, 
+            Batch_Gift_Entry_Version__c = 2);
 
-        insert diBatch;
+
+        insert new List<DataImportBatch__c> {diBatch, newDIBatch};
 
         List<DataImport__c> bdiRows = buildDataImports(NUM_BDI_ROWS_30_DAYS_AGO, null);
         List<DataImport__c> bgeRows = buildDataImports(NUM_BGE_ROWS_30_DAYS_AGO, diBatch.Id);
+        List<DataImport__c> newBGERows = buildDataImports(NUM_NEWGE_BGE_ROWS_30_DAYS_AGO, newDIBatch.Id);
         List<DataImport__c> bdiRows60DaysAgo = buildDataImports(NUM_DI_ROWS_60_DAYS_AGO, null);
 
         insert bdiRows;
         insert bgeRows;
+        insert newBGERows;
         insert bdiRows60DaysAgo;
 
         Datetime sixtyDaysAgo = Datetime.now().addDays(-60);
@@ -505,7 +516,7 @@ private class UTIL_OrgTelemetry_TEST {
         Test.stopTest();
 
         System.assertEquals(
-            NUM_BDI_ROWS_30_DAYS_AGO + NUM_BGE_ROWS_30_DAYS_AGO,
+            NUM_BDI_ROWS_30_DAYS_AGO + NUM_BGE_ROWS_30_DAYS_AGO + NUM_NEWGE_BGE_ROWS_30_DAYS_AGO,
             featureManagementMock.packageIntegerValuesByName.get(
                 UTIL_OrgTelemetry_SVC.TelemetryParameterName.Data_CountBDIRowsLast30Days.name()
             ),
@@ -535,6 +546,31 @@ private class UTIL_OrgTelemetry_TEST {
                 UTIL_OrgTelemetry_SVC.TelemetryParameterName.Data_CountBGERowsLast30Days.name()
             ),
             'setPackageIntegerValue should have been called with the feature Data_CountBGERowsLast30Days and set correctly'
+        );
+    }
+
+    /**
+     * @description Confirms BGE row counts related to new Gift Entry batches are calculated correctly
+     */
+    @IsTest
+    private static void validateCountOfNewGiftEntryBGERowsTelemetry() {
+        Test.startTest();
+        Integer currQueryCount = Limits.getQueries();
+
+        UTIL_OrgTelemetry_SVC telemetrySvc = new UTIL_OrgTelemetry_SVC();
+        telemetrySvc.featureManager = (UTIL_FeatureManagement) Test.createStub(UTIL_FeatureManagement.class, featureManagementMock);
+
+        telemetrySvc.processTelemetryType(UTIL_OrgTelemetry_SVC.TelemetryBatchCategory.Data_CountGERowsBatch);
+
+        System.assertEquals(currQueryCount+1, Limits.getQueries(), 'There should be one new query executed');
+        Test.stopTest();
+
+        System.assertEquals(
+            NUM_NEWGE_BGE_ROWS_30_DAYS_AGO,
+            featureManagementMock.packageIntegerValuesByName.get(
+                UTIL_OrgTelemetry_SVC.TelemetryParameterName.Data_CountGERowsLast30DaysBatch.name()
+            ),
+            'setPackageIntegerValue should have been called with the feature Data_CountGERowsLast30DaysBatch and set correctly'
         );
     }
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -3259,6 +3259,7 @@
         <members>IsEnabled_BDICMT</members>
         <members>IsEnabled_CustomizableRollups</members>
         <members>IsEnabled_DefaultGAU</members>
+        <members>IsEnabled_GiftEntry</members>
         <members>IsEnabled_HouseholdAcctModel</members>
         <members>IsEnabled_PaymentAllocations</members>
         <members>IsEnabled_RecurringDonations2</members>
@@ -3270,6 +3271,7 @@
         <members>DataCount_ONETIME_Use</members>
         <members>Data_CountBDIRowsLast30Days</members>
         <members>Data_CountBGERowsLast30Days</members>
+        <members>Data_CountGERowsLast30DaysBatch</members>
         <members>Data_CountErrorLog</members>
         <members>Data_CountOppsWithMultiplePayments</members>
         <members>Data_CountRdOppsAll</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -3271,8 +3271,8 @@
         <members>DataCount_ONETIME_Use</members>
         <members>Data_CountBDIRowsLast30Days</members>
         <members>Data_CountBGERowsLast30Days</members>
-        <members>Data_CountGERowsLast30DaysBatch</members>
         <members>Data_CountErrorLog</members>
+        <members>Data_CountGERowsLast30DaysBatch</members>
         <members>Data_CountOppsWithMultiplePayments</members>
         <members>Data_CountRdOppsAll</members>
         <members>Data_CountRdOppsOpenEnded</members>


### PR DESCRIPTION
# Critical Changes

# Changes

- Adds two new telemetry parameters
- The first telemetry parameter, Data_CountBGERowsLast30Days, is a count of DI rows attached to new GE Batches ('Gift Batch' is true and version >= 2)
- The second telemetry parameter, IsEnabled_GiftEntry, is a boolean indicating that gift entry is enabled in custom settings

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
