### PR TITLE
Remove built-in header from Allocations Widget

### DIFF
--- a/src/lwc/geFormSection/geFormSection.html
+++ b/src/lwc/geFormSection/geFormSection.html
@@ -24,7 +24,6 @@
                 </template>
                 <template if:true={element.componentName}>
                     <lightning-layout-item key={element.id}
-                                           padding='around-small'
                                            size='12'
                                            medium-device-size='12'>
                         <c-ge-form-widget element={element} widget-data={widgetData}></c-ge-form-widget>

--- a/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.html
+++ b/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.html
@@ -1,37 +1,35 @@
 <template>
-    <c-util-expandable-section label={element.label} is-collapsed={collapsed} id="gauExpandableSection">
-        <lightning-layout if:true={hasAlert}>
-            <lightning-layout-item size="12">
-                <div class={alertClass} role="alert">
-                    <span class="slds-assistive-text">Allocation error</span>
-                    <span class="slds-icon_container slds-icon-utility-error slds-m-right_x-small">
-                        <lightning-icon icon-name={alertIcon} variant="inverse" size="x-small"></lightning-icon>
-                    </span>
-                    <h2>{alertBanner.message}</h2>
-                </div>
-            </lightning-layout-item>
-        </lightning-layout>
-        <template for:each={rowList} for:item='row' for:index='index'>
-            <c-ge-form-widget-row-allocation
-                    data-defaultgau={row.isDefaultGAU}
-                    field-list={fieldList}
-                    key={row.element.key}
-                    row-index={index}
-                    row-record={row.record}
-                    total-amount={totalAmount}
-                    remaining-amount={remainingAmount}
-                    disabled={row.element.disabled}
-                    onremove={handleRemove}
-                    onvaluechange={handleChange}>
-            </c-ge-form-widget-row-allocation>
-        </template>
-        <lightning-layout class={footerClass}>
-            <lightning-layout-item size='3'>
-                <lightning-button label="Add New Allocation" onclick={handleAddRow}></lightning-button>
-            </lightning-layout-item>
-            <lightning-layout-item size='3' if:true={showRemainingAmount}>
-                $<span>{remainingAmount}</span> remaining
-            </lightning-layout-item>
-        </lightning-layout>
-    </c-util-expandable-section>
+    <lightning-layout if:true={hasAlert}>
+        <lightning-layout-item size="12">
+            <div class={alertClass} role="alert">
+                <span class="slds-assistive-text">Allocation error</span>
+                <span class="slds-icon_container slds-icon-utility-error slds-m-right_x-small">
+                    <lightning-icon icon-name={alertIcon} variant="inverse" size="x-small"></lightning-icon>
+                </span>
+                <h2>{alertBanner.message}</h2>
+            </div>
+        </lightning-layout-item>
+    </lightning-layout>
+    <template for:each={rowList} for:item='row' for:index='index'>
+        <c-ge-form-widget-row-allocation
+                data-defaultgau={row.isDefaultGAU}
+                field-list={fieldList}
+                key={row.element.key}
+                row-index={index}
+                row-record={row.record}
+                total-amount={totalAmount}
+                remaining-amount={remainingAmount}
+                disabled={row.element.disabled}
+                onremove={handleRemove}
+                onvaluechange={handleChange}>
+        </c-ge-form-widget-row-allocation>
+    </template>
+    <lightning-layout class={footerClass}>
+        <lightning-layout-item size='3'>
+            <lightning-button label="Add New Allocation" onclick={handleAddRow}></lightning-button>
+        </lightning-layout-item>
+        <lightning-layout-item size='3' if:true={showRemainingAmount}>
+            $<span>{remainingAmount}</span> remaining
+        </lightning-layout-item>
+    </lightning-layout>
 </template>

--- a/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
+++ b/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
@@ -23,7 +23,6 @@ export default class GeFormWidgetAllocation extends LightningElement {
     @track fieldList = [];
     @track allocationSettings;
     @track _totalAmount;
-    @track collapsed = false;
 
     CUSTOM_LABELS = GeLabelService.CUSTOM_LABELS;
 


### PR DESCRIPTION
# Critical Changes

# Changes
- Removed built-in header from Allocations Widget to match designs
# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
