### PR TITLE
Gift Entry:  hide matching modal link if the user missing permissions

### DIFF
--- a/src/lwc/geFormRenderer/geFormRenderer.html
+++ b/src/lwc/geFormRenderer/geFormRenderer.html
@@ -23,15 +23,17 @@
                 </lightning-layout-item>
             </template>
 
-            <template if:true={hasPendingDonations}>
-                <lightning-layout-item size='12'>
-                    <c-ge-review-donations ontogglemodal={toggleModal}
-                                           onchangeselecteddonation={handleChangeSelectedDonation}
-                                           opportunities={opportunities}
-                                           donor-id={selectedDonorId}
-                                           selected-donation={selectedDonation}>
-                    </c-ge-review-donations>
-                </lightning-layout-item>
+            <template if:false={isPermissionError}>
+                <template if:true={hasPendingDonations}>
+                    <lightning-layout-item size='12'>
+                        <c-ge-review-donations ontogglemodal={toggleModal}
+                                               onchangeselecteddonation={handleChangeSelectedDonation}
+                                               opportunities={opportunities}
+                                               donor-id={selectedDonorId}
+                                               selected-donation={selectedDonation}>
+                        </c-ge-review-donations>
+                    </lightning-layout-item>
+                </template>
             </template>
 
             <lightning-layout-item size='12'


### PR DESCRIPTION
# Critical Changes

# Changes
* hide the ability to open the matching modal if the user is missing permissions to a target or source field

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
