### PR TITLE
RD2: Persist Account on Opportunity when RD is updated

### DIFF
--- a/src/classes/RD2_OpportunityService.cls
+++ b/src/classes/RD2_OpportunityService.cls
@@ -305,8 +305,11 @@ public with sharing class RD2_OpportunityService {
 
         Boolean isChanged = false;
 
-        if (rd.npe03__Organization__c != null && opp.AccountId != rd.npe03__Organization__c) {
-            opp.AccountId = rd.npe03__Organization__c;
+        if (opp.AccountId != rd.npe03__Organization__c) {
+            opp.AccountId = rd.npe03__Organization__c == null
+                ? rd.npe03__Contact__c != null ? rd.npe03__Contact__r.AccountId : null
+                : rd.npe03__Organization__c;
+
             isChanged = true;
         }
 

--- a/src/classes/RD2_OpportunityService.cls
+++ b/src/classes/RD2_OpportunityService.cls
@@ -213,7 +213,7 @@ public with sharing class RD2_OpportunityService {
         for (npe03__Recurring_Donation__c rd : rds) {
             RD2_OpportunityMatcher matcher = new RD2_OpportunityMatcher(currentDate)
                 .includeCurrentOrOpen(rd.npe03__Donations__r);
-            
+
             matcher.match(scheduleService.getVisualizedInstallments(
                 currentDate, matcher.size(), rd.RecurringDonationSchedules__r
             ));
@@ -251,8 +251,8 @@ public with sharing class RD2_OpportunityService {
     */
     private Boolean syncOppWithRecurringDonation(Opportunity opp, npe03__Recurring_Donation__c rd) {
         Boolean isChanged = syncOppDonorInfo(opp, rd);
-        
-        //ensure the Opportunity and RD Currency sync is done first 
+
+        //ensure the Opportunity and RD Currency sync is done first
         //so the Opp is updated in the case there is a discrepancy
         return syncOppCurrency(opp, rd) || isChanged;
     }
@@ -305,7 +305,7 @@ public with sharing class RD2_OpportunityService {
 
         Boolean isChanged = false;
 
-        if (opp.AccountId != rd.npe03__Organization__c) {
+        if (rd.npe03__Organization__c != null && opp.AccountId != rd.npe03__Organization__c) {
             opp.AccountId = rd.npe03__Organization__c;
             isChanged = true;
         }
@@ -314,12 +314,12 @@ public with sharing class RD2_OpportunityService {
             opp.Primary_Contact__c = rd.npe03__Contact__c;
             isChanged = true;
         }
-        
+
         return isChanged;
     }
 
     /***
-    * @description Updates Opportunity CurrencyIsoCode if it differs from the related Recurring Donation 
+    * @description Updates Opportunity CurrencyIsoCode if it differs from the related Recurring Donation
     * @param opp Opportunity
     * @param rd Recurring Donation
     * @return Boolean Indicates if the currency on the Opportunity has been changed
@@ -406,7 +406,7 @@ public with sharing class RD2_OpportunityService {
 
             dbService.updateRecords(oppsToUpdate);
         }
-        
+
         return this;
     }
 }

--- a/src/classes/RD2_OpportunityService_TEST.cls
+++ b/src/classes/RD2_OpportunityService_TEST.cls
@@ -925,49 +925,50 @@ private with sharing class RD2_OpportunityService_TEST {
     }
 
     /***
-    * @description Verifies if Account is not getting removed in opportunity
-    * when recurring donation record with only contact is updated.
+    * @description Verifies the Account on Opportunity is not nulled
+    * when Recurring Donation having Contact specified only is updated
     */
     @isTest
-    private static void shouldNotRemoveAccountInOppWhenRDWithNoAccountIsModified() {
+    private static void shouldNotRemoveAccountOnOppWhenRDWithoutAccountIsModified() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         setUpConfiguration();
-
 
         npe03__Recurring_Donation__c rd = createRecurringDonation();
 
-        //create opp from rd with contact only
-        Opportunity opp = getOpportunityBuilderWithNoAccount(rd)
+        //create a related Opp where Contact is specified only
+        Opportunity opp = new TEST_OpportunityBuilder()
+            .withContact(rd.npe03__Contact__c)
+            .withRecurringDonation(rd.Id)
+            .withAmount(rd.npe03__Amount__c)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
             .build();
         insert opp;
 
-
-        //Verify if accountid is populated in opp when only contact is provided in RD
         List<Opportunity> opps = oppGateway.getRecords(rd);
-        System.assertEquals(1, opps.size(), 'One Installment Opp should be created on RD insert: ' + opps);
-        System.assert(opps[0].AccountId != null);
+        System.assertNotEquals(null, opps[0].AccountId,
+            'Opp Account should be populated on the Opp insert');
 
-        //update rd amount
         Test.startTest();
         rd.npe03__Amount__c = RD_NEW_AMOUNT;
         update rd;
         Test.stopTest();
 
-        //Verify if accountid is not nulled out when rd record is modified
-        List<Opportunity> oppUpdated = oppGateway.getRecords(rd);
-        System.assertEquals(RD_NEW_AMOUNT, oppUpdated[0].Amount, 'Amount should be updated');
-        System.assert(oppUpdated[0].AccountId != null);
+        rd = rdGateway.getRecord(rd.Id);
+        opps = oppGateway.getRecords(rd);
 
+        System.assertEquals(1, opps.size(), 'One Opp should exist: ' + opps);
+        System.assertEquals(RD_NEW_AMOUNT, opps[0].Amount, 'Opp Amount should be updated');
+        System.assertEquals(getContact().AccountId, opps[0].AccountId,
+            'Opp Account should be the same as the Contact household Account');
     }
 
     /***
-    * @description Verifies if Account is not getting removed in opportunity
-    * when recurring donation record with account is modified.
+    * @description Verifies the Account on Opportunity is not nulled
+    * when Recurring Donation having Organization specified is updated
     */
-    private static void shouldNotRemoveAccountInOppWhenRDWithAccountIsModified() {
+    private static void shouldNotRemoveAccountOnOppWhenRDWithAccountIsModified() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         setUpConfiguration();
@@ -977,66 +978,65 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation(acc);
 
-        //create opp from rd with account
         Opportunity opp = getOpportunityBuilder(rd)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
             .build();
         insert opp;
 
-        //update rd amount
         Test.startTest();
         rd.npe03__Amount__c = RD_NEW_AMOUNT;
         update rd;
         Test.stopTest();
 
-        //Verify if accountid is not changed or nulled out when rd record is modified
-        List<Opportunity> oppUpdated = oppGateway.getRecords(rd);
-        npe03__Recurring_Donation__c recurDonation = rdGateway.getRecord(rd.id);
+        rd = rdGateway.getRecord(rd.Id);
+        List<Opportunity> opps = oppGateway.getRecords(rd);
 
-        System.assertEquals(RD_NEW_AMOUNT, oppUpdated[0].Amount, 'Amount should be updated');
-        System.assert(oppUpdated[0].AccountId != null);
-        System.assertEquals(recurDonation.npe03__Organization__c, oppUpdated[0].AccountId);
+        System.assertEquals(1, opps.size(), 'One Opp should exist: ' + opps);
+        System.assertEquals(RD_NEW_AMOUNT, opps[0].Amount, 'Opp Amount should be updated');
+
+        System.assertNotEquals(null, opps[0].AccountId,
+            'Opp Account should be specified when RD is updated');
+        System.assertEquals(rd.npe03__Organization__c, opps[0].AccountId,
+            'Opp Account should be the same as the RD Account');
     }
 
     /***
-    * @description Verifies if Account is getting updated in opportunity
-    * when recurring donation's account is modified to another account
+    * @description Verifies the Account on Opportunity is matching the
+    * Account on the Recurring Donation when the RD Account is changed
     */
-    private static void shouldUpdateAccountInOppWhenRDAccountIsModified() {
+    private static void shouldUpdateAccountOnOppWhenRDAccountIsChanged() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         setUpConfiguration();
 
-        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
-        insert acc;
+        List<Account> organizations = new List<Account>{
+            UTIL_UnitTestData_TEST.buildOrganizationAccount(),
+            UTIL_UnitTestData_TEST.buildOrganizationAccount()
+        };
+        insert organizations;
 
-        Account accAnother = UTIL_UnitTestData_TEST.buildOrganizationAccount();
-        insert accAnother;
+        npe03__Recurring_Donation__c rd = createRecurringDonation(organizations[0]);
 
-        npe03__Recurring_Donation__c rd = createRecurringDonation(acc);
-
-        //create opp from rd with account
         Opportunity opp = getOpportunityBuilder(rd)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
             .build();
         insert opp;
 
-        //update rd to different account
         Test.startTest();
-        rd.npe03__Organization__c = accAnother.Id;
+        rd.npe03__Organization__c = organizations[1].Id;
         update rd;
         Test.stopTest();
 
-        //Verify if accountid is changed in opportunity when rd's account is modified
-        List<Opportunity> oppUpdated = oppGateway.getRecords(rd);
-        npe03__Recurring_Donation__c recurDonation = rdGateway.getRecord(rd.id);
+        rd = rdGateway.getRecord(rd.Id);
+        List<Opportunity> opps = oppGateway.getRecords(rd);
 
-        System.assert(oppUpdated[0].AccountId != null);
-        System.assertEquals(recurDonation.npe03__Organization__c, accAnother.id);
-        System.assertEquals(recurDonation.npe03__Organization__c, oppUpdated[0].AccountId);
-
+        System.assertEquals(1, opps.size(), 'One Opp should exist: ' + opps);
+        System.assertEquals(rd.npe03__Organization__c, organizations[1].Id,
+            'RD Account should be updated to the new organization');
+        System.assertEquals(rd.npe03__Organization__c, opps[0].AccountId,
+            'Opp Account should be the same as the RD Account');
     }
 
     // Helper Methods
@@ -1193,19 +1193,6 @@ private with sharing class RD2_OpportunityService_TEST {
             .withContact(rd.npe03__Contact__c)
             .withRecurringDonation(rd.Id)
             .withAccount(rd.npe03__Organization__c)
-            .withAmount(rd.npe03__Amount__c)
-            .withInstallmentNumber(1);
-    }
-
-     /**
-     * @description Instantiate an Opportunity builder for the specified Recurring Donation with no account
-     * @param rd Recurring Donation
-     * @return TEST_OpportunityBuilder New Opportunity builder
-     */
-    private static TEST_OpportunityBuilder getOpportunityBuilderWithNoAccount(npe03__Recurring_Donation__c rd) {
-        return new TEST_OpportunityBuilder()
-            .withContact(rd.npe03__Contact__c)
-            .withRecurringDonation(rd.Id)
             .withAmount(rd.npe03__Amount__c)
             .withInstallmentNumber(1);
     }

--- a/src/classes/RD2_OpportunityService_TEST.cls
+++ b/src/classes/RD2_OpportunityService_TEST.cls
@@ -924,6 +924,120 @@ private with sharing class RD2_OpportunityService_TEST {
         assertPaymentIsMatchingOpp(oppById);
     }
 
+    /***
+    * @description Verifies if Account is not getting removed in opportunity
+    * when recurring donation record with only contact is updated.
+    */
+    @isTest
+    private static void shouldNotRemoveAccountInOppWhenRDWithNoAccountIsModified() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        setUpConfiguration();
+
+
+        npe03__Recurring_Donation__c rd = createRecurringDonation();
+
+        //create opp from rd with contact only
+        Opportunity opp = getOpportunityBuilderWithNoAccount(rd)
+            .withCloseDate(CLOSE_DATE)
+            .withOpenStage()
+            .build();
+        insert opp;
+
+
+        //Verify if accountid is populated in opp when only contact is provided in RD
+        List<Opportunity> opps = oppGateway.getRecords(rd);
+        System.assertEquals(1, opps.size(), 'One Installment Opp should be created on RD insert: ' + opps);
+        System.assert(opps[0].AccountId != null);
+
+        //update rd amount
+        Test.startTest();
+        rd.npe03__Amount__c = RD_NEW_AMOUNT;
+        update rd;
+        Test.stopTest();
+
+        //Verify if accountid is not nulled out when rd record is modified
+        List<Opportunity> oppUpdated = oppGateway.getRecords(rd);
+        System.assertEquals(RD_NEW_AMOUNT, oppUpdated[0].Amount, 'Amount should be updated');
+        System.assert(oppUpdated[0].AccountId != null);
+
+    }
+
+    /***
+    * @description Verifies if Account is not getting removed in opportunity
+    * when recurring donation record with account is modified.
+    */
+    private static void shouldNotRemoveAccountInOppWhenRDWithAccountIsModified() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        setUpConfiguration();
+
+        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
+        insert acc;
+
+        npe03__Recurring_Donation__c rd = createRecurringDonation(acc);
+
+        //create opp from rd with account
+        Opportunity opp = getOpportunityBuilder(rd)
+            .withCloseDate(CLOSE_DATE)
+            .withOpenStage()
+            .build();
+        insert opp;
+
+        //update rd amount
+        Test.startTest();
+        rd.npe03__Amount__c = RD_NEW_AMOUNT;
+        update rd;
+        Test.stopTest();
+
+        //Verify if accountid is not changed or nulled out when rd record is modified
+        List<Opportunity> oppUpdated = oppGateway.getRecords(rd);
+        npe03__Recurring_Donation__c recurDonation = rdGateway.getRecord(rd.id);
+
+        System.assertEquals(RD_NEW_AMOUNT, oppUpdated[0].Amount, 'Amount should be updated');
+        System.assert(oppUpdated[0].AccountId != null);
+        System.assertEquals(recurDonation.npe03__Organization__c, oppUpdated[0].AccountId);
+    }
+
+    /***
+    * @description Verifies if Account is getting updated in opportunity
+    * when recurring donation's account is modified to another account
+    */
+    private static void shouldUpdateAccountInOppWhenRDAccountIsModified() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        setUpConfiguration();
+
+        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
+        insert acc;
+
+        Account accAnother = UTIL_UnitTestData_TEST.buildOrganizationAccount();
+        insert accAnother;
+
+        npe03__Recurring_Donation__c rd = createRecurringDonation(acc);
+
+        //create opp from rd with account
+        Opportunity opp = getOpportunityBuilder(rd)
+            .withCloseDate(CLOSE_DATE)
+            .withOpenStage()
+            .build();
+        insert opp;
+
+        //update rd to different account
+        Test.startTest();
+        rd.npe03__Organization__c = accAnother.Id;
+        update rd;
+        Test.stopTest();
+
+        //Verify if accountid is changed in opportunity when rd's account is modified
+        List<Opportunity> oppUpdated = oppGateway.getRecords(rd);
+        npe03__Recurring_Donation__c recurDonation = rdGateway.getRecord(rd.id);
+
+        System.assert(oppUpdated[0].AccountId != null);
+        System.assertEquals(recurDonation.npe03__Organization__c, accAnother.id);
+        System.assertEquals(recurDonation.npe03__Organization__c, oppUpdated[0].AccountId);
+
+    }
 
     // Helper Methods
     //////////////////
@@ -1083,6 +1197,19 @@ private with sharing class RD2_OpportunityService_TEST {
             .withInstallmentNumber(1);
     }
 
+     /**
+     * @description Instantiate an Opportunity builder for the specified Recurring Donation with no account
+     * @param rd Recurring Donation
+     * @return TEST_OpportunityBuilder New Opportunity builder
+     */
+    private static TEST_OpportunityBuilder getOpportunityBuilderWithNoAccount(npe03__Recurring_Donation__c rd) {
+        return new TEST_OpportunityBuilder()
+            .withContact(rd.npe03__Contact__c)
+            .withRecurringDonation(rd.Id)
+            .withAmount(rd.npe03__Amount__c)
+            .withInstallmentNumber(1);
+    }
+
     /***
     * @description Queries OCRs for specified Opportunities
     * @param oppIds Opportunity Ids
@@ -1119,7 +1246,7 @@ private with sharing class RD2_OpportunityService_TEST {
         System.assertNotEquals(null, actualException, 'An Exception should be generated');
         System.assert(actualException.getMessage().contains(System.Label.RD2_CurrencyChangeIsRestrictedOnRD),
             'Exception message should match, actual message: ' + actualException.getMessage());
-            
+
         Map<Id, Opportunity> oppById = new Map<Id, Opportunity>(oppGateway.getRecords(rd));
         for (Opportunity opp : oppById.values()) {
             System.assertEquals(CURRENCY_CAD, (String) opp.get(CURRENCY_ISO_CODE_FIELD),
@@ -1143,11 +1270,11 @@ private with sharing class RD2_OpportunityService_TEST {
         for (npe01__OppPayment__c payment : payments) {
             Opportunity opp = oppById.get(payment.npe01__Opportunity__c);
 
-            System.assertEquals(opp.Amount, payment.npe01__Payment_Amount__c, 
+            System.assertEquals(opp.Amount, payment.npe01__Payment_Amount__c,
                 'Payment Amount should match Opportunity Amount');
 
             if (isMultiCurrencyEnabled) {
-                System.assertEquals((String) opp.get(CURRENCY_ISO_CODE_FIELD), (String) payment.get(CURRENCY_ISO_CODE_FIELD), 
+                System.assertEquals((String) opp.get(CURRENCY_ISO_CODE_FIELD), (String) payment.get(CURRENCY_ISO_CODE_FIELD),
                     'Payment currency should match Opportunity currency');
             }
         }

--- a/src/classes/RD2_OpportunityService_TEST.cls
+++ b/src/classes/RD2_OpportunityService_TEST.cls
@@ -1039,6 +1039,98 @@ private with sharing class RD2_OpportunityService_TEST {
             'Opp Account should be the same as the RD Account');
     }
 
+    /***
+    * @description Verifies the Account on Opportunity is the Contact household Account
+    * when Recurring Donation has Organization removed
+    */
+    private static void shouldUpdateAccountOnOppWhenRDHasOrganizationRemoved() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        setUpConfiguration();
+
+        Account organization = UTIL_UnitTestData_TEST.buildOrganizationAccount();
+        insert organization;
+
+        Contact contact = getContact();
+
+        npe03__Recurring_Donation__c rd = buildRecurringDonation()
+            .withAccount(organization.Id)
+            .withContact(contact.Id)
+            .build();
+        insert rd;
+
+        Opportunity opp = getOpportunityBuilder(rd)
+            .withCloseDate(CLOSE_DATE)
+            .withOpenStage()
+            .build();
+        insert opp;
+
+        Test.startTest();
+        rd.npe03__Organization__c = null;
+        update rd;
+        Test.stopTest();
+
+        rd = rdGateway.getRecord(rd.Id);
+        List<Opportunity> opps = oppGateway.getRecords(rd);
+
+        System.assertEquals(1, opps.size(), 'One Opp should exist: ' + opps);
+
+        System.assertNotEquals(null, opps[0].AccountId,
+            'Opp Account should be specified when RD has organization removed');
+        System.assertEquals(contact.AccountId, opps[0].AccountId,
+            'Opp Account should be the same as the Contact household Account');
+        System.assertEquals(contact.Id, opps[0].Primary_Contact__c,
+            'Opp Primary Contact should be the same as the RD Contact');
+    }
+
+    /***
+    * @description Verifies the Account on Opportunity is the Contact household Account
+    * when Recurring Donation has Organization removed and the Contact replaced
+    */
+    private static void shouldUpdateAccountOnOppWhenRDHasOrganizationRemovedAndContactReplaced() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        setUpConfiguration();
+
+        Account organization = UTIL_UnitTestData_TEST.buildOrganizationAccount();
+        insert organization;
+
+        Contact contact = getContact();
+        Contact newHouseholdContact = UTIL_UnitTestData_TEST.getContact();
+        insert newHouseholdContact;
+        newHouseholdContact = [SELECT AccountId FROM Contact WHERE Id = :newHouseholdContact.Id];
+
+        npe03__Recurring_Donation__c rd = buildRecurringDonation()
+            .withAccount(organization.Id)
+            .withContact(contact.Id)
+            .build();
+        insert rd;
+
+        Opportunity opp = getOpportunityBuilder(rd)
+            .withCloseDate(CLOSE_DATE)
+            .withOpenStage()
+            .build();
+        insert opp;
+
+        Test.startTest();
+        rd.npe03__Organization__c = null;
+        rd.npe03__Contact__c = newHouseholdContact.Id;
+        update rd;
+        Test.stopTest();
+
+        rd = rdGateway.getRecord(rd.Id);
+        List<Opportunity> opps = oppGateway.getRecords(rd);
+
+        System.assertEquals(1, opps.size(), 'One Opp should exist: ' + opps);
+
+        System.assertNotEquals(null, opps[0].AccountId,
+            'Opp Account should be specified when RD has organization removed');
+        System.assertEquals(newHouseholdContact.AccountId, opps[0].AccountId,
+            'Opp Account should be the same as the new Contact household Account');
+        System.assertEquals(newHouseholdContact.Id, opps[0].Primary_Contact__c,
+            'Opp Primary Contact should be the same as the RD Contact');
+    }
+
     // Helper Methods
     //////////////////
 


### PR DESCRIPTION
When the Recurring Donation is updated and its value synchronized with future Open Opportunities, the Account on Opportunities should match the Account on the Recurring Donation.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
