### PR TITLE
Adjust old BGE telemetry to exclude new GE rows

### DIFF
--- a/src/classes/UTIL_OrgTelemetry_SVC.cls
+++ b/src/classes/UTIL_OrgTelemetry_SVC.cls
@@ -424,7 +424,12 @@ public without sharing class UTIL_OrgTelemetry_SVC {
      */
     private void handleBGECount() {
         try {
-            Integer bgeCount = Database.countQuery('SELECT count() FROM DataImport__c WHERE CreatedDate = Last_n_days:30 AND NPSP_Data_Import_Batch__r.GiftBatch__c = true');
+            Integer bgeCount = Database.countQuery(
+                'SELECT count() FROM DataImport__c '+
+                'WHERE CreatedDate = Last_n_days:30 '+
+                'AND NPSP_Data_Import_Batch__r.GiftBatch__c = true '+
+                'AND (NPSP_Data_Import_Batch__r.Batch_Gift_Entry_Version__c = null OR '+
+                    'NPSP_Data_Import_Batch__r.Batch_Gift_Entry_Version__c <= 1)');
             featuremanager.setPackageIntegerValue(TelemetryParameterName.Data_CountBGERowsLast30Days.name(), bgeCount);
         } catch (Exception ex) {
             featuremanager.setPackageIntegerValue(TelemetryParameterName.Data_CountBGERowsLast30Days.name(), -1);

--- a/src/classes/UTIL_OrgTelemetry_TEST.cls
+++ b/src/classes/UTIL_OrgTelemetry_TEST.cls
@@ -549,7 +549,7 @@ private class UTIL_OrgTelemetry_TEST {
         Test.stopTest();
 
         System.assertEquals(
-            NUM_BGE_ROWS_30_DAYS_AGO + NUM_NEWGE_BGE_ROWS_30_DAYS_AGO,
+            NUM_BGE_ROWS_30_DAYS_AGO,
             featureManagementMock.packageIntegerValuesByName.get(
                 UTIL_OrgTelemetry_SVC.TelemetryParameterName.Data_CountBGERowsLast30Days.name()
             ),


### PR DESCRIPTION
# Critical Changes

# Changes

- Updates the criteria for old BGE telemetry (which we have been using to determine the usage of the soon-to-be legacy BGE product) to restrict new GE records and keep the metric consistent

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
