### PR TITLE
RD2: Copy Installment Amount into fixed-length RD Amount when Schedule Type is null

### DIFF
--- a/src/classes/RD2_DataMigrationMapper.cls
+++ b/src/classes/RD2_DataMigrationMapper.cls
@@ -147,7 +147,7 @@ public class RD2_DataMigrationMapper {
             handleCustomInstallmentPeriod(rd);
         }
 
-        if (rd.npe03__Schedule_Type__c == RD_Constants.SCHEDULE_TYPE_DIVIDE_BY
+        if ((rd.npe03__Schedule_Type__c == RD_Constants.SCHEDULE_TYPE_DIVIDE_BY || rd.npe03__Schedule_Type__c == null)
             && rd.npe03__Installment_Amount__c != null
             && rd.npe03__Installment_Amount__c != 0
         ) {

--- a/src/classes/RD2_DataMigration_TEST.cls
+++ b/src/classes/RD2_DataMigration_TEST.cls
@@ -499,7 +499,6 @@ private class RD2_DataMigration_TEST {
     @IsTest
     private static void shouldSetAmountFromInstallmentAmountWhenScheduleTypeIsDivideBy() {
         Integer installments = 4;
-
         npe03__Recurring_Donation__c rd = getLegacyRecurringDonationBuilder(getContact().Id)
             .withId(null)
             .withInstallmentPeriodYearly()
@@ -509,10 +508,7 @@ private class RD2_DataMigration_TEST {
             .build();
         insert rd;
 
-        rd = getRecords()[0];
-        rd.Status__c = null;//simulate legacy Recurring Donation (Status default on insert is Active)
-
-        npe03__Recurring_Donation__c convertedRD = new RD2_DataMigrationMapper(rd)
+        npe03__Recurring_Donation__c convertedRD = new RD2_DataMigrationMapper(getRecords()[0])
             .convertToEnhancedRD();
 
         System.assertEquals(AMOUNT_VALUE / installments, convertedRD.npe03__Amount__c, 'Amount should be copied from Installment Amount');
@@ -525,16 +521,46 @@ private class RD2_DataMigration_TEST {
      */
     @IsTest
     private static void shouldNotChangeAmountWhenScheduleTypeIsMultiplyBy() {
+        Integer installments = 4;
+        npe03__Recurring_Donation__c rd = getLegacyRecurringDonationBuilder(getContact().Id)
+            .withId(null)
+            .withInstallmentPeriodYearly()
+            .withPlannedInstallments(installments)
+            .withScheduleType(RD_Constants.SCHEDULE_TYPE_MULTIPLY_BY)
+            .withOpenEndedStatusNone()
+            .build();
+        insert rd;
 
-        npe03__Recurring_Donation__c convertedRD = new RD2_DataMigrationMapper(
-            getLegacyRecurringDonationBuilder()
-                .withScheduleTypeMultiplyValue()
-                .build()
-        ).convertToEnhancedRD();
+        npe03__Recurring_Donation__c convertedRD = new RD2_DataMigrationMapper(getRecords()[0])
+            .convertToEnhancedRD();
 
         System.assertEquals(AMOUNT_VALUE, convertedRD.npe03__Amount__c, 'Amount should be unchanged');
+        System.assertEquals(RD2_Constants.RECURRING_TYPE_FIXED, convertedRD.RecurringType__c, 'Recurring Type should be Fixed');
+        System.assertEquals(installments, convertedRD.npe03__Installments__c, 'Number of Planned Installments should be unchanged');
     }
 
+    /**
+     * @description Verifies Amount is set from Installment Amount when Schedule Type is null
+     */
+    @IsTest
+    private static void shouldSetAmountFromInstallmentAmountWhenScheduleTypeIsNull() {
+        Integer installments = 4;
+        npe03__Recurring_Donation__c rd = getLegacyRecurringDonationBuilder(getContact().Id)
+            .withId(null)
+            .withInstallmentPeriodYearly()
+            .withPlannedInstallments(installments)
+            .withScheduleType(null)
+            .withOpenEndedStatusNone()
+            .build();
+        insert rd;
+
+        npe03__Recurring_Donation__c convertedRD = new RD2_DataMigrationMapper(getRecords()[0])
+            .convertToEnhancedRD();
+
+        System.assertEquals(AMOUNT_VALUE / installments, convertedRD.npe03__Amount__c, 'Amount should be copied from Installment Amount');
+        System.assertEquals(RD2_Constants.RECURRING_TYPE_FIXED, convertedRD.RecurringType__c, 'Recurring Type should be Fixed');
+        System.assertEquals(installments, convertedRD.npe03__Installments__c, 'Number of Planned Installments should be unchanged');
+    }
 
     /**
      * @description Verifies Start Date is set to Date Established when


### PR DESCRIPTION
Amount on RD should be the same as the Installment Amount when Schedule Type is null for a fixed-length RD after RD2 enablement migration and RD2 nightly batch jobs are executed.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
