### PR TITLE
Load Existing Data Import Rows in GAU Widget

### DIFF
--- a/src/classes/BGE_BatchGiftEntry_UTIL.cls
+++ b/src/classes/BGE_BatchGiftEntry_UTIL.cls
@@ -88,6 +88,8 @@ public with sharing class BGE_BatchGiftEntry_UTIL {
 
         } else if (batch.Batch_Gift_Entry_Version__c >= 2.0) {
 
+            fieldApiNames.add(DataImport__c.Additional_Object_JSON__c.getDescribe().getName());
+
             for (String field : getCoreDataImportFields(includeRelationshipFields)) {
                 fieldApiNames.add(field.toLowerCase());
             }

--- a/src/lwc/geFormField/geFormField.html
+++ b/src/lwc/geFormField/geFormField.html
@@ -5,10 +5,10 @@
             type={inputType}
             formatter={formatter}
             step={granularity}
-            required={element.required}
+            required={required}
             onchange={handleValueChange} 
             label={fieldLabel}
-            disabled={element.disabled}>
+            disabled={disabled}>
         </lightning-input>
     </template>
     <template if:true={isLookup}>
@@ -17,16 +17,16 @@
                                 object-api-name={objectApiName}
                                 onchange={handleValueChange}
                                 default-value={element.defaultValue}
-                                required={element.required}
+                                required={required}
                                 id={element.id}
                                 object-describe-info={objectDescribeInfo}
                                 label={fieldLabel}
-                                disabled={element.disabled}>
+                                disabled={disabled}>
         </c-ge-form-field-lookup>
     </template>
     <template if:true={isRichText}>
         <label class="slds-form-element__label">
-            <abbr class="slds-required" title="required" if:true={element.required}>*</abbr>
+            <abbr class="slds-required" title="required" if:true={required}>*</abbr>
             {fieldLabel}
         </label>
         <lightning-input-rich-text data-id='inputComponent'
@@ -42,7 +42,7 @@
     <template if:true={isPicklist}>
         <c-ge-form-field-picklist data-id='inputComponent'
             value={value}
-            required={element.required}
+            required={required}
             field-name={fieldApiName}
             object-name={objectApiName}
             onchange={handleValueChange}
@@ -53,7 +53,7 @@
     <template if:true={isTextArea}>
         <lightning-textarea data-id='inputComponent'
             value={value}
-            required={element.required}
+            required={required}
             onchange={handleValueChange}
             label={fieldLabel}>
         </lightning-textarea>

--- a/src/lwc/geFormField/geFormField.js
+++ b/src/lwc/geFormField/geFormField.js
@@ -23,6 +23,7 @@ export default class GeFormField extends LightningElement {
     @track picklistValues = [];
     @track objectDescribeInfo;
     @track richTextValid = true;
+    @track _disabled = false;
     @api element;
     @api targetFieldName;
     _defaultValue = null;
@@ -87,17 +88,6 @@ export default class GeFormField extends LightningElement {
     }
 
     connectedCallback() {
-        if(isNotEmpty(this.targetFieldName)) {
-            // Construct an element object using the field name and mapping info
-            const required = this.fieldInfo.Is_Required || (this.element && this.element.required);
-            this.element = {
-                ...this.element,
-                label: this.fieldInfo.Target_Field_Label,
-                required,
-                dataImportFieldMappingDevNames: [this.targetFieldName]
-            };
-        }
-
         const { defaultValue, recordValue } = this.element;
 
         if(recordValue) {
@@ -174,6 +164,16 @@ export default class GeFormField extends LightningElement {
     }
 
     @api
+    disable() {
+        this._disabled = true;
+    }
+
+    @api
+    enable() {
+        this._disabled = false;
+    }
+
+    @api
     get fieldAndValue() {
         let fieldAndValue = {};
 
@@ -198,6 +198,14 @@ export default class GeFormField extends LightningElement {
 
     get formatter() {
         return GeFormService.getNumberFormatterByDescribeType(this.fieldType);
+    }
+
+    get required() {
+        return (this.fieldInfo && this.fieldInfo.Is_Required) || (this.element && this.element.required);
+    }
+
+    get disabled() {
+        return this._disabled || (this.element && this.element.disabled);
     }
 
     get granularity() {
@@ -340,6 +348,11 @@ export default class GeFormField extends LightningElement {
             this.loadLookUp(data, value);
         }
 
+        if(this.sourceFieldAPIName === DI_DONATION_AMOUNT.fieldApiName) {
+            // fire event for reactive widget component containing the Data Import field API name and Value
+            // currently only used for the Donation Amount.
+            fireEvent(null, 'widgetData', { donationAmount: this.value });
+        }
     }
 
     /**

--- a/src/lwc/geFormSection/geFormSection.js
+++ b/src/lwc/geFormSection/geFormSection.js
@@ -113,9 +113,14 @@ export default class GeFormSection extends LightningElement {
     @api
     load(data){
         const fields = this.template.querySelectorAll('c-ge-form-field');
+        const widgetList = this.template.querySelectorAll('c-ge-form-widget');
 
         fields.forEach(field => {
             field.load(data);
+        });
+
+        widgetList.forEach(widget => {
+            widget.load(data);
         });
     }
 

--- a/src/lwc/geFormWidget/geFormWidget.js
+++ b/src/lwc/geFormWidget/geFormWidget.js
@@ -15,6 +15,11 @@ export default class GeFormWidget extends LightningElement {
     }
 
     @api
+    load(data) {
+        this.widgetComponent.load(data);
+    }
+
+    @api
     get widgetAndValues() {
         let widgetAndValues = {};
         const thisWidget = this.widgetComponent;

--- a/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.js
+++ b/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.js
@@ -1,5 +1,5 @@
-import {LightningElement, api, track} from 'lwc';
-import {fireEvent, registerListener} from 'c/pubsubNoPageRef';
+import {LightningElement, api} from 'lwc';
+import {fireEvent} from 'c/pubsubNoPageRef';
 import GeLabelService from 'c/geLabelService';
 import {isEmpty, isNotEmpty, isNumeric} from 'c/utilCommon';
 import ALLOCATION_OBJECT from '@salesforce/schema/Allocation__c';
@@ -166,12 +166,12 @@ export default class GeFormWidgetRowAllocation extends LightningElement {
 
     disableField(fieldName) {
         const field = this.getFieldByName(fieldName);
-        field.element =  {...field.element, disabled: true};
+        field.disable();
     }
 
     enableField(fieldName) {
         const field = this.getFieldByName(fieldName);
-        field.element =  {...field.element, disabled: false};
+        field.enable();
     }
 
     remove() {
@@ -211,21 +211,18 @@ export default class GeFormWidgetRowAllocation extends LightningElement {
      * If the whole row is disabled (default GAU) then all fields in the row should be disabled
      */
     get mergedFieldList() {
-        if(this.disabled) {
-            return this.fieldList.map(f => {
-                const { element } = f;
-                return {
-                    ...f,
-                    element: {
-                        ...element,
-                        disabled: true,
-                        defaultValue: this.getDefaultForField(f.mappedField) // only needed for default GAU for now
-                    }
-                };
-            });
-        }
-
-        return this.fieldList;
+        return this.fieldList.map(field => {
+            const { element } = field;
+            return {
+                ...field,
+                element: {
+                    ...element,
+                    disabled: this.disabled ? this.disabled : element.disabled,
+                    defaultValue: this.getDefaultForField(field.mappedField),
+                    dataImportFieldMappingDevNames: [field.mappedField]
+                }
+            };
+        });
     }
 
 }


### PR DESCRIPTION
# Critical Changes

# Changes
When a data import row is opened from the batch gift entry table, GAU allocations will also be loaded in addition to the rest of the form.

# Issues Closed
W-038511

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
