### PR TITLE
Load existing Data Imports into GAU Widget

### DIFF
--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -88,6 +88,8 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
 
         } else if (batch.Batch_Gift_Entry_Version__c >= 2.0) {
 
+            fieldApiNames.add(DataImport__c.Additional_Object_JSON__c.getDescribe().getName());
+
             for (String field : getCoreDataImportFields(includeRelationshipFields)) {
                 fieldApiNames.add(field.toLowerCase());
             }

--- a/src/lwc/geFormField/geFormField.js
+++ b/src/lwc/geFormField/geFormField.js
@@ -340,6 +340,11 @@ export default class GeFormField extends LightningElement {
             this.loadLookUp(data, value);
         }
 
+        if(this.sourceFieldAPIName === DI_DONATION_AMOUNT.fieldApiName) {
+            // fire event for reactive widget component containing the Data Import field API name and Value
+            // currently only used for the Donation Amount.
+            fireEvent(null, 'widgetData', { donationAmount: this.value });
+        }
     }
 
     /**

--- a/src/lwc/geFormSection/geFormSection.js
+++ b/src/lwc/geFormSection/geFormSection.js
@@ -113,9 +113,14 @@ export default class GeFormSection extends LightningElement {
     @api
     load(data){
         const fields = this.template.querySelectorAll('c-ge-form-field');
+        const widgetList = this.template.querySelectorAll('c-ge-form-widget');
 
         fields.forEach(field => {
             field.load(data);
+        });
+
+        widgetList.forEach(widget => {
+            widget.load(data);
         });
     }
 

--- a/src/lwc/geFormWidget/geFormWidget.js
+++ b/src/lwc/geFormWidget/geFormWidget.js
@@ -15,6 +15,11 @@ export default class GeFormWidget extends LightningElement {
     }
 
     @api
+    load(data) {
+        this.widgetComponent.load(data);
+    }
+
+    @api
     get widgetAndValues() {
         let widgetAndValues = {};
         const thisWidget = this.widgetComponent;

--- a/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.js
+++ b/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.js
@@ -1,5 +1,5 @@
-import {LightningElement, api, track} from 'lwc';
-import {fireEvent, registerListener} from 'c/pubsubNoPageRef';
+import {LightningElement, api} from 'lwc';
+import {fireEvent} from 'c/pubsubNoPageRef';
 import GeLabelService from 'c/geLabelService';
 import {isEmpty, isNotEmpty, isNumeric} from 'c/utilCommon';
 import ALLOCATION_OBJECT from '@salesforce/schema/Allocation__c';
@@ -211,21 +211,17 @@ export default class GeFormWidgetRowAllocation extends LightningElement {
      * If the whole row is disabled (default GAU) then all fields in the row should be disabled
      */
     get mergedFieldList() {
-        if(this.disabled) {
-            return this.fieldList.map(f => {
-                const { element } = f;
-                return {
-                    ...f,
-                    element: {
-                        ...element,
-                        disabled: true,
-                        defaultValue: this.getDefaultForField(f.mappedField) // only needed for default GAU for now
-                    }
-                };
-            });
-        }
-
-        return this.fieldList;
+        return this.fieldList.map(field => {
+            const { element } = field;
+            return {
+                ...field,
+                element: {
+                    ...element,
+                    disabled: this.disabled,
+                    defaultValue: this.getDefaultForField(field.mappedField) 
+                }
+            };
+        });
     }
 
 }


### PR DESCRIPTION
# Critical Changes

# Changes
When a data import row is opened from the batch gift entry table, GAU allocations will also be loaded in addition to the rest of the form.

# Issues Closed
[W-038511](https://foundation.lightning.force.com/lightning/r/agf__ADM_Work__c/a2x1E000001HqUjQAK/view)

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
