### PR TITLE
initialize default Gift Entry settings in post-install script

### DIFF
--- a/scripts/configure_npsp_default_settings.cls
+++ b/scripts/configure_npsp_default_settings.cls
@@ -21,6 +21,7 @@ public static void initializeNPSPSettings() {
     %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgBDESettings();
     %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgAllocationsSettings();
     %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgDataImportSettings();
+    %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgGiftEntrySettings();    
     %%%NAMESPACE%%%UTIL_CustomSettingsFacade.getOrgCustomizableRollupSettings();
 
     Id rtId = [SELECT Id FROM RecordType WHERE SObjectType = 'Opportunity' AND DeveloperName = 'Membership' LIMIT 1].Id;

--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -189,6 +189,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
         UTIL_CustomSettingsFacade.getOrgBDESettings();
         UTIL_CustomSettingsFacade.getOrgAllocationsSettings();
         UTIL_CustomSettingsFacade.getOrgDataImportSettings();
+        UTIL_CustomSettingsFacade.getOrgGiftEntrySettings();
 
         UTIL_Debug.debug('****NPSP-to-Cumulus Map: ' + JSON.serializePretty(npspToCumulusMap));
 


### PR DESCRIPTION
# Critical Changes

Includes initial creation of gift-entry settings in the post-install script for NPSP. Without this update, Org Telemetry will fail on a mixed DML error and disrupt our ability to collect telemetry.
# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
