### PR TITLE
RD2: Data Migration handles Day of Month values of 29 and 30

### DIFF
--- a/src/classes/RD2_DataMigrationMapper.cls
+++ b/src/classes/RD2_DataMigrationMapper.cls
@@ -39,7 +39,7 @@ public class RD2_DataMigrationMapper {
     /**
     * @description Defines mock "Day of Month" last day value for dry run data migration
     */
-    private static final String DRY_RUN_DAY_OF_MONTH_LAST_DAY = '28';
+    private static final String DRY_RUN_DAY_OF_MONTH_LAST_DAY = '30';
 
     /**
     * @description Recurring Donation to convert to enhanced format
@@ -233,7 +233,7 @@ public class RD2_DataMigrationMapper {
      * @return void
      */
     private void setDayOfMonth(npe03__Recurring_Donation__c rd) {
-        Set<String> lastDaysOfMonth = new Set<String>{ '29', '30', '31' };
+        final String lastDayOfMonth = '31';
 
         if (rd.Always_Use_Last_Day_Of_Month__c == false
             && String.isEmpty(rd.Day_of_Month__c)
@@ -242,7 +242,7 @@ public class RD2_DataMigrationMapper {
         }
 
         if (rd.Always_Use_Last_Day_Of_Month__c == true
-            || lastDaysOfMonth.contains(rd.Day_of_Month__c)
+            || rd.Day_of_Month__c == lastDayOfMonth
         ) {
             rd.Day_of_Month__c = isDryRunMode
                 ? DRY_RUN_DAY_OF_MONTH_LAST_DAY

--- a/src/classes/RD2_DataMigration_TEST.cls
+++ b/src/classes/RD2_DataMigration_TEST.cls
@@ -594,10 +594,10 @@ private class RD2_DataMigration_TEST {
      * @description Verifies Day of Month is unchanged when it is not the last day of month
      */
     @IsTest
-    private static void shouldNotChangeDayOfMonth() {
+    private static void shouldNotChangeDayOfMonthWhenDayOfMonthIsNot31() {
         TEST_RecurringDonationBuilder rdBuilder = getLegacyRecurringDonationBuilder();
 
-        for (Integer i = 1; i < 29; i++) {
+        for (Integer i = 1; i < 31; i++) {
             String dayOfMonth = String.valueOf(i);
 
             npe03__Recurring_Donation__c convertedRD = new RD2_DataMigrationMapper(
@@ -612,29 +612,19 @@ private class RD2_DataMigration_TEST {
     }
 
     /**
-     * @description Verifies Day of Month is set as Last Day for specific RDs
+     * @description Verifies Day of Month is set as Last Day when Day of Month has "31" as the value
      */
     @IsTest
-    private static void shouldSetDayOfMonthAsTheLastDay() {
-        List<npe03__Recurring_Donation__c> convertedRDs = new List<npe03__Recurring_Donation__c>();
-        TEST_RecurringDonationBuilder rdBuilder = getLegacyRecurringDonationBuilder();
-
-        for (Integer i = 28; i <= 31; i++) {
-            Boolean useLastDayOfMonth = i == 28;
-
-            convertedRDs.add(new RD2_DataMigrationMapper(
-                rdBuilder
-                    .withAlwaysUseLastDayOfMonth(useLastDayOfMonth)
-                    .withDayOfMonth(String.valueOf(i))
+    private static void shouldSetDayOfMonthAsTheLastDayWhenDayOfMonthIs31() {
+        npe03__Recurring_Donation__c convertedRD = new RD2_DataMigrationMapper(
+                getLegacyRecurringDonationBuilder()
+                    .withAlwaysUseLastDayOfMonth(false)
+                    .withDayOfMonth(String.valueOf('31'))
                     .build()
-                ).convertToEnhancedRD()
-            );
-        }
+            ).convertToEnhancedRD();
 
-        for (npe03__Recurring_Donation__c convertedRD : convertedRDs) {
-            System.assertEquals(RD2_Constants.DAY_OF_MONTH_LAST_DAY, convertedRD.Day_of_Month__c,
-                'Day of Month should be Last Day');
-        }
+        System.assertEquals(RD2_Constants.DAY_OF_MONTH_LAST_DAY, convertedRD.Day_of_Month__c,
+            'Day of Month should be Last Day when original value is "31"');
     }
 
     /**
@@ -646,8 +636,6 @@ private class RD2_DataMigration_TEST {
         TEST_RecurringDonationBuilder rdBuilder = getLegacyRecurringDonationBuilder();
 
         for (Integer i = 1; i <= 31; i++) {
-            Boolean useLastDayOfMonth = i == 28;
-
             convertedRDs.add(new RD2_DataMigrationMapper(
                 rdBuilder
                     .withNextPaymentDate(Date.newInstance(2019, 10, i))
@@ -672,8 +660,6 @@ private class RD2_DataMigration_TEST {
         TEST_RecurringDonationBuilder rdBuilder = getLegacyRecurringDonationBuilder();
 
         for (Integer i = 1; i <= 31; i++) {
-            Boolean useLastDayOfMonth = i == 28;
-
             convertedRDs.add(new RD2_DataMigrationMapper(
                 rdBuilder
                     .withDateEstablished(Date.newInstance(2019, 10, i))
@@ -1766,12 +1752,12 @@ private class RD2_DataMigration_TEST {
     }
 
     /**
-     * @description Verifies no error is logged when legacy Recurring Donation has Day Of MOnth > 28
+     * @description Verifies no error is logged when legacy Recurring Donation has Day Of Month "31" and
      * when migration is run in a dry run mode
      */
     @IsTest
     private static void shouldNotLogErrorWhenDayOfMonthIsLastDayInDryRunMode() {
-        final String dayOfMonth = '29';
+        final String dayOfMonth = '31';
         npe03__Recurring_Donation__c rd = getLegacyRecurringDonationBuilder(getContact().Id)
             .withId(null)
             .withDayOfMonth(dayOfMonth)
@@ -2224,9 +2210,9 @@ private class RD2_DataMigration_TEST {
     private static void assertDayOfMonth(npe03__Recurring_Donation__c rd, Integer expectedDayOfMonth) {
         System.assertNotEquals(null, rd.Day_of_Month__c, 'Day of Month should not be null');
 
-        if (expectedDayOfMonth < 29) {
+        if (expectedDayOfMonth < 31) {
             System.assertEquals(expectedDayOfMonth, Integer.valueOf(rd.Day_of_Month__c),
-                'Day of Month should match the expected day when less than 29: '+ JSON.serialize(rd));
+                'Day of Month should match the expected day when less than 31: '+ JSON.serialize(rd));
         } else {
             System.assertEquals(RD2_Constants.DAY_OF_MONTH_LAST_DAY, rd.Day_of_Month__c,
                 'Day of Month should be set as the Last Day');
@@ -2234,7 +2220,7 @@ private class RD2_DataMigration_TEST {
     }
 
     /****
-    * @description Asserts if the error message contains Donor is required field error
+    * @description Asserts if the error message contain message about Donor being required on the RD
     * @param jobId Batch job Id
     * @param rd Recurring Donation record
     * @return void

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -277,23 +277,24 @@ public with sharing class RD2_ValidationService {
             return;
         }
 
-        if (rd.Day_of_Month__c != RD2_Constants.DAY_OF_MONTH_LAST_DAY) {
-            Integer dayOfMonth;
-            try {
-                dayOfMonth = Integer.valueOf(rd.Day_of_Month__c);
+        if (rd.Day_of_Month__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY) {
+            return;
+        }
 
-            } catch (Exception e) {
-            }
+        Integer dayOfMonth;
+        try {
+            dayOfMonth = Integer.valueOf(rd.Day_of_Month__c);
+        } catch (Exception e) {
+        }
 
-            Boolean isValid = dayOfMonth > 0 && dayOfMonth < 29;
+        Boolean isValid = dayOfMonth > 0 && dayOfMonth < 31;
 
-            if (!isValid) {
-                rd.addError(
-                    String.format(
-                        System.Label.RD2_DayOfMonthMustBeValid,
-                        new String[]{ rd.Day_of_Month__c })
-                );
-            }
+        if (!isValid) {
+            rd.addError(
+                String.format(
+                    System.Label.RD2_DayOfMonthMustBeValid,
+                    new String[]{ rd.Day_of_Month__c })
+            );
         }
     }
 

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -310,30 +310,25 @@ private with sharing class RD2_ValidationService_TEST {
     private static void shouldFailWhenDayOfMonthIsNotValidForMonthlyInstallments() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
-        TEST_RecurringDonationBuilder rdBuilder = getRecurringDonationBuilder()
-            .withContact(getContact().Id);
+        String day = '31';
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
+            .withContact(getContact().Id)
+            .withDayOfMonth(day)
+            .build();
 
-        for (String day : new Set<String>{
-            '29', '30', '31'
-        }) {
-            npe03__Recurring_Donation__c rd = rdBuilder
-                .withDayOfMonth(day)
-                .build();
-
-            String errMessage = '';
-            try {
-                insert rd;
-            } catch (Exception e) {
-                errMessage = e.getMessage();
-            }
-            String expectedMessage = String.format(
-                System.Label.RD2_DayOfMonthMustBeValid,
-                new String[]{day }
-            );
-            System.assert(errMessage.contains(expectedMessage),
-                'Day Of Month should be valid: ' + errMessage);
+        String errMessage = '';
+        try {
+            insert rd;
+        } catch (Exception e) {
+            errMessage = e.getMessage();
         }
 
+        String expectedMessage = String.format(
+            System.Label.RD2_DayOfMonthMustBeValid,
+            new String[]{ day }
+        );
+        System.assert(errMessage.contains(expectedMessage),
+            'The error message should contain invalud Day Of Month message: ' + errMessage);
     }
 
     /***
@@ -347,7 +342,7 @@ private with sharing class RD2_ValidationService_TEST {
             .withContact(getContact().Id);
 
         for (String day : new Set<String>{
-            '15', '10', '28'
+            '15', '10', '28', '29', '30'
         }) {
             npe03__Recurring_Donation__c rd = rdBuilder
                 .withDayOfMonth(day)

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1579,7 +1579,7 @@ If you&apos;re not sure how to resolve these errors, post a message in the Nonpr
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Validate Recurring Donations data if it is valid day of month</shortDescription>
-        <value>{0} is not a supported value for Day of Month. Select a value between 1 and 28 or select Last Day of Month.</value>
+        <value>{0} is not a supported value for Day of Month. Select a value between 1 and 30 or select Last Day of Month.</value>
     </labels>
     <labels>
         <fullName>RD2_DayOfMonthIsRequiredForMonthlyInstallment</fullName>

--- a/src/objects/RecurringDonationSchedule__c.object
+++ b/src/objects/RecurringDonationSchedule__c.object
@@ -334,6 +334,16 @@
                     <label>28</label>
                 </value>
                 <value>
+                    <fullName>29</fullName>
+                    <default>false</default>
+                    <label>29</label>
+                </value>
+                <value>
+                    <fullName>30</fullName>
+                    <default>false</default>
+                    <label>30</label>
+                </value>
+                <value>
                     <fullName>Last_Day</fullName>
                     <default>false</default>
                     <label>Last Day Of Month</label>


### PR DESCRIPTION
During Enhanced Recurring Donations enablement, Recurring Donations with a Day of Month values of 29 or 30 should be properly converted to the RD2 format while still retaining 29 and 30 picklist values.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
