### PR TITLE
Gift Entry: hide modal when missing field permissions

### DIFF
--- a/src/lwc/geFormRenderer/geFormRenderer.html
+++ b/src/lwc/geFormRenderer/geFormRenderer.html
@@ -27,10 +27,10 @@
                 <template if:true={hasPendingDonations}>
                     <lightning-layout-item size='12'>
                         <c-ge-review-donations ontogglemodal={toggleModal}
-                                            onchangeselecteddonation={handleChangeSelectedDonation}
-                                            opportunities={opportunities}
-                                            donor-id={selectedDonorId}
-                                            selected-donation={selectedDonation}>
+                                               onchangeselecteddonation={handleChangeSelectedDonation}
+                                               opportunities={opportunities}
+                                               donor-id={selectedDonorId}
+                                               selected-donation={selectedDonation}>
                         </c-ge-review-donations>
                     </lightning-layout-item>
                 </template>

--- a/src/lwc/geFormRenderer/geFormRenderer.html
+++ b/src/lwc/geFormRenderer/geFormRenderer.html
@@ -23,15 +23,17 @@
                 </lightning-layout-item>
             </template>
 
-            <template if:true={hasPendingDonations}>
-                <lightning-layout-item size='12'>
-                    <c-ge-review-donations ontogglemodal={toggleModal}
-                                           onchangeselecteddonation={handleChangeSelectedDonation}
-                                           opportunities={opportunities}
-                                           donor-id={selectedDonorId}
-                                           selected-donation={selectedDonation}>
-                    </c-ge-review-donations>
-                </lightning-layout-item>
+            <template if:false={isPermissionError}>
+                <template if:true={hasPendingDonations}>
+                    <lightning-layout-item size='12'>
+                        <c-ge-review-donations ontogglemodal={toggleModal}
+                                            onchangeselecteddonation={handleChangeSelectedDonation}
+                                            opportunities={opportunities}
+                                            donor-id={selectedDonorId}
+                                            selected-donation={selectedDonation}>
+                        </c-ge-review-donations>
+                    </lightning-layout-item>
+                </template>
             </template>
 
             <lightning-layout-item size='12'


### PR DESCRIPTION
# Critical Changes

# Changes
* if a user doesn't have permissions on a target field or a source field do not display the link to the matching modal

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
