### PR TITLE
feature/insights-contact-merge

### DIFF
--- a/src/classes/CON_ContactMerge_CTRL.cls
+++ b/src/classes/CON_ContactMerge_CTRL.cls
@@ -61,6 +61,7 @@ public with sharing class CON_ContactMerge_CTRL {
     /*******************************************************************************************************
     * @description Max number of Contacts returned by a query.
     */
+    
     private final Integer SOSL_LIMIT = 100;
 
     /*******************************************************************************************************
@@ -73,6 +74,24 @@ public with sharing class CON_ContactMerge_CTRL {
     public Boolean hasContactObjectDeletePermission() {
         return UTIL_Describe.getObjectDescribe('Contact').isDeletable();
     }
+
+    /*******************************************************************************************************
+    * @description Check read permission on Duplicate Record Sets
+    */
+    public Boolean hasDSRObjectReadPermission() {
+        return UTIL_Describe.getObjectDescribe('DuplicateRecordSet').isAccessible();
+    }
+
+    /*******************************************************************************************************
+    * @description To decide whether to show Search by Contact page or not
+    */ 
+    
+    public Boolean showContactSearch { get; set; }
+    
+    /*******************************************************************************************************
+    * @description To decide whether to show the Show Duplicate Record Set button
+    */
+    public Boolean showDRSButton { get; set; }
 
     /*******************************************************************************************************
     * @description Wraps a contact together with a checkbox, to allow contact selection.
@@ -184,14 +203,21 @@ public with sharing class CON_ContactMerge_CTRL {
     * @param controller The default list controller for contact. It allows us to do pagination on the page.
     */
     public CON_ContactMerge_CTRL(ApexPages.StandardSetController controller){
+        System.debug('Contact Merge page contructor first line----->');
         searchText='';
         searchResults = new List<ContactWrapper>();
         selectedRecords = new Map<String, Contact>();
         step = 1;
         fieldRows = new List<FieldRow>();
         canContinueWithMerge = true;
-
         set<Id> mergeIds = new set<Id>();
+        showContactSearch = false;
+        showDRSButton = true;
+        String showContactSearchParameter = System.currentPagereference().getParameters().get('showContactSearch');
+        if (showContactSearchParameter == 'true') {
+            showContactSearch = true;
+        }
+        
 
         if (!hasContactObjectDeletePermission()) {
             canContinueWithMerge = false;
@@ -795,4 +821,38 @@ public with sharing class CON_ContactMerge_CTRL {
 
         return null;
     }
+    
+    /******************************************************************************************************
+     * @description Redirect to Show Duplicate Record Set list page of Contact Merge
+     * @return PageReference redirect to DRS_ContactMerge page.
+     */
+    public PageReference redirectToShowDRSList() {
+        try {
+            showContactSearch = false;
+            if (!hasDSRObjectReadPermission()) {
+                showDRSButton = false;
+                ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, System.Label.conMergeErrorNoDRSFound));
+                return null;
+            }
+            PageReference pageRef = new PageReference('/apex/DRS_ContactMerge');
+            pageRef.setRedirect(true);
+            return pageRef;
+                  
+        } catch (exception ex) {
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, ex.getMessage()));
+        }
+        return null;
+    }
+
+    /******************************************************************************************************
+     * @description Displays the Search by Contact page of Contact Merge
+     * 
+     */
+    public void showContactSearchPage() {
+        step = 1;
+        searchText='';
+        showContactSearch = true; 
+        showDRSButton = true;              
+    }
+
 }

--- a/src/classes/DRS_ContactMerge_CTRL
+++ b/src/classes/DRS_ContactMerge_CTRL
@@ -1,0 +1,281 @@
+public with sharing class DRS_ContactMerge_CTRL {
+      
+    /*******************************************************************************************************
+    * @description To decide whether to show Dupliacate Record Set record list on the page or not
+    */ 
+    
+    public Boolean showDRS { get;set; }
+    
+    /*******************************************************************************************************
+    * @description Duplicate Record Sets to be displayed on page
+    */ 
+    public List<DuplicateRecordSet> listDuplicateRecordSets { get; set; }
+    
+    /*******************************************************************************************************
+    * @description Standard set controller variables
+    */ 
+    public ApexPages.StandardSetController stdSetCon {
+       get {
+           if(stdSetCon == null){ 
+               stdSetCon = new ApexPages.StandardSetController(Database.getQueryLocator(constructSOQL())); 
+               stdSetCon.setPageSize(pageSize);    
+           }
+           return stdSetCon;
+       }
+       set;
+    }
+    
+    /*******************************************************************************************************
+    * @description The list of Duplicate Record Set field names that are used in search and displayed in Found Duplicate
+    * Record Sets.
+    */
+    private List<String> drsFieldNames {
+        get {
+            if (drsFieldNames == null) {
+                drsFieldNames = UTIL_Describe.listStrFromFieldSet
+                                      ('DuplicateRecordSet', 
+                                      UTIL_Namespace.StrTokenNSPrefix('ContactMergeDRS'));
+                Set<String> setStr = new set<string>(drsfieldNames);
+                // now add additional fields we know we need
+                setStr.add('Id');
+                setStr.add('Name');
+                setStr.add('DuplicateRuleId');
+                setStr.add('RecordCount');
+                setStr.add('LastModifiedDate');
+                drsFieldNames.clear();
+                drsFieldNames.addAll(setStr);
+            }
+            return drsFieldNames;
+        }
+        set;
+    }
+    
+    /*******************************************************************************************************
+    * @description The list of Duplicate Record Item field name to be displayed in Found Duplicate Record Sets.
+    */
+    private List<String> driFieldNames {
+        get {
+            if (driFieldNames == null) {
+                driFieldNames = new List<String>();
+                driFieldNames.add('Name');
+                driFieldNames.add('RecordId');
+            }
+            return driFieldNames;
+        }
+        set;
+    }
+    
+    /*******************************************************************************************************
+    * @description To decide whether to continue with Contact merge page depending on permissions for contact object
+    */
+    
+    public Boolean canContinueWithMerge { get; set; }
+    
+    /*******************************************************************************************************
+    * @description Check whether user has delete permission on Contact
+    *@return Boolean Whether user has contact delete permission
+    */
+
+    public Boolean hasContactObjectDeletePermission() {
+        return UTIL_Describe.getObjectDescribe('Contact').isDeletable();
+    }
+    
+    
+    /*******************************************************************************************************
+    * @description To decide whether to continue with DRS display page depending on permissions for 
+    * Duplicate Reccord Set object
+    */
+    public Boolean canContinueWithDRSDisplay { get; set; }
+    
+    /*******************************************************************************************************
+    * @description Check whether user has read permission on Duplicate Record Sets
+    *@return Boolean Whether user has Duplicate Record Sets read permission
+    */
+    
+    public Boolean hasDRSObjectReadPermission() {
+        return UTIL_Describe.getObjectDescribe('DuplicateRecordSet').isAccessible();
+    }
+    
+    /*******************************************************************************************************
+    * @description Duplicate Record Set diplay page size.
+    */
+    private Integer pageSize = 10;
+    
+    /*******************************************************************************************************
+    * @description Total number of pages in pagination implemented on Duplicate Record Set diplay page.
+    */
+    public Integer totalPages { get; set; }
+    
+    /***************************************************************************************************
+    * @description Checks whether there are more records to display on next page in pagination implemented 
+    * on Duplicate Record Set diplay page.
+    */
+    
+    public Boolean hasNext {
+        get {
+            return stdSetCon.getHasNext();
+        }
+        set;
+    }
+    
+    /***************************************************************************************************
+    * @description Checks whether there are records prior to the records dislayed on the current page to be 
+    * display on the previous page in pagination implemented on Duplicate Record Set diplay page.
+    */
+    
+    public Boolean hasPrevious {
+        get {
+            return stdSetCon.getHasPrevious();
+        }
+        set;
+    }
+    
+    /***************************************************************************************************
+    * @description Page number of the current page
+    */
+    
+    public Integer pageNumber {
+        get {
+            return stdSetCon.getPageNumber();
+            }
+        set;
+    } 
+      
+    /*******************************************************************************************************
+    * @description Constructor for StandardSetController to allow invocation from list views.
+    * @param controller The default list controller for Duplicate Record Sets. It allows us to do pagination on the page.
+    */
+    public DRS_ContactMerge_CTRL (ApexPages.StandardSetController controller) {
+        showDRS = false;
+        totalPages  = 0;
+        canContinueWithMerge = true;
+        canContinueWithDRSDisplay = true;
+        listDuplicateRecordSets = new List<DuplicateRecordSet>();
+        
+        // Check if user has delete permission on Contact
+        if (!hasContactObjectDeletePermission()) {
+            canContinueWithMerge = false;
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, System.Label.conMergeErrorNoDeleteObjPermission));
+            return;
+        }
+        
+    }
+
+    
+    /*******************************************************************************************************
+    * @description Redirects to the NPSP Contact Merge page
+    * @return PageReference The page that it redirects to CON_ContactMerge page.
+    */
+    public PageReference searchByContact() {
+        try {
+            PageReference pageRef = new PageReference('/apex/CON_ContactMerge');
+            pageRef.getParameters().put('showContactSearch','true');
+            pageRef.setRedirect(true);
+            return pageRef;
+                  
+        } catch (exception ex) {
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, ex.getMessage()));
+        }
+        return null;
+    }
+    
+    /******************************************************************************************************
+     * @description Fetches the list of Duplicate Record Sets from standard set controller for pagination
+     * @return List<DuplicateRecordSet> Returns the current list of Duplicate Record Sets
+     */
+    public List<DuplicateRecordSet> getDuplicateRecordSets() {
+        return (List<DuplicateRecordSet>)stdSetCon.getRecords();
+    }
+
+    /*******************************************************************************************************
+    * @description Shows list of Duplicate Record Set records related to contact dupliacte rules
+    */
+    public void showDuplicateRecordSets() {
+        showDRS = true;
+        listDuplicateRecordSets = getDuplicateRecordSets();
+        if(listDuplicateRecordSets.size() == 0) {
+            canContinueWithDRSDisplay = false;
+            ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.ERROR, System.Label.conMergeErrorNoDRSFound));
+        }
+        totalPages = getTotalPages(); 
+    }
+    
+    /*******************************************************************************************************
+    * @description Shows list of Contact records related to selected Duplicate Record Set
+    */
+    public void showContactRelatedToDRS() {
+        //logic to display contacts related to selected DRS
+    }
+    
+    /*******************************************************************************************************
+    * @description Construct SOQL query to fetch all the contact related Duplicate Record Sets
+    * @return String Returns the query to fetch Duplicate Record Sets
+    */
+    public String constructSOQL() {
+        //build SOQL subquery on Duplicate Record Items
+        String subQueryOrderBy = 'CreatedDate DESC';
+        String subQuery =  new UTIL_Query()
+                                  .withFrom('DuplicateRecordItems')
+                                  .withSelectFields(driFieldNames)
+                                  .withOrderBy(subQueryOrderBy)
+                                  .withLimit(1)
+                                  .build();
+        String subQueryStr = '('+subQuery+')';
+        drsFieldNames.add(subQueryStr);
+        String setOrderBy = 'LastModifiedDate DESC ';
+        String setWhereClause = 'RecordCount > 1 AND DuplicateRule.SObjectType = \'Contact\'';
+        
+        //build the SOQL query and execute
+        String queryStr =  new UTIL_Query()
+                               .withFrom(DuplicateRecordSet.sObjectType)
+                               .withSelectFields(drsFieldNames)
+                               .withWhere(setWhereClause)
+                               .withOrderBy(setOrderBy)
+                               .build();
+        return queryStr;
+    }
+    
+    /***************************************************************************************************
+    * @description Calculates total number of pages of Duplicate Record Sets
+    */
+    public Integer getTotalPages() {
+        return (Integer)Math.ceil(Decimal.valueOf(stdSetCon.getResultSize())/pageSize);
+    }
+
+    /***************************************************************************************************
+    * @description Fetches the records to be displayed on first page of Duplicate Record Sets
+    */    
+    public void firstPage() {
+        stdSetCon.first();
+        listDuplicateRecordSets = getDuplicateRecordSets();
+    }
+    
+    /***************************************************************************************************
+    * @description Fetches the records to be displayed on previous page of Duplicate Record Sets
+    */ 
+    
+    public void previousPage() {
+        stdSetCon.previous();
+        listDuplicateRecordSets = getDuplicateRecordSets();
+    }   
+        
+    /***************************************************************************************************
+    * @description Fetches the records to be displayed on next page of Duplicate Record Sets
+    */
+    
+    public void nextPage() {
+        stdSetCon.next();
+        listDuplicateRecordSets = getDuplicateRecordSets();
+    }
+    
+    /***************************************************************************************************
+    * @description Fetches the records to be displayed on last pages of Duplicate Record Sets
+    */ 
+    
+    public void lastPage() {
+        stdSetCon.last();
+        listDuplicateRecordSets = getDuplicateRecordSets();
+    }
+    
+
+}

--- a/src/pages/CON_ContactMerge.page
+++ b/src/pages/CON_ContactMerge.page
@@ -15,15 +15,29 @@
     <apex:stylesheet value="{!URLFOR($Resource.CumulusStaticResources, '/npsp-slds/npsp-common.css')}" />
 
     <div class="slds-scope">
-
         <!-- PAGE HEADER -->
         <apex:form id="pgHeader">
             <c:UTIL_PageHeader headerLabel="{!$Label.conMergePageTitle}"
                                header="{!$Label.conMergePageTitleDetail}"
                                icon="contact" iconCategory="standard"
                                showSaveBtn="false" showCancelBtn="false"/>
+            <!-- PAGE BUTTON-->
+            <div class="slds-m-top_medium slds-m-bottom_large slds-p-horizontal_large">
+                <apex:commandButton id="srchByConBtn"
+                                    action="{!showContactSearchPage}" 
+                                    value="{!$Label.conMergeSearchByContact}" 
+                                    styleClass="slds-button slds-button_neutral"
+                                    rendered="{!AND((!showContactSearch),canContinueWithMerge)}"/>
+            </div>
+            <div class="slds-m-top_medium slds-m-bottom_large slds-p-horizontal_large">                
+                <apex:commandButton id="ShowDRS"
+                                    action="{!redirectToShowDRSList}" 
+                                    value="Show Duplicate Record Sets" 
+                                    styleClass="slds-button slds-button_neutral"
+                                    rendered="{!AND(canContinueWithMerge,showDRSButton)}"/>
+            </div>
         </apex:form>
-
+        
         <style type="text/css">
             .slds .slds-path__stage {
                 /* fix weird issue where check icon was not aligning properly */
@@ -42,228 +56,191 @@
                 display: inline-flex;
             }
         </style>
-
+        
         <apex:variable var="step1class" value="{!IF(step == 1, 'slds-is-current', 'slds-is-complete')}"/>
         <apex:variable var="step2class" value="{!IF(step < 2, 'slds-is-incomplete', IF(step == 2, 'slds-is-current', 'slds-is-complete'))}"/>
         <apex:variable var="step3class" value="{!IF(step < 3, 'slds-is-incomplete', IF(STEP == 3, 'slds-is-current', 'slds-is-complete'))}"/>
-
-        <div class="slds-m-top_medium slds-m-bottom_large slds-p-horizontal_large">
-            <div class="slds-path" role="application tablist">
-                <ul class="slds-path__nav" role="presentation">
-                    <li class="slds-path__item {!step1class}" role="presentation">
-                        <div class="slds-path__link" role="tab">
-                            <span class="slds-path__stage">
-                                <svg aria-hidden="true" class="slds-icon slds-icon_x-small" viewBox="0 0 24 24">
-                                    <path  d="M8.8 19.6L1.2 12c-.3-.3-.3-.8 0-1.1l1-1c.3-.3.8-.3 1 0L9 15.7c.1.2.5.2.6 0L20.9 4.4c.2-.3.7-.3 1 0l1 1c.3.3.3.7 0 1L9.8 19.6c-.2.3-.7.3-1 0z"/>
-                                </svg>
-                                <span class="slds-assistive-text">{!$Label.conMergeStageComplete}</span>
-                            </span>
-                            <span class="slds-path__title">{!$Label.npe01__Contact_Merge_Step1}</span>
-                        </div>
-                    </li>
-                    <li class="slds-path__item {!step2class}" role="presentation">
-                        <div class="slds-path__link" role="tab">
-                            <span class="slds-path__stage">
-                                <svg aria-hidden="true" class="slds-icon slds-icon_x-small" viewBox="0 0 24 24">
-                                    <path  d="M8.8 19.6L1.2 12c-.3-.3-.3-.8 0-1.1l1-1c.3-.3.8-.3 1 0L9 15.7c.1.2.5.2.6 0L20.9 4.4c.2-.3.7-.3 1 0l1 1c.3.3.3.7 0 1L9.8 19.6c-.2.3-.7.3-1 0z"/>
-                                </svg>
-                                <span class="slds-assistive-text">{!$Label.conMergeStageComplete}</span>
-                            </span>
-                            <span class="slds-path__title">{!$Label.npe01__Contact_Merge_Step2}</span>
-                        </div>
-                    </li>
-                    <li class="slds-path__item {!step3class}" role="presentation">
-                        <div class="slds-path__link" role="tab">
-                            <span class="slds-path__stage">
-                                <svg aria-hidden="true" class="slds-icon slds-icon_x-small" viewBox="0 0 24 24">
-                                    <path  d="M8.8 19.6L1.2 12c-.3-.3-.3-.8 0-1.1l1-1c.3-.3.8-.3 1 0L9 15.7c.1.2.5.2.6 0L20.9 4.4c.2-.3.7-.3 1 0l1 1c.3.3.3.7 0 1L9.8 19.6c-.2.3-.7.3-1 0z"/>
-                                </svg>
-                                <span class="slds-assistive-text">{!$Label.conMergeStageComplete}</span>
-                            </span>
-                            <span class="slds-path__title">{!$Label.npe01__Contact_Merge_Step3}</span>
-                        </div>
-                    </li>
-                    <li class="slds-path__item slds-is-incomplete" role="presentation">
-                        <div class="slds-path__link" role="tab">
-                            <span class="slds-path__stage">
-                                <svg aria-hidden="true" class="slds-icon slds-icon_x-small" viewBox="0 0 24 24">
-                                    <path  d="M8.8 19.6L1.2 12c-.3-.3-.3-.8 0-1.1l1-1c.3-.3.8-.3 1 0L9 15.7c.1.2.5.2.6 0L20.9 4.4c.2-.3.7-.3 1 0l1 1c.3.3.3.7 0 1L9.8 19.6c-.2.3-.7.3-1 0z"/>
-                                </svg>
-                                <span class="slds-assistive-text">{!$Label.conMergeStageComplete}</span>
-                            </span>
-                            <span class="slds-path__title">{!$Label.npe01__Contact_Merge_Step4}</span>
-                        </div>
-                    </li>
-                </ul>
+        
+        <apex:outputPanel rendered="{!showContactSearch}">
+            <div class="slds-m-top_medium slds-m-bottom_large slds-p-horizontal_large">
+                <div class="slds-path" role="application tablist">
+                    <ul class="slds-path__nav" role="presentation">
+                        <li class="slds-path__item {!step1class}" role="presentation">
+                            <div class="slds-path__link" role="tab">
+                                <span class="slds-path__stage">
+                                    <svg aria-hidden="true" class="slds-icon slds-icon_x-small" viewBox="0 0 24 24">
+                                        <path  d="M8.8 19.6L1.2 12c-.3-.3-.3-.8 0-1.1l1-1c.3-.3.8-.3 1 0L9 15.7c.1.2.5.2.6 0L20.9 4.4c.2-.3.7-.3 1 0l1 1c.3.3.3.7 0 1L9.8 19.6c-.2.3-.7.3-1 0z"/>
+                                    </svg>
+                                    <span class="slds-assistive-text">{!$Label.conMergeStageComplete}</span>
+                                </span>
+                                <span class="slds-path__title">{!$Label.npe01__Contact_Merge_Step1}</span>
+                            </div>
+                        </li>
+                        <li class="slds-path__item {!step2class}" role="presentation">
+                            <div class="slds-path__link" role="tab">
+                                <span class="slds-path__stage">
+                                    <svg aria-hidden="true" class="slds-icon slds-icon_x-small" viewBox="0 0 24 24">
+                                        <path  d="M8.8 19.6L1.2 12c-.3-.3-.3-.8 0-1.1l1-1c.3-.3.8-.3 1 0L9 15.7c.1.2.5.2.6 0L20.9 4.4c.2-.3.7-.3 1 0l1 1c.3.3.3.7 0 1L9.8 19.6c-.2.3-.7.3-1 0z"/>
+                                    </svg>
+                                    <span class="slds-assistive-text">{!$Label.conMergeStageComplete}</span>
+                                </span>
+                                <span class="slds-path__title">{!$Label.npe01__Contact_Merge_Step2}</span>
+                            </div>
+                        </li>
+                        <li class="slds-path__item {!step3class}" role="presentation">
+                            <div class="slds-path__link" role="tab">
+                                <span class="slds-path__stage">
+                                    <svg aria-hidden="true" class="slds-icon slds-icon_x-small" viewBox="0 0 24 24">
+                                        <path  d="M8.8 19.6L1.2 12c-.3-.3-.3-.8 0-1.1l1-1c.3-.3.8-.3 1 0L9 15.7c.1.2.5.2.6 0L20.9 4.4c.2-.3.7-.3 1 0l1 1c.3.3.3.7 0 1L9.8 19.6c-.2.3-.7.3-1 0z"/>
+                                    </svg>
+                                    <span class="slds-assistive-text">{!$Label.conMergeStageComplete}</span>
+                                </span>
+                                <span class="slds-path__title">{!$Label.npe01__Contact_Merge_Step3}</span>
+                            </div>
+                        </li>
+                        <li class="slds-path__item slds-is-incomplete" role="presentation">
+                            <div class="slds-path__link" role="tab">
+                                <span class="slds-path__stage">
+                                    <svg aria-hidden="true" class="slds-icon slds-icon_x-small" viewBox="0 0 24 24">
+                                        <path  d="M8.8 19.6L1.2 12c-.3-.3-.3-.8 0-1.1l1-1c.3-.3.8-.3 1 0L9 15.7c.1.2.5.2.6 0L20.9 4.4c.2-.3.7-.3 1 0l1 1c.3.3.3.7 0 1L9.8 19.6c-.2.3-.7.3-1 0z"/>
+                                    </svg>
+                                    <span class="slds-assistive-text">{!$Label.conMergeStageComplete}</span>
+                                </span>
+                                <span class="slds-path__title">{!$Label.npe01__Contact_Merge_Step4}</span>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
             </div>
-        </div>
-
+        </apex:outputpanel>
         <c:UTIL_PageMessages html-class="slds-grid slds-grid_align-center slds-m-bottom_small"/>
-
-        <apex:outputText rendered="{!AND(step <= 2, canContinueWithMerge)}">
-            <div class="slds-text-align_center slds-m-bottom_x-large">
-                <apex:form styleClass="slds-form slds-form_inline">
-                    <div class="slds-form-element slds-size_1-of-2">
-                        <div class="slds-form-element__control slds-size_1-of-1">
-                            <div class="slds-input-has-icon slds-input-has-icon_left">
-                                <svg aria-hidden="true" class="slds-icon slds-input__icon slds-icon-text-default" viewBox="0 0 24 24">
-                                    <path  d="M22.9 20.9l-6.2-6.1c1.3-1.8 1.9-4 1.6-6.4-.6-3.9-3.8-7.1-7.8-7.4C5 .4.4 5 1 10.5c.3 4 3.5 7.3 7.4 7.8 2.4.3 4.6-.3 6.4-1.5l6.1 6.1c.3.3.7.3 1 0l.9-1c.3-.3.3-.7.1-1zM3.7 9.6c0-3.2 2.7-5.9 5.9-5.9s6 2.7 6 5.9-2.7 6-6 6-5.9-2.6-5.9-6z"/>
-                                </svg>
-                                <apex:inputText value="{!searchText}" styleClass="slds-input" html-placeholder="{!$Label.conMergeSearchPlaceholder}"/>
+        <apex:outputPanel rendered="{!showContactSearch}">
+            <apex:outputText rendered="{!AND(step <= 2, canContinueWithMerge)}">
+                <div class="slds-text-align_center slds-m-bottom_x-large">
+                    <apex:form styleClass="slds-form slds-form_inline">
+                        <div class="slds-form-element slds-size_1-of-2">
+                            <div class="slds-form-element__control slds-size_1-of-1">
+                                <div class="slds-input-has-icon slds-input-has-icon_left">
+                                    <svg aria-hidden="true" class="slds-icon slds-input__icon slds-icon-text-default" viewBox="0 0 24 24">
+                                        <path  d="M22.9 20.9l-6.2-6.1c1.3-1.8 1.9-4 1.6-6.4-.6-3.9-3.8-7.1-7.8-7.4C5 .4.4 5 1 10.5c.3 4 3.5 7.3 7.4 7.8 2.4.3 4.6-.3 6.4-1.5l6.1 6.1c.3.3.7.3 1 0l.9-1c.3-.3.3-.7.1-1zM3.7 9.6c0-3.2 2.7-5.9 5.9-5.9s6 2.7 6 5.9-2.7 6-6 6-5.9-2.6-5.9-6z"/>
+                                    </svg>
+                                    <apex:inputText value="{!searchText}" styleClass="slds-input" html-placeholder="{!$Label.conMergeSearchPlaceholder}"/>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <apex:commandButton action="{!search}" value="{!$Label.mtchBtnSearch}" styleClass="slds-button slds-button_brand"/>
-                </apex:form>
-            </div>
-        </apex:outputText>
+                        <apex:commandButton action="{!search}" value="{!$Label.mtchBtnSearch}" styleClass="slds-button slds-button_brand"/>
+                    </apex:form>
+                </div>
+            </apex:outputText>
 
-        <apex:outputText rendered="{!step == 2}">
-            <apex:variable var="hasResults" value="{!searchResults.size > 0}"/>
-            <apex:variable var="cardClass" value="{!IF(hasResults, '', 'slds-card_empty')}"/>
+            <apex:outputText rendered="{!step == 2}">
+                <apex:variable var="hasResults" value="{!searchResults.size > 0}"/>
+                <apex:variable var="cardClass" value="{!IF(hasResults, '', 'slds-card_empty')}"/>
 
-            <apex:form >
-                <div class="slds-card slds-m-horizontal_large {!cardClass}">
-                    <div class="slds-card__header slds-grid slds-grid_align-spread">
-                        <h2 class="slds-text-heading_small slds-truncate slds-align-middle">{!$Label.conMergeFoundContacts}</h2>
-                        <apex:commandButton action="{!nextStep}" rendered="{!hasResults}" value="{!$Label.labelListViewNext}" styleClass="slds-button slds-button_neutral"/>
-                    </div>
-                    <div class="slds-card__body">
-                        <apex:outputText rendered="{!NOT(hasResults)}">
-                        <h3 class="slds-text-heading_small slds-p-top_large slds-p-bottom_large">
-                            <apex:outputText value="{!$Label.npe01__contact_merge_error_confirm_message_nothing_found}"/>
-                        </h3>
-                        </apex:outputText>
-                        <apex:outputText rendered="{!hasResults}">
+                <apex:form >
+                    <div class="slds-card slds-m-horizontal_large {!cardClass}">
+                        <div class="slds-card__header slds-grid slds-grid_align-spread">
+                            <h2 class="slds-text-heading_small slds-truncate slds-align-middle">{!$Label.conMergeFoundContacts}</h2>
+                            <apex:commandButton action="{!nextStep}" rendered="{!hasResults}" value="{!$Label.labelListViewNext}" styleClass="slds-button slds-button_neutral"/>
+                        </div>
+                        <div class="slds-card__body">
+                            <apex:outputText rendered="{!NOT(hasResults)}">
+                            <h3 class="slds-text-heading_small slds-p-top_large slds-p-bottom_large">
+                                <apex:outputText value="{!$Label.npe01__contact_merge_error_confirm_message_nothing_found}"/>
+                            </h3>
+                            </apex:outputText>
+                            <apex:outputText rendered="{!hasResults}">
 
-                            <table class="slds-table slds-table_bordered slds-max-medium-table_stacked-horizontal">
-                                <thead>
-                                    <tr>
-                                        <th></th>
-                                        <th class="slds-text-heading_label" scope="col">Name</th>
-                                        <apex:repeat value="{!$ObjectType.Contact.FieldSets.ContactMergeFoundFS}" var="field">
-                                            <th class="slds-text-heading_label" scope="col">
-                                                <apex:outputText value="{!field.label}"/>
-                                            </th>
+                                <table class="slds-table slds-table_bordered slds-max-medium-table_stacked-horizontal">
+                                    <thead>
+                                        <tr>
+                                            <th></th>
+                                            <th class="slds-text-heading_label" scope="col">Name</th>
+                                            <apex:repeat value="{!$ObjectType.Contact.FieldSets.ContactMergeFoundFS}" var="field">
+                                                <th class="slds-text-heading_label" scope="col">
+                                                    <apex:outputText value="{!field.label}"/>
+                                                </th>
+                                            </apex:repeat>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <apex:repeat value="{!searchResults}" var="item">
+                                            <tr>
+                                                <td class="slds-row-select">
+                                                    <label class="slds-checkbox">
+                                                        <apex:inputCheckbox value="{!item.selected}"/>
+                                                        <span class="slds-checkbox_faux" id="fauxCBSelect"></span>
+                                                        <span class="slds-form-element__label slds-assistive-text">
+                                                            {!$Label.conMergeSelectContact} <apex:outputText value="{!item.con.Name}"/>
+                                                        </span>
+                                                    </label>
+                                                </td>
+                                                <td>
+                                                    <a href="{!URLFOR($Action.Contact.View, item.con.Id)}" class="slds-truncate">
+                                                        <apex:outputText value="{!item.con.Name}"/>
+                                                    </a>
+                                                </td>
+                                                <apex:repeat value="{!$ObjectType.Contact.FieldSets.ContactMergeFoundFS}" var="field">
+                                                    <td>
+                                                        <span class="slds-truncate">
+                                                            <apex:outputField value="{!item.con[field]}"/>
+                                                        </span>
+                                                    </td>
+                                                </apex:repeat>
+                                            </tr>
                                         </apex:repeat>
-                                    </tr>
+                                    </tbody>
+                                </table>
+                            </apex:outputText>
+                        </div>
+                        <div class="slds-card__footer">
+                            <apex:commandButton action="{!nextStep}" rendered="{!hasResults}" value="{!$Label.labelListViewNext}" styleClass="slds-button slds-button_neutral"/>
+                        </div>
+                    </div>
+                </apex:form>
+            </apex:outputText>
+
+            <apex:outputText id="contactMerge" rendered="{!step == 3}">
+
+                <apex:form id="mergeForm" styleClass="slds-form">
+                    <div class="slds-card slds-m-horizontal_large slds-m-bottom_large hide-when-modal-open">
+                        <div class="slds-card__header slds-grid slds-grid_align-spread">
+                            <h2 class="slds-text-heading_small slds-truncate slds-align-middle">{!$Label.conMergeSelectedContacts}</h2>
+                            <button type="button" class="slds-button slds-button_brand" data-toggle="modal" data-target="merge_warning_modal">{!$Label.conMergeBtnLabel}</button>
+                        </div>
+                        <div class="slds-card__body">
+                            <table class="slds-table slds-table_bordered">
+                                <thead>
+                                    <!-- header row(s) -->
+                                    <apex:repeat var="row" value="{!fieldRows}">
+                                        <apex:outputText rendered="{!row.styleClass == 'header'}">
+                                            <tr>
+                                                <th class="slds-size_1-of-12"></th>
+                                                <apex:repeat var="col" value="{!row.values}">
+                                                    <th class="slds-size_1-of-3 slds-cell-wrap">
+                                                        <span class="slds-text-heading_small">
+                                                            <apex:outputText value="{!col.value}"/>
+                                                        </span>
+                                                        <span class="slds-text-body_small kill-white-space">
+                                                            (<apex:commandLink action="{!selectDefaultRecord}" value="{!$Label.conMergeSelectAll}"><apex:param name="recordId" value="{!col.objId}"/></apex:commandLink>)
+                                                        </span>
+                                                    </th>
+                                                </apex:repeat>
+                                            </tr>
+                                        </apex:outputText>
+                                    </apex:repeat>
                                 </thead>
                                 <tbody>
-                                    <apex:repeat value="{!searchResults}" var="item">
-                                        <tr>
-                                            <td class="slds-row-select">
-                                                <label class="slds-checkbox">
-                                                    <apex:inputCheckbox value="{!item.selected}"/>
-                                                    <span class="slds-checkbox_faux" id="fauxCBSelect"></span>
-                                                    <span class="slds-form-element__label slds-assistive-text">
-                                                        {!$Label.conMergeSelectContact} <apex:outputText value="{!item.con.Name}"/>
-                                                    </span>
-                                                </label>
-                                            </td>
-                                            <td>
-                                                <a href="{!URLFOR($Action.Contact.View, item.con.Id)}" class="slds-truncate">
-                                                    <apex:outputText value="{!item.con.Name}"/>
-                                                </a>
-                                            </td>
-                                            <apex:repeat value="{!$ObjectType.Contact.FieldSets.ContactMergeFoundFS}" var="field">
-                                                <td>
-                                                    <span class="slds-truncate">
-                                                        <apex:outputField value="{!item.con[field]}"/>
-                                                    </span>
-                                                </td>
-                                            </apex:repeat>
-                                        </tr>
-                                    </apex:repeat>
-                                </tbody>
-                            </table>
-                        </apex:outputText>
-                    </div>
-                    <div class="slds-card__footer">
-                        <apex:commandButton action="{!nextStep}" rendered="{!hasResults}" value="{!$Label.labelListViewNext}" styleClass="slds-button slds-button_neutral"/>
-                    </div>
-                </div>
-            </apex:form>
-        </apex:outputText>
-
-        <apex:outputText id="contactMerge" rendered="{!step == 3}">
-
-            <apex:form id="mergeForm" styleClass="slds-form">
-                <div class="slds-card slds-m-horizontal_large slds-m-bottom_large hide-when-modal-open">
-                    <div class="slds-card__header slds-grid slds-grid_align-spread">
-                        <h2 class="slds-text-heading_small slds-truncate slds-align-middle">{!$Label.conMergeSelectedContacts}</h2>
-                        <button type="button" class="slds-button slds-button_brand" data-toggle="modal" data-target="merge_warning_modal">{!$Label.conMergeBtnLabel}</button>
-                    </div>
-                    <div class="slds-card__body">
-                        <table class="slds-table slds-table_bordered">
-                            <thead>
-                                <!-- header row(s) -->
-                                <apex:repeat var="row" value="{!fieldRows}">
-                                    <apex:outputText rendered="{!row.styleClass == 'header'}">
-                                        <tr>
-                                            <th class="slds-size_1-of-12"></th>
-                                            <apex:repeat var="col" value="{!row.values}">
-                                                <th class="slds-size_1-of-3 slds-cell-wrap">
-                                                    <span class="slds-text-heading_small">
-                                                        <apex:outputText value="{!col.value}"/>
-                                                    </span>
-                                                    <span class="slds-text-body_small kill-white-space">
-                                                        (<apex:commandLink action="{!selectDefaultRecord}" value="{!$Label.conMergeSelectAll}"><apex:param name="recordId" value="{!col.objId}"/></apex:commandLink>)
-                                                    </span>
+                                    <!-- master row(s) -->
+                                    <apex:repeat var="row" value="{!fieldRows}">
+                                        <apex:outputText rendered="{!row.fieldName == '$MASTER$'}">
+                                            <tr>
+                                                <th class="slds-size_1-of-12">
+                                                    <apex:inputHidden id="winner" value="{!row.selectedValue}"/>
+                                                    <apex:outputText value="{!row.fieldLabel}"/>
                                                 </th>
-                                            </apex:repeat>
-                                        </tr>
-                                    </apex:outputText>
-                                </apex:repeat>
-                            </thead>
-                            <tbody>
-                                <!-- master row(s) -->
-                                <apex:repeat var="row" value="{!fieldRows}">
-                                    <apex:outputText rendered="{!row.fieldName == '$MASTER$'}">
-                                        <tr>
-                                            <th class="slds-size_1-of-12">
-                                                <apex:inputHidden id="winner" value="{!row.selectedValue}"/>
-                                                <apex:outputText value="{!row.fieldLabel}"/>
-                                            </th>
-                                            <apex:repeat var="col" value="{!row.values}">
-                                                <th class="slds-form-element__control slds-size_1-of-3 slds-cell-wrap">
-                                                    <label class="slds-radio">
-                                                        <apex:outputText rendered="{!row.selectedValue == col.objId}">
-                                                            <input type="radio" class="radio-winner-value" checked="true" name="{!row.fieldName}" data-target="{!$Component.winner}" value="{!col.objId}"/>
-                                                        </apex:outputText>
-                                                        <apex:outputText rendered="{!row.selectedValue != col.objId}">
-                                                            <input type="radio" class="radio-winner-value" name="{!row.fieldName}" data-target="{!$Component.winner}" value="{!col.objId}"/>
-                                                        </apex:outputText>
-                                                        <span class="slds-radio_faux"></span>
-                                                        <span>
-                                                            <apex:outputText value="{!col.objId}"/>
-                                                        </span>
-                                                        <span class="slds-assistive-text">{!$Label.conMergeWinnerAsstText}</span>
-                                                    </label>
-                                                </th>
-                                            </apex:repeat>
-                                        </tr>
-                                    </apex:outputText>
-                                </apex:repeat>
-                            </tbody>
-                            <tbody>
-                                <!-- normal and separator rows go here -->
-                                <apex:repeat var="row" value="{!fieldRows}">
-                                    <apex:outputText rendered="{!row.styleClass == 'separator'}">
-                                        <tr>
-                                            <th colspan="5" class="slds-theme_shade slds-text-heading_label">
-                                                <apex:outputText value="{!row.fieldLabel}"/>
-                                            </th>
-                                        </tr>
-                                    </apex:outputText>
-                                    <apex:outputText rendered="{!row.styleClass != 'separator' && row.styleClass != 'header' && row.fieldName != '$MASTER$'}">
-                                        <tr>
-                                            <th class="slds-size_1-of-12">
-                                                <apex:inputHidden id="winner" value="{!row.selectedValue}" rendered="{!row.showRadio}"/>
-                                                <apex:outputText value="{!row.fieldLabel}"/>
-                                            </th>
-                                            <apex:repeat var="col" value="{!row.values}">
-                                                <apex:outputText rendered="{!row.showRadio}">
-                                                    <td class="slds-form-element__control slds-size_1-of-3 slds-cell-wrap">
+                                                <apex:repeat var="col" value="{!row.values}">
+                                                    <th class="slds-form-element__control slds-size_1-of-3 slds-cell-wrap">
                                                         <label class="slds-radio">
                                                             <apex:outputText rendered="{!row.selectedValue == col.objId}">
                                                                 <input type="radio" class="radio-winner-value" checked="true" name="{!row.fieldName}" data-target="{!$Component.winner}" value="{!col.objId}"/>
@@ -273,75 +250,114 @@
                                                             </apex:outputText>
                                                             <span class="slds-radio_faux"></span>
                                                             <span>
-                                                                <apex:outputText value="{!col.value}"/>
+                                                                <apex:outputText value="{!col.objId}"/>
                                                             </span>
+                                                            <span class="slds-assistive-text">{!$Label.conMergeWinnerAsstText}</span>
                                                         </label>
-                                                    </td>
-                                                </apex:outputText>
-                                                <apex:outputText rendered="{!NOT(row.showRadio)}">
-                                                    <td class="slds-size_1-of-3 slds-cell-wrap">
-                                                        <apex:outputText value="{!col.value}"/>
-                                                    </td>
-                                                </apex:outputText>
-                                            </apex:repeat>
-                                        </tr>
-                                    </apex:outputText>
-                                </apex:repeat>
-                            </tbody>
-                        </table>
+                                                    </th>
+                                                </apex:repeat>
+                                            </tr>
+                                        </apex:outputText>
+                                    </apex:repeat>
+                                </tbody>
+                                <tbody>
+                                    <!-- normal and separator rows go here -->
+                                    <apex:repeat var="row" value="{!fieldRows}">
+                                        <apex:outputText rendered="{!row.styleClass == 'separator'}">
+                                            <tr>
+                                                <th colspan="5" class="slds-theme_shade slds-text-heading_label">
+                                                    <apex:outputText value="{!row.fieldLabel}"/>
+                                                </th>
+                                            </tr>
+                                        </apex:outputText>
+                                        <apex:outputText rendered="{!row.styleClass != 'separator' && row.styleClass != 'header' && row.fieldName != '$MASTER$'}">
+                                            <tr>
+                                                <th class="slds-size_1-of-12">
+                                                    <apex:inputHidden id="winner" value="{!row.selectedValue}" rendered="{!row.showRadio}"/>
+                                                    <apex:outputText value="{!row.fieldLabel}"/>
+                                                </th>
+                                                <apex:repeat var="col" value="{!row.values}">
+                                                    <apex:outputText rendered="{!row.showRadio}">
+                                                        <td class="slds-form-element__control slds-size_1-of-3 slds-cell-wrap">
+                                                            <label class="slds-radio">
+                                                                <apex:outputText rendered="{!row.selectedValue == col.objId}">
+                                                                    <input type="radio" class="radio-winner-value" checked="true" name="{!row.fieldName}" data-target="{!$Component.winner}" value="{!col.objId}"/>
+                                                                </apex:outputText>
+                                                                <apex:outputText rendered="{!row.selectedValue != col.objId}">
+                                                                    <input type="radio" class="radio-winner-value" name="{!row.fieldName}" data-target="{!$Component.winner}" value="{!col.objId}"/>
+                                                                </apex:outputText>
+                                                                <span class="slds-radio_faux"></span>
+                                                                <span>
+                                                                    <apex:outputText value="{!col.value}"/>
+                                                                </span>
+                                                            </label>
+                                                        </td>
+                                                    </apex:outputText>
+                                                    <apex:outputText rendered="{!NOT(row.showRadio)}">
+                                                        <td class="slds-size_1-of-3 slds-cell-wrap">
+                                                            <apex:outputText value="{!col.value}"/>
+                                                        </td>
+                                                    </apex:outputText>
+                                                </apex:repeat>
+                                            </tr>
+                                        </apex:outputText>
+                                    </apex:repeat>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="slds-card__footer">
+                            <button type="button" class="slds-button slds-button_brand" data-toggle="modal" data-target="merge_warning_modal">{!$Label.conMergeBtnLabel}</button>
+                        </div>
                     </div>
-                    <div class="slds-card__footer">
-                        <button type="button" class="slds-button slds-button_brand" data-toggle="modal" data-target="merge_warning_modal">{!$Label.conMergeBtnLabel}</button>
-                    </div>
-                </div>
-                <div>
-                    <div id="merge_warning_modal" tabindex="-1" aria-hidden="true" role="dialog" class="slds-modal slds-modal_prompt">
-                        <div class="slds-modal__container slds-modal_prompt slds-size_1-of-3">
-                            <div class="slds-modal__header slds-theme_error slds-theme_alert-texture">
-                                <button class="slds-button slds-button_icon-inverse slds-modal__close" data-dismiss="modal" data-target="merge_warning_modal">
-                                    <svg aria-hidden="true" class="slds-button__icon slds-button__icon_large" viewBox="0 0 24 24">
-                                        <path  d="M14.3 11.7l6-6c.3-.3.3-.7 0-1l-.9-1c-.3-.2-.7-.2-1 0l-6 6.1c-.2.2-.5.2-.7 0l-6-6.1c-.3-.3-.7-.3-1 0l-1 1c-.2.2-.2.7 0 .9l6.1 6.1c.2.2.2.4 0 .6l-6.1 6.1c-.3.3-.3.7 0 1l1 1c.2.2.7.2.9 0l6.1-6.1c.2-.2.4-.2.6 0l6.1 6.1c.2.2.7.2.9 0l1-1c.3-.3.3-.7 0-1l-6-6c-.2-.2-.2-.5 0-.7z"/>
-                                    </svg>
-                                    <span class="slds-assistive-text">{!$Label.bdiBtnClose}</span>
-                                </button>
-                            </div>
-                            <div class="slds-modal__content slds-p-around_medium">
-                                <div>
-                                    <p class="slds-text-align_center">
-                                        <apex:outputText value="{!$Label.npe01__contact_merge_error_confirm_message}"/>
-                                    </p>
+                    <div>
+                        <div id="merge_warning_modal" tabindex="-1" aria-hidden="true" role="dialog" class="slds-modal slds-modal_prompt">
+                            <div class="slds-modal__container slds-modal_prompt slds-size_1-of-3">
+                                <div class="slds-modal__header slds-theme_error slds-theme_alert-texture">
+                                    <button class="slds-button slds-button_icon-inverse slds-modal__close" data-dismiss="modal" data-target="merge_warning_modal">
+                                        <svg aria-hidden="true" class="slds-button__icon slds-button__icon_large" viewBox="0 0 24 24">
+                                            <path  d="M14.3 11.7l6-6c.3-.3.3-.7 0-1l-.9-1c-.3-.2-.7-.2-1 0l-6 6.1c-.2.2-.5.2-.7 0l-6-6.1c-.3-.3-.7-.3-1 0l-1 1c-.2.2-.2.7 0 .9l6.1 6.1c.2.2.2.4 0 .6l-6.1 6.1c-.3.3-.3.7 0 1l1 1c.2.2.7.2.9 0l6.1-6.1c.2-.2.4-.2.6 0l6.1 6.1c.2.2.7.2.9 0l1-1c.3-.3.3-.7 0-1l-6-6c-.2-.2-.2-.5 0-.7z"/>
+                                        </svg>
+                                        <span class="slds-assistive-text">{!$Label.bdiBtnClose}</span>
+                                    </button>
                                 </div>
-                            </div>
-                            <div class="slds-modal__footer slds-theme_default">
-                                <div class="slds-x-small-buttons_horizontal">
-                                    <apex:commandButton action="{!mergeContacts}" value="{!$Label.conMergeBtnLabel}" styleClass="slds-button slds-button_destructive" id="mergeContacts"/>
-                                    <button class="slds-button slds-button_neutral" data-dismiss="modal" data-target="merge_warning_modal" id="btnCancel">{!$Label.stgBtnCancel}</button>
+                                <div class="slds-modal__content slds-p-around_medium">
+                                    <div>
+                                        <p class="slds-text-align_center">
+                                            <apex:outputText value="{!$Label.npe01__contact_merge_error_confirm_message}"/>
+                                        </p>
+                                    </div>
+                                </div>
+                                <div class="slds-modal__footer slds-theme_default">
+                                    <div class="slds-x-small-buttons_horizontal">
+                                        <apex:commandButton action="{!mergeContacts}" value="{!$Label.conMergeBtnLabel}" styleClass="slds-button slds-button_destructive" id="mergeContacts"/>
+                                        <button class="slds-button slds-button_neutral" data-dismiss="modal" data-target="merge_warning_modal" id="btnCancel">{!$Label.stgBtnCancel}</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <div class="slds-backdrop" tabindex="-1"></div>
                     </div>
-                    <div class="slds-backdrop" tabindex="-1"></div>
-                </div>
 
-            </apex:form>
+                </apex:form>
 
-            <script>
-                document.getElementById('{!$Component.mergeForm}').addEventListener(
-                    'submit',
-                    function (e) {
-                        var checkedRadios = document.querySelectorAll('.radio-winner-value:checked');
+                <script>
+                    document.getElementById('{!$Component.mergeForm}').addEventListener(
+                        'submit',
+                        function (e) {
+                            var checkedRadios = document.querySelectorAll('.radio-winner-value:checked');
 
-                        for (var i = 0; i < checkedRadios.length; ++i) {
-                            var el = checkedRadios[i];
-                            var winnerEl = el.getAttribute('data-target');
-                            var winner = el.value;
-                            document.getElementById(winnerEl).value = winner;
-                        }
-                    },
-                    false
-                );
-            </script>
-        </apex:outputText>
+                            for (var i = 0; i < checkedRadios.length; ++i) {
+                                var el = checkedRadios[i];
+                                var winnerEl = el.getAttribute('data-target');
+                                var winner = el.value;
+                                document.getElementById(winnerEl).value = winner;
+                            }
+                        },
+                        false
+                    );
+                </script>
+            </apex:outputText>
+        </apex:outputPanel>
 
     </div>
 </apex:page>

--- a/src/pages/DRS_ContactMerge.page
+++ b/src/pages/DRS_ContactMerge.page
@@ -1,0 +1,129 @@
+<apex:page standardController="DuplicateRecordSet"
+    extensions="DRS_ContactMerge_CTRL"
+    title="{!$Label.conMergePageTitle}"
+    tabStyle="Contact_Merge__tab"
+    id="DSR_contactMergePage"
+    showHeader="true"
+    recordSetVar="dupRecSet"
+    sidebar="false"
+    docType="html-5.0"
+    standardStylesheets="true"
+    action="{!showDuplicateRecordSets}">
+
+    <apex:slds />
+
+    <apex:includeScript value="{!URLFOR($Resource.CumulusStaticResources, '/npsp-slds/modal.js')}"/>
+    <apex:stylesheet value="{!URLFOR($Resource.CumulusStaticResources, '/npsp-slds/npsp-common.css')}" />
+
+    <div class="slds-scope">
+        <apex:variable var="hasResults" value="{!listDuplicateRecordSets.size > 0}"/>
+        <apex:variable var="cardClass" value="{!IF(hasResults, '', 'slds-card_empty')}"/>
+        <!-- PAGE HEADER -->
+        <apex:form id="pgHeader">
+            <c:UTIL_PageHeader headerLabel="{!$Label.conMergePageTitle}"
+                               header="{!$Label.conMergePageTitleDetail}"
+                               icon="contact" iconCategory="standard"
+                               showSaveBtn="false" showCancelBtn="false"/>
+                                
+            <apex:outputPanel id="mergePanel" rendered="{!canContinueWithMerge}">
+                <div class="slds-m-top_medium slds-m-bottom_large slds-p-horizontal_large">
+                    <apex:commandButton id="srchByConBtn"
+                                        action="{!searchByContact}" 
+                                        value="{!$Label.conMergeSearchByContact}" 
+                                        styleClass="slds-button slds-button_neutral"/>
+                </div>
+            </apex:outputPanel>
+            <c:UTIL_PageMessages html-class="slds-grid slds-grid_align-center slds-m-bottom_small"/>
+            <apex:outputPanel id="panelData" rendered="{!showDRS}">
+            <div class="slds-card slds-m-horizontal_large {!cardClass}">
+                <div class="slds-card__header slds-grid slds-grid_align-spread">
+                    <h2 class="slds-text-heading_small slds-truncate slds-align-middle">
+                        {!$Label.conMergeFoundDRS}
+                    </h2>
+                </div>
+                <div class="slds-card__body">
+                    <table class="slds-table slds-table_bordered slds-max-medium-table_stacked-horizontal">
+                        <thead>
+                            <tr>
+                                <th class="slds-text-heading_label" scope="col">Duplicate Record Set Name</th>
+                                <th class="slds-text-heading_label" scope="col">Last Modified Date</th>
+                                <th class="slds-text-heading_label" scope="col">Duplicate Rule</th>
+                                <th class="slds-text-heading_label" scope="col">Record Count</th>
+                                <apex:repeat value="{!$ObjectType.DuplicateRecordSet.FieldSets.ContactMergeDRS}" var="field">
+                                    <th class="slds-text-heading_label" scope="col">
+                                        <apex:outputText value="{!field.label}"/>
+                                    </th>
+                                </apex:repeat>
+                                <th class="slds-text-heading_label" scope="col">First Contact Name</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <apex:repeat value="{!listDuplicateRecordSets}" var="drs">
+                                <tr>
+                                    <td>
+                                        <a href="{!URLFOR($Action.DuplicateRecordSet.View, drs.Id)}" class="slds-truncate">
+                                            <apex:outputText value="{!drs.Name}"/>
+                                        </a>
+                                    </td>
+                                    <td>
+                                        <span class="slds-truncate">
+                                            <apex:outputField value="{!drs.LastModifiedDate}"/>
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <span class="slds-truncate">
+                                            <apex:outputField value="{!drs.DuplicateRuleId}"/>
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <span class="slds-truncate">
+                                            <apex:outputField value="{!drs.RecordCount}"/>
+                                        </span>
+                                    </td>
+                                    <apex:repeat value="{!$ObjectType.DuplicateRecordSet.FieldSets.ContactMergeDRS}" var="field">
+                                        <td>
+                                            <span class="slds-truncate">
+                                                <apex:outputField value="{!drs[field]}"/>
+                                            </span>
+                                        </td>
+                                    </apex:repeat>
+                                    <td>
+                                        <span class="slds-truncate">
+                                            <apex:outputField value="{!drs.DuplicateRecordItems[0].RecordId}"/>
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <apex:commandButton action="{!showContactRelatedToDRS}" value="{!$Label.conMergeDRSPickBtnLabel}" 
+                                                            styleClass="slds-button slds-button_brand"/>
+                                    </td>
+                                </tr>
+                            </apex:repeat>
+                        </tbody>
+                    </table>
+                </div>
+                <div  class="slds-card__footer">
+                    <apex:commandButton action="{!firstPage}" value="{!$Label.labelListViewFirst}" 
+                                        styleClass="slds-button slds-button_brand"
+                                        reRender="panelData"
+                                        disabled="{!(!hasPrevious)}"/> 
+                    <apex:commandButton action="{!previousPage}" value="{!$Label.labelListViewPrevious}" 
+                                        styleClass="slds-button slds-button_brand"
+                                        reRender="panelData"
+                                        disabled="{!(!hasPrevious)}"/>
+                    <apex:outputLabel styleClass="slds-p-left_x-small slds-p-right_x-small" value=" Page {!pageNumber} of {!totalPages} " />
+                    <apex:commandButton action="{!nextPage}" value="{!$Label.labelListViewNext}" 
+                                        styleClass="slds-button slds-button_brand"
+                                        reRender="panelData"
+                                        disabled="{!(!hasNext)}"/>
+                    <apex:commandButton action="{!lastPage}" value="{!$Label.labelListViewLast}" 
+                                        styleClass="slds-button slds-button_brand"
+                                        reRender="panelData"
+                                        disabled="{!(!hasNext)}"/>  
+                </div>
+            </div>
+            </apex:outputPanel>
+        </apex:form>
+        
+    </div>
+</apex:page>


### PR DESCRIPTION
Updates to Contact Merge functionality are done to display two buttons on the Contact Merge page. First button 'Search By Contacts' will redirect to the existing contact merge functionality. The second button 'Show Duplicate Record Sets' will redirect to list of DRSs related to contact duplicate rules. This second page includes pagination to handle large number of DRS records. The 'Duplicate Record Set Name', 'Duplicate Rule' and 'First Contact Name' columns of the DRS list contains the links to the detail page of the respective records
