### PR TITLE
Allocations: Remaining Amount formatting/math

### DIFF
--- a/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.html
+++ b/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.html
@@ -30,7 +30,7 @@
                 <lightning-button label="Add New Allocation" onclick={handleAddRow}></lightning-button>
             </lightning-layout-item>
             <lightning-layout-item size='3' if:true={showRemainingAmount}>
-                $<span>{remainingAmount}</span> remaining
+                <lightning-formatted-number value={remainingAmount} format-style='currency'></lightning-formatted-number>
             </lightning-layout-item>
         </lightning-layout>
     </c-util-expandable-section>

--- a/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
+++ b/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
@@ -326,7 +326,9 @@ export default class GeFormWidgetAllocation extends LightningElement {
      */
     get remainingAmount() {
         if(isNumeric(this.totalAmount) && isNumeric(this.allocatedAmount)) {
-            return this.totalAmount - this.allocatedAmount;
+            const remainingCents = Math.round(this.totalAmount * 100) - Math.round(this.allocatedAmount * 100);
+            // avoid floating point errors by subtracting whole numbers
+            return (remainingCents / 100)
         }
         return 0;
     }


### PR DESCRIPTION
# Critical Changes

# Changes
- Fix floating point math problems with calculating the remaining allocation amount
- Use lightning-formatted-number for outputting currency values
# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
