### PR TITLE
RD2: Health Check allows Day of Month picklist values of 29 and 30

### DIFF
--- a/src/classes/STG_PanelRDHealthCheck.cls
+++ b/src/classes/STG_PanelRDHealthCheck.cls
@@ -416,7 +416,7 @@ public inherited sharing class STG_PanelRDHealthCheck {
          */
         private Set<String> getSupportedDayOfMonth() {
             Set<String> values = new Set<String>();
-            for (Integer i = 0; i < 29; i++) {
+            for (Integer i = 0; i < 31; i++) {
                 values.add(String.valueOf(i));
             }
 

--- a/src/classes/STG_PanelRDHealthCheck_TEST.cls
+++ b/src/classes/STG_PanelRDHealthCheck_TEST.cls
@@ -117,17 +117,17 @@ private class STG_PanelRDHealthCheck_TEST {
         }
 
         // Since RD1 is enabled by default, there are 4 configuration errors:
-        // - Quarterly in the Installment Period field
-        // - 29,30,31 in the DayOfMonth field
-        System.assertEquals(4, errCount,
-            'There should exactly four entries in this validation.\n' + results
+        // - Value of Quarterly in the Installment Period field
+        // - Value of 31 in the DayOfMonth field
+        System.assertEquals(2, errCount,
+            'Number of entries in the validation should match.\n' + results
         );
 
         System.assert(errResults.contains(RD_Constants.INSTALLMENT_PERIOD_QUARTERLY),
             'The error should reference the "' + RD_Constants.INSTALLMENT_PERIOD_QUARTERLY + '" picklist value.\n' + errResults
         );
-        System.assert(errResults.contains('29'),
-            'The error should reference the "29" picklist value.\n' + errResults
+        System.assert(errResults.contains('31'),
+            'The error should reference the "31" picklist value.\n' + errResults
         );
     }
 


### PR DESCRIPTION
When Enhanced Recurring Donations are enabled, HealthCheck will not report an issue for unsupported picklist values when "Day of Month" field on Recurring Donation SObject has values of "29" and "30" as active.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
