### PR TITLE
CRLP:  Exclude currency conversion for custom numeric field rollups in a multi-currency org

### DIFF
--- a/src/classes/CRLP_Operation_SVC.cls
+++ b/src/classes/CRLP_Operation_SVC.cls
@@ -183,8 +183,10 @@ public class CRLP_Operation_SVC {
     private static Decimal convertAmountToCurrency(Decimal amount, CRLP_Rollup rollup, SObject amtSObject, Date dateValue) {
 
         // If the amount is not null or zero, then convert to the Account currency as required
-        if (amount == null || amount == 0 || !UTIL_Currency.getInstance().isMultiCurrencyOrganization()
-            || rollup.amountFieldType != Schema.DisplayType.Currency) {
+        if (amount == null || amount == 0
+            || !UTIL_Currency.getInstance().isMultiCurrencyOrganization()
+            || rollup.amountFieldType != Schema.DisplayType.Currency
+            ) {
             return amount;
         }
 

--- a/src/classes/CRLP_Operation_SVC.cls
+++ b/src/classes/CRLP_Operation_SVC.cls
@@ -183,7 +183,8 @@ public class CRLP_Operation_SVC {
     private static Decimal convertAmountToCurrency(Decimal amount, CRLP_Rollup rollup, SObject amtSObject, Date dateValue) {
 
         // If the amount is not null or zero, then convert to the Account currency as required
-        if (amount == null || amount == 0 || !UTIL_Currency.getInstance().isMultiCurrencyOrganization()) {
+        if (amount == null || amount == 0 || !UTIL_Currency.getInstance().isMultiCurrencyOrganization()
+            || rollup.amountFieldType != Schema.DisplayType.Currency) {
             return amount;
         }
 

--- a/src/classes/CRLP_Operation_SVC.cls
+++ b/src/classes/CRLP_Operation_SVC.cls
@@ -186,7 +186,7 @@ public class CRLP_Operation_SVC {
         if (amount == null || amount == 0
             || !UTIL_Currency.getInstance().isMultiCurrencyOrganization()
             || rollup.amountFieldType != Schema.DisplayType.Currency
-            ) {
+        ) {
             return amount;
         }
 

--- a/src/classes/CRLP_Operation_SVC.cls
+++ b/src/classes/CRLP_Operation_SVC.cls
@@ -45,6 +45,9 @@ public class CRLP_Operation_SVC {
     /* @description 'Name' of the object referenced in the rollup. Visible to classes that extend this virtual class. */
     private static final String oppObjectName = UTIL_Describe.getObjectDescribe('Opportunity').getName();
 
+    /* @description Is the Org enabled for Multi-Currency */
+    private static final Boolean isMultiCurrencyOrg = UTIL_Currency.getInstance().isMultiCurrencyOrganization();
+
     /**
      * @description Perform the rollup operation based on the details in the CRLP_Rollup_SVC.Rollup instance
      * against the passed  SObjects
@@ -184,7 +187,7 @@ public class CRLP_Operation_SVC {
 
         // If the amount is not null or zero, then convert to the Account currency as required
         if (amount == null || amount == 0
-            || !UTIL_Currency.getInstance().isMultiCurrencyOrganization()
+            || !isMultiCurrencyOrg
             || rollup.amountFieldType != Schema.DisplayType.Currency
         ) {
             return amount;
@@ -240,7 +243,7 @@ public class CRLP_Operation_SVC {
             CRLP_Operation.RollupType operation = CRLP_Operation.getRollupTypeFromString(r.operation);
 
             // If the ResultField (DetailField) is the same as the Amount Field, then just get the value that
-            // was retrieved/converted in the code block above. Otherwise retrieve and convert as required.
+            // was retrieved/converted in the code block above. Otherwise retrieve and convert.
             if (r.detailField == amtField && r.detailObject == oppObjectName) {
                 resultVal = amountValue;
             } else {
@@ -250,10 +253,16 @@ public class CRLP_Operation_SVC {
 
                 // If the result field is a currency type field and multi-currency is enabled in the org
                 // then convert it to the target currency
-                if (resultVal != null && r.resultFieldDisplayType == DisplayType.CURRENCY &&
-                    UTIL_Currency.getInstance().isMultiCurrencyOrganization()) {
-                    String fromCurrCode = UserInfo.getDefaultCurrency(); // default just in case there's an issue getting the detail record currency
-                    resultVal = UTIL_CurrencyConversion.convertAmount((Decimal) resultVal, dateValue, fromCurrCode, rollup.currCode);
+                if (resultVal != null && r.resultFieldDisplayType == DisplayType.CURRENCY && isMultiCurrencyOrg) {
+                    String fromCurrency = UserInfo.getDefaultCurrency(); // default just in case there's an issue getting the detail record currency
+                    try {
+                        Object currencyIsoCode = (r.detailObject == oppObjectName ?
+                            oppSObject.get('CurrencyIsoCode') : detailSObject.get('CurrencyIsoCode'));
+                        if (currencyIsoCode != null) {
+                            fromCurrency = (String) currencyIsoCode;
+                        }
+                    } catch (Exception ex) { }
+                    resultVal = UTIL_CurrencyConversion.convertAmount((Decimal) resultVal, dateValue, fromCurrency, rollup.currCode);
                 }
             }
 

--- a/src/classes/CRLP_Rollup.cls
+++ b/src/classes/CRLP_Rollup.cls
@@ -54,7 +54,7 @@ public class CRLP_Rollup {
     public String detailObject;
     public String amountObject;
     public String amountFieldName;
-    public DisplayType amountFieldType;
+    public Schema.DisplayType amountFieldType;
     public String dateObject;
     public String dateFieldName;
     public SoapType dateFieldType;

--- a/src/classes/CRLP_Rollup.cls
+++ b/src/classes/CRLP_Rollup.cls
@@ -54,6 +54,7 @@ public class CRLP_Rollup {
     public String detailObject;
     public String amountObject;
     public String amountFieldName;
+    public DisplayType amountFieldType;
     public String dateObject;
     public String dateFieldName;
     public SoapType dateFieldType;
@@ -135,6 +136,8 @@ public class CRLP_Rollup {
 
         // Don't get the amount field if the operation is a Count
         if (this.amountFieldName == null && rlp.Amount_Field__c != null && rlp.Operation__c != CRLP_Operation.RollupType.Count.name()) {
+            DescribeFieldResult amountField = CRLP_Rollup_SVC.getSObjectFieldDescribe(amountObject, rlp.Amount_Field__r.QualifiedApiName);
+            this.amountFieldType = amountField.getType();
             this.amountFieldName = rlp.Amount_Field__r.QualifiedApiName;
         }
 

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -255,7 +255,6 @@ public class CRLP_RollupContact_TEST {
      * 4. Nightly LDV Batch Job
      */
     private static void testRollupsServices(TestType tt) {
-        Map<Id, Contact> mapConIdCon;
         // Start by enabling Customizable Rollups (which disables all legacy rollup operations)
         UTIL_CustomSettingsFacade.getRollupSettingsForTests(new Customizable_Rollup_Settings__c (
                 Customizable_Rollups_Enabled__c = true,
@@ -483,10 +482,10 @@ public class CRLP_RollupContact_TEST {
         Test.stopTest();
 
         // Query the Contact with all the target fields specified in the rollups
-        String baseContactQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType);
-        mapConIdCon = new Map<Id, Contact>((List<Contact>)Database.query(baseContactQuery));
-        c = mapConIdCon.get(conId);
-        c4 = mapConIdCon.get(con4Id);
+        String conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :conId LIMIT 1';
+        c = Database.query(conQuery);
+        conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :con4Id LIMIT 1';
+        c4 = Database.query(conQuery);
 
         // If the AlwaysRollupToPrimaryContact field is checked, the totals will include the org donation
         if (tt == TestType.TestWithAlwaysRollupToPrimary) {
@@ -534,11 +533,13 @@ public class CRLP_RollupContact_TEST {
         if (tt == TestType.TestBatch) {
             // Contact2.npo02__NumberOfClosedOpps__c was set to 100, but has attached opps, so it should be reset to 0.
             Id c2Id = c2.Id;
-            c2 = mapConIdCon.get(c2Id);
+            conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :c2Id LIMIT 1';
+            c2 = database.query(conQuery);
             System.assertEquals(0, c2.npo02__NumberOfClosedOpps__c);
 
             Id c3Id = c3.Id;
-            c3 = mapConIdCon.get(c3Id);
+            conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :c3Id LIMIT 1';
+            c3 = database.query(conQuery);
             System.assertEquals(null, c3.npo02__NumberOfClosedOpps__c);
         }
     }

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -535,6 +535,8 @@ public class CRLP_RollupContact_TEST {
             c2 = database.query(conQuery);
             System.assertEquals(0, c2.npo02__NumberOfClosedOpps__c);
 
+            // Contact3.npo02__NumberOfClosedOpps__c was set to null and has attached opps, so it remain as
+            // null (vs. being reset to 0).
             Id c3Id = c3.Id;
             conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :c3Id LIMIT 1';
             c3 = database.query(conQuery);

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -37,8 +37,12 @@
 public class CRLP_RollupContact_TEST {
 
     private Enum TestType {
-        TestTrigger, TestQueueuable, TestBatch, testSkewBatch, TestWithAlwaysRollupToPrimary
+        TestTrigger, TestQueueuable, TestBatch, testSkewBatch, TestMultiCurrBatch, TestWithAlwaysRollupToPrimary
     }
+
+    private static String otherCurrencyCode;
+
+    private static String defaultCurrCode = UserInfo.getDefaultCurrency();
 
     /**
      * @description Test Setup: Insert a dummy contact and let it create an Account. The Opportunity data has to
@@ -48,7 +52,8 @@ public class CRLP_RollupContact_TEST {
     private static void setupBaseTestData() {
         Contact c1 = UTIL_UnitTestData_TEST.getContact();
         Contact c2 = UTIL_UnitTestData_TEST.getContact();
-        insert new List<Contact>{c1, c2};
+        Contact c3 = UTIL_UnitTestData_TEST.getContact();
+        insert new List<Contact>{c1, c2, c3};
     }
 
     /**
@@ -218,6 +223,10 @@ public class CRLP_RollupContact_TEST {
                         CMT_UnitTestData_TEST.RollupRecordType.PmtToContact,
                         'First_Soft_Credit_Amount__c', CRLP_Operation.RollupType.SUM, 'npe01__Payment_Amount__c') + ',' +
 
+                 CMT_UnitTestData_TEST.createRollupRecord('Sum of Number in multicurrency', null,
+                        CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
+                        'custom_cont_num__c', CRLP_Operation.RollupType.SUM, 'custom_number__c') + ',' +
+
                 CMT_UnitTestData_TEST.createRollupRecord('Total Writeoffs', filterGroupId2,
                         CMT_UnitTestData_TEST.RollupRecordType.PmtToContact,
                         'npo02__LastMembershipAmount__c', CRLP_Operation.RollupType.SUM, 'npe01__Payment_Amount__c') +
@@ -244,6 +253,49 @@ public class CRLP_RollupContact_TEST {
         testRollupsServices(TestType.TestWithAlwaysRollupToPrimary);
     }
 
+    @isTest
+    public static void test_Rollups_ForMultiCurrencyOrg() {
+        //CRLP_RollupAccount_TEST.test_Rollups_MultiCurrencyBatch();
+        setUpMultiCurrencyOrg();
+        testRollupsServices(TestType.TestMultiCurrBatch);
+
+    }
+    private static void setUpMultiCurrencyOrg() {
+        // Test is only relevant for multi-currency organizations.  If not, skip it
+        if (!UserInfo.isMultiCurrencyOrganization()) {
+            return;
+        }
+
+        CRLP_RollupAccount_TEST.UtilCurrencyCacheMock mockCurrencyCache = new CRLP_RollupAccount_TEST.UtilCurrencyCacheMock();
+        UTIL_CurrencyCache.instance = mockCurrencyCache;
+
+        // Define a simple 2x exchange rate to use for this test
+        mockCurrencyCache.effectiveRatesReturn = new List<Decimal>{ 2.0 };
+        mockCurrencyCache.effectiveDatesReturn = new List<Date>{ Date.newInstance(1900,1,1) };
+
+        // Test is only relevant if the multicurrency org actually has multiple currencies.   If not, skip it
+        SObject[] currencies = Database.query('SELECT IsoCode FROM CurrencyType WHERE IsActive = True');
+        if (currencies.size() <= 1) {
+            return;
+        }
+
+        // Get another currency code to use for the future tests
+        for (SObject curr : currencies) {
+            if ((String)curr.get('IsoCode') != defaultCurrCode) {
+                otherCurrencyCode = (String)curr.get('IsoCode');
+                break;
+            }
+        }
+
+        // Enable for standard currency management in the mock
+        UTIL_Currency_TEST.UtilCurrencyMock mockCurr = new UTIL_Currency_TEST.UtilCurrencyMock();
+        UTIL_Currency.instance = mockCurr;
+        mockCurr.orgDefaultCurrencyReturn = defaultCurrCode;
+        mockCurr.getDefaultCurrencyReturn = defaultCurrCode;
+        mockCurr.isAdvancedCurrencyManagementEnabledReturn = false; // we're forcing the rates rather than attempting to query
+        mockCurr.isMultiCurrencyOrganizationReturn = true;
+    }
+
     /**
      * @description Test some simple rollups from the Opportunity/Payment object to the Contact using
      * four different methods:
@@ -253,7 +305,8 @@ public class CRLP_RollupContact_TEST {
      * 4. Nightly LDV Batch Job
      */
     private static void testRollupsServices(TestType tt) {
-
+        Contact multiCurrCont;
+        Map<Id, Contact> mapConIdCon;
         // Start by enabling Customizable Rollups (which disables all legacy rollup operations)
         UTIL_CustomSettingsFacade.getRollupSettingsForTests(new Customizable_Rollup_Settings__c (
                 Customizable_Rollups_Enabled__c = true,
@@ -311,6 +364,7 @@ public class CRLP_RollupContact_TEST {
         insert orgAcct;
 
         String closedStage = UTIL_UnitTestData_TEST.getClosedWonStage();
+        String openStage = UTIL_UnitTestData_TEST.getOpenStage();
         Id rtId = UTIL_RecordTypes.getRecordTypeIdForGiftsTests(Opportunity.SObjectType);
 
         List<Opportunity> opps = new List<Opportunity>();
@@ -384,6 +438,49 @@ public class CRLP_RollupContact_TEST {
             String donationYr = UTIL_String.removeNonNumericCharacters(orgDonationDate.year().format());
             donationYears.add(donationYr);
         }
+        if (tt == TestType.TestMultiCurrBatch) {
+
+            multiCurrCont = UTIL_UnitTestData_TEST.getContact();
+            insert multiCurrCont;
+            //Contact multiCurrCont = [SELECT Id, FirstName, LastName, AccountId FROM Contact where Id =:cont.Id];
+            //multiCurrCont.put('CurrencyIsoCode', otherCurrencyCode);
+            multiCurrCont.CurrencyIsoCode = otherCurrencyCode;
+            Id acc = multiCurrCont.AccountId;
+
+            Database.update(multiCurrCont);
+            Opportunity opp = new Opportunity(
+                Name = 'Test MultiCurrencyOpp',
+                CloseDate = Date.today().addDays(10),
+                Amount = 50,
+                StageName = openStage,
+                AccountId = multiCurrCont.AccountId,
+                Primary_Contact__c = multiCurrCont.Id,
+                RecordTypeId = rtId,
+                npe01__Do_Not_Automatically_Create_Payment__c = true,
+                custom_number__c = 100,
+                Type = 'New'
+
+            );
+
+            Opportunity opp2 = new Opportunity(
+                Name = 'Test MultiCurrencyOpp2',
+                CloseDate = Date.today().addDays(2),
+                Amount = 100,
+                StageName = openStage,
+                AccountId = multiCurrCont.AccountId,
+                Primary_Contact__c = multiCurrCont.Id,
+                RecordTypeId = rtId,
+                npe01__Do_Not_Automatically_Create_Payment__c = true,
+                custom_number__c = 200,
+                Type = 'New'
+
+            );
+            opp.put('CurrencyIsoCode', defaultCurrCode);
+            opp2.put('CurrencyIsoCode', defaultCurrCode);
+            opps.add(opp);
+            opps.add(opp2);
+
+        }
 
         // create 4 opps for con4 to test single result opp edge cases
         Date earlyLastYear = Date.newInstance(Date.today().year()-1,1,1);
@@ -438,7 +535,7 @@ public class CRLP_RollupContact_TEST {
                 Type = 'New'
         ));
 
-        insert opps;
+           insert opps;
 
         // Mark two payments as written off; though only one should be rolled up
         npe01__OppPayment__c pmt1 = [SELECT npe01__Written_Off__c, npe01__Paid__c FROM npe01__OppPayment__c
@@ -469,7 +566,7 @@ public class CRLP_RollupContact_TEST {
         if (tt == TestType.TestTrigger) {
             // No need to execute anything special here. If the triggers worked as expected, then
             // the data will be rolled up automatically upon the stopTest().
-        } else if (tt == TestType.TestBatch) {
+        } else if (tt == TestType.TestBatch || tt == TestType.TestMultiCurrBatch) {
             CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
                     CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode, null, null);
         } else if (tt == TestType.testSkewBatch) {
@@ -481,10 +578,10 @@ public class CRLP_RollupContact_TEST {
         Test.stopTest();
 
         // Query the Contact with all the target fields specified in the rollups
-        String conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :conId LIMIT 1';
-        c = Database.query(conQuery);
-        conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :con4Id LIMIT 1';
-        c4 = Database.query(conQuery);
+        String baseContactQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType);
+        mapConIdCon = new Map<Id, Contact>((List<Contact>)Database.query(baseContactQuery));
+        c = mapConIdCon.get(conId);
+        c4 = mapConIdCon.get(con4Id);
 
         // If the AlwaysRollupToPrimaryContact field is checked, the totals will include the org donation
         if (tt == TestType.TestWithAlwaysRollupToPrimary) {
@@ -498,6 +595,11 @@ public class CRLP_RollupContact_TEST {
             }
         }
 
+        if (tt == TestType.TestMultiCurrBatch) {
+            Contact con = mapConIdCon.get(multiCurrCont.Id);
+            System.debug('Here is the contact with multicurrency:' + con);
+            System.assertEquals(300, con.custom_cont_num__c, 'The number of closed won opps should be equal to ' + 300);
+        }
         // Basic rollup asserts using existing NPSP rollup fields.
         System.assertEquals(cnt, c.npo02__NumberOfClosedOpps__c);
         System.assertEquals(totalDonations, c.npo02__TotalOppAmount__c);
@@ -507,11 +609,12 @@ public class CRLP_RollupContact_TEST {
         System.assertEquals(totalDonations.divide(cnt, 2, System.RoundingMode.HALF_UP), c.npo02__AverageAmount__c);
         System.assertEquals(total2YearsAgo, c.npo02__OppAmount2YearsAgo__c);
         System.assertEquals(bestGiftYear, c.npo02__Best_Gift_Year__c);
-        System.assertEquals(last365Days, c.npo02__OppAmountLastNDays__c);
+        System.assertEquals(last365Days, c.npo02__OppAmountLastNDays__c, 'what is the number' + last365Days);
         System.assertEquals('New', c.Department);
 
         System.assertEquals(1, c.npo02__OppsClosed2YearsAgo__c, 'The number of close lost opps should be 1');
         System.assertEquals(wonCountLastYear, c.npo02__OppsClosedLastYear__c, 'The number of closed won opps should be equal to ' + wonCountLastYear);
+
 
         // These 10 use other fields on the Contact object since there are no NPSP related fields to store the values in
         System.assertEquals(totalPayments, c.First_Soft_Credit_Amount__c,
@@ -531,15 +634,11 @@ public class CRLP_RollupContact_TEST {
         if (tt == TestType.TestBatch) {
             // Contact2.npo02__NumberOfClosedOpps__c was set to 100, but has attached opps, so it should be reset to 0.
             Id c2Id = c2.Id;
-            conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :c2Id LIMIT 1';
-            c2 = database.query(conQuery);
+            c2 = mapConIdCon.get(c2Id);
             System.assertEquals(0, c2.npo02__NumberOfClosedOpps__c);
 
-            // Contact3.npo02__NumberOfClosedOpps__c was set to null and has attached opps, so it remain as
-            // null (vs. being reset to 0).
             Id c3Id = c3.Id;
-            conQuery = CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :c3Id LIMIT 1';
-            c3 = database.query(conQuery);
+            c3 = mapConIdCon.get(c3Id);
             System.assertEquals(null, c3.npo02__NumberOfClosedOpps__c);
         }
     }

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -545,11 +545,19 @@ public class CRLP_RollupContact_TEST {
     }
 
      /**
-     * @description Verifies the SUM on numeric source field will not use currency conversion
-     * when calculating the target field value
+     * @description Multi-Currency Specific tests:
+     * 1. Verifies the SUM on numeric source field will not use currency conversion when calculating the target field value
+     * 2. Verifies that a SingleResultRollup (Largest Gift) is properly converted
      */
     @isTest
-    private static void shouldSumNumericFieldValuesWithoutUsingCurrencyConversion() {
+    private static void shouldHandleCurrencyConversionWhereNeeded() {
+        final Decimal oppAmountUSD = 100;
+        final Decimal oppAmountCAD = 500;
+
+        if (!UserInfo.isMultiCurrencyOrganization()) {
+            return;
+        }
+        
         // Enable Customizable Rollups (which disables all legacy rollup operations)
         UTIL_CustomSettingsFacade.getRollupSettingsForTests(new Customizable_Rollup_Settings__c (
             Customizable_Rollups_Enabled__c = true,
@@ -565,8 +573,11 @@ public class CRLP_RollupContact_TEST {
             CMT_UnitTestData_TEST.createRollupRecord('Number field in the SUM rollup', null,
                 CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
                 'npo02__NumberOfClosedOpps__c', CRLP_Operation.RollupType.SUM,
-                null, 'Recurring_Donation_Installment_Number__c') +
-            ']';
+                null, 'Recurring_Donation_Installment_Number__c') + ',' +
+            CMT_UnitTestData_TEST.createRollupRecord('Largest Gift Amount', null,
+                    CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
+                    'npo02__LargestAmount__c', CRLP_Operation.RollupType.FIRST, 'Amount') +
+        ']';
 
         // Deserialize the rollups to use for testing
         CRLP_Rollup_SEL.cachedRollups = (List<Rollup__mdt>) JSON.deserialize(rollupsJSON, List<Rollup__mdt>.class);
@@ -576,21 +587,23 @@ public class CRLP_RollupContact_TEST {
 
         final Date closeDate = Date.newInstance(2019, 6, 15);
         TEST_OpportunityBuilder oppBuilder = new TEST_OpportunityBuilder()
-            .withContact(c.Id)
-            .withAmount(100);
+            .withContact(c.Id);
 
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withCurrencyIsoCode('CAD')
+                .withAmount(oppAmountCAD)
                 .withCloseDate(closeDate)
                 .withClosedWonStage()
                 .withInstallmentNumber(10)
                 .build(),
             oppBuilder
                 .withCurrencyIsoCode('USD')
+                .withAmount(oppAmountUSD)
                 .withCloseDate(closeDate.addMonths(1))
                 .withOpenStage()
                 .withInstallmentNumber(15)
+                .withAmount(500)
                 .build()
         };
 
@@ -604,7 +617,11 @@ public class CRLP_RollupContact_TEST {
             CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :contactId LIMIT 1'
         );
 
+        Decimal convertedAmt = UTIL_CurrencyConversion.convertAmountUsingStandardRates('CAD', 'USD', oppAmountCAD);
+
         System.assertEquals(25, c.npo02__NumberOfClosedOpps__c,
             'Rollup target field should contain sum of numeric field values without currency conversion');
-    }
+        System.assertEquals(convertedAmt, c.npo02__LargestAmount__c,
+            'The Largest Gift Amount should be equal to the CAD amount converted to USD');
+   }
 }

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -218,8 +218,6 @@ public class CRLP_RollupContact_TEST {
                         CMT_UnitTestData_TEST.RollupRecordType.PmtToContact,
                         'First_Soft_Credit_Amount__c', CRLP_Operation.RollupType.SUM, 'npe01__Payment_Amount__c') + ',' +
 
-
-
                 CMT_UnitTestData_TEST.createRollupRecord('Total Writeoffs', filterGroupId2,
                         CMT_UnitTestData_TEST.RollupRecordType.PmtToContact,
                         'npo02__LastMembershipAmount__c', CRLP_Operation.RollupType.SUM, 'npe01__Payment_Amount__c') +

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -119,6 +119,10 @@ public class CRLP_RollupContact_TEST {
                         CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
                         'npo02__NumberOfClosedOpps__c', CRLP_Operation.RollupType.COUNT, null, 'Fair_Market_Value__c') + ',' +
 
+                CMT_UnitTestData_TEST.createRollupRecord('Sum of Number in multicurrency', null,
+                        CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
+                        'custom_cont_num__c', CRLP_Operation.RollupType.SUM, null,'custom_number__c') + ',' +
+
                 CMT_UnitTestData_TEST.createRollupRecord('Total Donations All Time', filterGroupId1,
                         CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
                         'npo02__TotalOppAmount__c', CRLP_Operation.RollupType.SUM, 'Amount') + ',' +
@@ -223,9 +227,7 @@ public class CRLP_RollupContact_TEST {
                         CMT_UnitTestData_TEST.RollupRecordType.PmtToContact,
                         'First_Soft_Credit_Amount__c', CRLP_Operation.RollupType.SUM, 'npe01__Payment_Amount__c') + ',' +
 
-                 CMT_UnitTestData_TEST.createRollupRecord('Sum of Number in multicurrency', null,
-                        CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
-                        'custom_cont_num__c', CRLP_Operation.RollupType.SUM, 'custom_number__c') + ',' +
+
 
                 CMT_UnitTestData_TEST.createRollupRecord('Total Writeoffs', filterGroupId2,
                         CMT_UnitTestData_TEST.RollupRecordType.PmtToContact,
@@ -443,21 +445,20 @@ public class CRLP_RollupContact_TEST {
             multiCurrCont = UTIL_UnitTestData_TEST.getContact();
             insert multiCurrCont;
             //Contact multiCurrCont = [SELECT Id, FirstName, LastName, AccountId FROM Contact where Id =:cont.Id];
-            //multiCurrCont.put('CurrencyIsoCode', otherCurrencyCode);
-            multiCurrCont.CurrencyIsoCode = otherCurrencyCode;
+            multiCurrCont.put('CurrencyIsoCode', otherCurrencyCode);
             Id acc = multiCurrCont.AccountId;
 
             Database.update(multiCurrCont);
             Opportunity opp = new Opportunity(
                 Name = 'Test MultiCurrencyOpp',
                 CloseDate = Date.today().addDays(10),
-                Amount = 50,
-                StageName = openStage,
+                Amount = 100,
+                StageName = closedStage,
                 AccountId = multiCurrCont.AccountId,
                 Primary_Contact__c = multiCurrCont.Id,
                 RecordTypeId = rtId,
                 npe01__Do_Not_Automatically_Create_Payment__c = true,
-                custom_number__c = 100,
+                custom_number__c = 10,
                 Type = 'New'
 
             );
@@ -466,12 +467,12 @@ public class CRLP_RollupContact_TEST {
                 Name = 'Test MultiCurrencyOpp2',
                 CloseDate = Date.today().addDays(2),
                 Amount = 100,
-                StageName = openStage,
+                StageName = closedStage,
                 AccountId = multiCurrCont.AccountId,
                 Primary_Contact__c = multiCurrCont.Id,
                 RecordTypeId = rtId,
                 npe01__Do_Not_Automatically_Create_Payment__c = true,
-                custom_number__c = 200,
+                custom_number__c = 7,
                 Type = 'New'
 
             );
@@ -598,7 +599,7 @@ public class CRLP_RollupContact_TEST {
         if (tt == TestType.TestMultiCurrBatch) {
             Contact con = mapConIdCon.get(multiCurrCont.Id);
             System.debug('Here is the contact with multicurrency:' + con);
-            System.assertEquals(300, con.custom_cont_num__c, 'The number of closed won opps should be equal to ' + 300);
+            System.assertEquals(17, con.custom_cont_num__c, 'The number of closed won opps should be equal to ' + 300);
         }
         // Basic rollup asserts using existing NPSP rollup fields.
         System.assertEquals(cnt, c.npo02__NumberOfClosedOpps__c);

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -40,10 +40,6 @@ public class CRLP_RollupContact_TEST {
         TestTrigger, TestQueueuable, TestBatch, testSkewBatch, TestWithAlwaysRollupToPrimary
     }
 
-    private static String otherCurrencyCode;
-
-    private static String defaultCurrCode = UserInfo.getDefaultCurrency();
-
     /**
      * @description Test Setup: Insert a dummy contact and let it create an Account. The Opportunity data has to
      * be created in the actual unit test to allow for the trigger test to run
@@ -514,7 +510,7 @@ public class CRLP_RollupContact_TEST {
         System.assertEquals(totalDonations.divide(cnt, 2, System.RoundingMode.HALF_UP), c.npo02__AverageAmount__c);
         System.assertEquals(total2YearsAgo, c.npo02__OppAmount2YearsAgo__c);
         System.assertEquals(bestGiftYear, c.npo02__Best_Gift_Year__c);
-        System.assertEquals(last365Days, c.npo02__OppAmountLastNDays__c, 'what is the number' + last365Days);
+        System.assertEquals(last365Days, c.npo02__OppAmountLastNDays__c);
         System.assertEquals('New', c.Department);
 
         System.assertEquals(1, c.npo02__OppsClosed2YearsAgo__c, 'The number of close lost opps should be 1');

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -313,7 +313,6 @@ public class CRLP_RollupContact_TEST {
         insert orgAcct;
 
         String closedStage = UTIL_UnitTestData_TEST.getClosedWonStage();
-        String openStage = UTIL_UnitTestData_TEST.getOpenStage();
         Id rtId = UTIL_RecordTypes.getRecordTypeIdForGiftsTests(Opportunity.SObjectType);
 
         List<Opportunity> opps = new List<Opportunity>();

--- a/src/classes/CRLP_RollupContact_TEST.cls
+++ b/src/classes/CRLP_RollupContact_TEST.cls
@@ -37,7 +37,7 @@
 public class CRLP_RollupContact_TEST {
 
     private Enum TestType {
-        TestTrigger, TestQueueuable, TestBatch, testSkewBatch, TestMultiCurrBatch, TestWithAlwaysRollupToPrimary
+        TestTrigger, TestQueueuable, TestBatch, testSkewBatch, TestWithAlwaysRollupToPrimary
     }
 
     private static String otherCurrencyCode;
@@ -52,8 +52,7 @@ public class CRLP_RollupContact_TEST {
     private static void setupBaseTestData() {
         Contact c1 = UTIL_UnitTestData_TEST.getContact();
         Contact c2 = UTIL_UnitTestData_TEST.getContact();
-        Contact c3 = UTIL_UnitTestData_TEST.getContact();
-        insert new List<Contact>{c1, c2, c3};
+        insert new List<Contact>{c1, c2};
     }
 
     /**
@@ -118,10 +117,6 @@ public class CRLP_RollupContact_TEST {
                 CMT_UnitTestData_TEST.createRollupRecord('Count Donations', filterGroupId1,
                         CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
                         'npo02__NumberOfClosedOpps__c', CRLP_Operation.RollupType.COUNT, null, 'Fair_Market_Value__c') + ',' +
-
-                CMT_UnitTestData_TEST.createRollupRecord('Sum of Number in multicurrency', null,
-                        CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
-                        'custom_cont_num__c', CRLP_Operation.RollupType.SUM, null,'custom_number__c') + ',' +
 
                 CMT_UnitTestData_TEST.createRollupRecord('Total Donations All Time', filterGroupId1,
                         CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
@@ -255,49 +250,6 @@ public class CRLP_RollupContact_TEST {
         testRollupsServices(TestType.TestWithAlwaysRollupToPrimary);
     }
 
-    @isTest
-    public static void test_Rollups_ForMultiCurrencyOrg() {
-        //CRLP_RollupAccount_TEST.test_Rollups_MultiCurrencyBatch();
-        setUpMultiCurrencyOrg();
-        testRollupsServices(TestType.TestMultiCurrBatch);
-
-    }
-    private static void setUpMultiCurrencyOrg() {
-        // Test is only relevant for multi-currency organizations.  If not, skip it
-        if (!UserInfo.isMultiCurrencyOrganization()) {
-            return;
-        }
-
-        CRLP_RollupAccount_TEST.UtilCurrencyCacheMock mockCurrencyCache = new CRLP_RollupAccount_TEST.UtilCurrencyCacheMock();
-        UTIL_CurrencyCache.instance = mockCurrencyCache;
-
-        // Define a simple 2x exchange rate to use for this test
-        mockCurrencyCache.effectiveRatesReturn = new List<Decimal>{ 2.0 };
-        mockCurrencyCache.effectiveDatesReturn = new List<Date>{ Date.newInstance(1900,1,1) };
-
-        // Test is only relevant if the multicurrency org actually has multiple currencies.   If not, skip it
-        SObject[] currencies = Database.query('SELECT IsoCode FROM CurrencyType WHERE IsActive = True');
-        if (currencies.size() <= 1) {
-            return;
-        }
-
-        // Get another currency code to use for the future tests
-        for (SObject curr : currencies) {
-            if ((String)curr.get('IsoCode') != defaultCurrCode) {
-                otherCurrencyCode = (String)curr.get('IsoCode');
-                break;
-            }
-        }
-
-        // Enable for standard currency management in the mock
-        UTIL_Currency_TEST.UtilCurrencyMock mockCurr = new UTIL_Currency_TEST.UtilCurrencyMock();
-        UTIL_Currency.instance = mockCurr;
-        mockCurr.orgDefaultCurrencyReturn = defaultCurrCode;
-        mockCurr.getDefaultCurrencyReturn = defaultCurrCode;
-        mockCurr.isAdvancedCurrencyManagementEnabledReturn = false; // we're forcing the rates rather than attempting to query
-        mockCurr.isMultiCurrencyOrganizationReturn = true;
-    }
-
     /**
      * @description Test some simple rollups from the Opportunity/Payment object to the Contact using
      * four different methods:
@@ -307,7 +259,6 @@ public class CRLP_RollupContact_TEST {
      * 4. Nightly LDV Batch Job
      */
     private static void testRollupsServices(TestType tt) {
-        Contact multiCurrCont;
         Map<Id, Contact> mapConIdCon;
         // Start by enabling Customizable Rollups (which disables all legacy rollup operations)
         UTIL_CustomSettingsFacade.getRollupSettingsForTests(new Customizable_Rollup_Settings__c (
@@ -440,48 +391,6 @@ public class CRLP_RollupContact_TEST {
             String donationYr = UTIL_String.removeNonNumericCharacters(orgDonationDate.year().format());
             donationYears.add(donationYr);
         }
-        if (tt == TestType.TestMultiCurrBatch) {
-
-            multiCurrCont = UTIL_UnitTestData_TEST.getContact();
-            insert multiCurrCont;
-            //Contact multiCurrCont = [SELECT Id, FirstName, LastName, AccountId FROM Contact where Id =:cont.Id];
-            multiCurrCont.put('CurrencyIsoCode', otherCurrencyCode);
-            Id acc = multiCurrCont.AccountId;
-
-            Database.update(multiCurrCont);
-            Opportunity opp = new Opportunity(
-                Name = 'Test MultiCurrencyOpp',
-                CloseDate = Date.today().addDays(10),
-                Amount = 100,
-                StageName = closedStage,
-                AccountId = multiCurrCont.AccountId,
-                Primary_Contact__c = multiCurrCont.Id,
-                RecordTypeId = rtId,
-                npe01__Do_Not_Automatically_Create_Payment__c = true,
-                custom_number__c = 10,
-                Type = 'New'
-
-            );
-
-            Opportunity opp2 = new Opportunity(
-                Name = 'Test MultiCurrencyOpp2',
-                CloseDate = Date.today().addDays(2),
-                Amount = 100,
-                StageName = closedStage,
-                AccountId = multiCurrCont.AccountId,
-                Primary_Contact__c = multiCurrCont.Id,
-                RecordTypeId = rtId,
-                npe01__Do_Not_Automatically_Create_Payment__c = true,
-                custom_number__c = 7,
-                Type = 'New'
-
-            );
-            opp.put('CurrencyIsoCode', defaultCurrCode);
-            opp2.put('CurrencyIsoCode', defaultCurrCode);
-            opps.add(opp);
-            opps.add(opp2);
-
-        }
 
         // create 4 opps for con4 to test single result opp edge cases
         Date earlyLastYear = Date.newInstance(Date.today().year()-1,1,1);
@@ -567,7 +476,7 @@ public class CRLP_RollupContact_TEST {
         if (tt == TestType.TestTrigger) {
             // No need to execute anything special here. If the triggers worked as expected, then
             // the data will be rolled up automatically upon the stopTest().
-        } else if (tt == TestType.TestBatch || tt == TestType.TestMultiCurrBatch) {
+        } else if (tt == TestType.TestBatch) {
             CRLP_RollupBatch_SVC.executeBatchRollupJob(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
                     CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode, null, null);
         } else if (tt == TestType.testSkewBatch) {
@@ -596,11 +505,6 @@ public class CRLP_RollupContact_TEST {
             }
         }
 
-        if (tt == TestType.TestMultiCurrBatch) {
-            Contact con = mapConIdCon.get(multiCurrCont.Id);
-            System.debug('Here is the contact with multicurrency:' + con);
-            System.assertEquals(17, con.custom_cont_num__c, 'The number of closed won opps should be equal to ' + 300);
-        }
         // Basic rollup asserts using existing NPSP rollup fields.
         System.assertEquals(cnt, c.npo02__NumberOfClosedOpps__c);
         System.assertEquals(totalDonations, c.npo02__TotalOppAmount__c);
@@ -642,5 +546,69 @@ public class CRLP_RollupContact_TEST {
             c3 = mapConIdCon.get(c3Id);
             System.assertEquals(null, c3.npo02__NumberOfClosedOpps__c);
         }
+    }
+
+     /**
+     * @description Verifies the SUM on numeric source field will not use currency conversion
+     * when calculating the target field value
+     */
+    @isTest
+    private static void shouldSumNumericFieldValuesWithoutUsingCurrencyConversion() {
+        // Enable Customizable Rollups (which disables all legacy rollup operations)
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(new Customizable_Rollup_Settings__c (
+            Customizable_Rollups_Enabled__c = true,
+            Rollups_Limit_on_Attached_Opps_for_Skew__c = 0,
+            Rollups_Skew_Dispatcher_Batch_Size__c = 200
+        ));
+
+        // Disable all legacy rollup triggers
+        UTIL_UnitTestData_TEST.disableRollupTriggers();
+
+        // Create a single rollup definition
+        String rollupsJSON = '[' +
+            CMT_UnitTestData_TEST.createRollupRecord('Number field in the SUM rollup', null,
+                CMT_UnitTestData_TEST.RollupRecordType.OppToContact,
+                'npo02__NumberOfClosedOpps__c', CRLP_Operation.RollupType.SUM,
+                null, 'Recurring_Donation_Installment_Number__c') +
+            ']';
+
+        // Deserialize the rollups to use for testing
+        CRLP_Rollup_SEL.cachedRollups = (List<Rollup__mdt>) JSON.deserialize(rollupsJSON, List<Rollup__mdt>.class);
+
+        Contact c = UTIL_UnitTestData_TEST.getContact();
+        insert c;
+
+        final Date closeDate = Date.newInstance(2019, 6, 15);
+        TEST_OpportunityBuilder oppBuilder = new TEST_OpportunityBuilder()
+            .withContact(c.Id)
+            .withAmount(100);
+
+        List<Opportunity> opps = new List<Opportunity>{
+            oppBuilder
+                .withCurrencyIsoCode('CAD')
+                .withCloseDate(closeDate)
+                .withClosedWonStage()
+                .withInstallmentNumber(10)
+                .build(),
+            oppBuilder
+                .withCurrencyIsoCode('USD')
+                .withCloseDate(closeDate.addMonths(1))
+                .withOpenStage()
+                .withInstallmentNumber(15)
+                .build()
+        };
+
+        Test.startTest();
+        insert opps;
+        Test.stopTest();
+
+        // Query the Contact with all the target fields specified in the rollups
+        Id contactId = c.Id;
+        c = Database.query(
+            CRLP_Query_SEL.buildObjectQueryForRollup(Contact.SObjectType) + ' WHERE Id = :contactId LIMIT 1'
+        );
+
+        System.assertEquals(25, c.npo02__NumberOfClosedOpps__c,
+            'Rollup target field should contain sum of numeric field values without currency conversion');
     }
 }

--- a/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls
+++ b/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls
@@ -1,6 +1,6 @@
 /**
 // Created by Michael Smith on 01/26/2018.
-// Last Modified on 04/03/2019 to disable new RD2 functionality and to improve multi-currency support
+// Last Modified on 04/03/2020 to disable new RD2 functionality and to improve multi-currency support
 //
 // - Deploy this using the "deploy_rollup_testing" CCI flow. That will create the necessary target fields
 //   on the Account object for Account-Contact Soft Credit, Account Soft Credit, and Payment Rollup testing.

--- a/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls
+++ b/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls
@@ -1,6 +1,6 @@
 /**
 // Created by Michael Smith on 01/26/2018.
-// Last Modified on 04/09/2019 to include in the deploy_rollup_testing cci flow
+// Last Modified on 04/03/2019 to disable new RD2 functionality and to improve multi-currency support
 //
 // - Deploy this using the "deploy_rollup_testing" CCI flow. That will create the necessary target fields
 //   on the Account object for Account-Contact Soft Credit, Account Soft Credit, and Payment Rollup testing.
@@ -40,6 +40,11 @@
 */
 public class CRLP_TEST_VALIDATE_ROLLUPS {
 
+    // ========================================================================
+    // NOTE: When testing in a multi-currency org, set up CAD with this rate:
+    private static final Double CURR_EXCHANGE_RATE = 2.0;
+    // ========================================================================
+
     // THE FOLLOWING CAN BE ADJUSTED BY THE RUNNING USER DURING THE TESTING TO ADJUST FOR ORG CONFIGURATION
     private static final Boolean ROLLUPS_INCLUDES_MEMBERSHIP = true;
     private static final Boolean ALLOC_INCLUDES_MEMBERSHIP = true;
@@ -57,9 +62,6 @@ public class CRLP_TEST_VALIDATE_ROLLUPS {
     private static final Integer OPP_COUNT_PER_ACCT = 500;
     private static final Integer CLOSED_OPP_COUNT_PER_ACCT = 450;
 
-    // When testing in a multi-currency org, set up CAD with this rate: 1.2311
-    private static final Double CURR_EXCHANGE_RATE = 2.0;
-
     private static final String ACCOUNT_NAME_RD = 'CRLP TEST ACCOUNT - RD';
     private static final String ACCOUNT_NAME_ORG = 'CRLP TEST ACCOUNT - ORG';
     private static final String ACCOUNT_NAME_ASC = 'CRLP TEST ACCOUNT - AccSoftCredit';
@@ -70,9 +72,10 @@ public class CRLP_TEST_VALIDATE_ROLLUPS {
     private static final String ACCOUNT_SOFT_CREDIT_ROLE_A = 'Influencer';
     private static final String ACCOUNT_SOFT_CREDIT_ROLE_B = 'Donation Source';
 
+    private static final Decimal OPPORTUNITY_AMOUNT_USD = BASE_AMOUNT_USD;
     private static final Decimal OPPORTUNITY_AMOUNT = (UserInfo.isMultiCurrencyOrganization() ? BASE_AMOUNT_USD*CURR_EXCHANGE_RATE : BASE_AMOUNT_USD);
-    private static final Decimal ACCOUNT_SOFT_CREDIT_BASE_AMOUNT = BASE_AMOUNT_USD/2;
-    private static final Decimal ACCOUNT_SOFT_CREDIT_AMOUNT = (UserInfo.isMultiCurrencyOrganization() ? ACCOUNT_SOFT_CREDIT_BASE_AMOUNT*CURR_EXCHANGE_RATE : ACCOUNT_SOFT_CREDIT_BASE_AMOUNT);
+    
+    private static final Decimal ACCOUNT_SOFT_CREDIT_AMOUNT = OPPORTUNITY_AMOUNT / 2;
 
     private static final Date MEMBERSHIP_FIRST_DATE = Date.newInstance(BASE_YEAR,6,30);
     private static final Decimal MEMBERSHIP_AMOUNT = 25;
@@ -83,7 +86,7 @@ public class CRLP_TEST_VALIDATE_ROLLUPS {
             + (ROLLUPS_INCLUDES_MEMBERSHIP ? MEMBERSHIP_TOTAL : 0);
     private static final Decimal ROLLUP_TOTAL_WON_COUNT = CLOSED_OPP_COUNT_PER_ACCT
             + (ROLLUPS_INCLUDES_MEMBERSHIP ? MEMBERSHIP_COUNT : 0);
-    private static final Decimal ROLLUP_TOTAL_LASTYEAR = (OPPORTUNITY_AMOUNT * MAX_OPPS_PER_YEAR)
+    private static final Decimal ROLLUP_TOTAL_LASTYEAR = (BASE_AMOUNT_USD * MAX_OPPS_PER_YEAR)
             + (ROLLUPS_INCLUDES_MEMBERSHIP ? MEMBERSHIP_AMOUNT : 0) ;
     private static final Decimal ROLLUP_AVERAGE = ROLLUP_TOTAL_WON_AMOUNT.divide(ROLLUP_TOTAL_WON_COUNT, 2, System.RoundingMode.HALF_UP);
     private static final Decimal ROLLUP_LARGEST = BASE_AMOUNT_USD;
@@ -436,7 +439,7 @@ public class CRLP_TEST_VALIDATE_ROLLUPS {
                     assertValue(ORG_DONATION_AMT, c.Largest_Soft_Credit_Amount__c, 'Org Contact.Largest_Soft_Credit_Amount__c should be');
                 }
                 assertValue(0, c.npo02__TotalOppAmount__c, 'Contact.npo02__TotalOppAmount__c should be');
-                assertValue(OPPORTUNITY_AMOUNT, (Double) c.get('First_Soft_Credit_Amount__c'), c.Id + ' Contact.First_Soft_Credit_Amount__c should be');
+                assertValue(OPPORTUNITY_AMOUNT_USD, (Double) c.get('First_Soft_Credit_Amount__c'), c.Id + ' Contact.First_Soft_Credit_Amount__c should be');
 
                 assertValue(null, c.npo02__MembershipJoinDate__c, 'Contact.npo02__MembershipJoinDate__c should be');
                 assertValue(null, c.npo02__MembershipEndDate__c, 'Contact.npo02__MembershipEndDate__c should be');
@@ -732,17 +735,26 @@ public class CRLP_TEST_VALIDATE_ROLLUPS {
     }
 
     private static void createTestingAllocationsAndAccountSoftCredits() {
+        npe03__Recurring_Donations_Settings__c rdSettings = npe03__Recurring_Donations_Settings__c.getOrgDefaults();
+        rdSettings.EnableAutomaticNaming__c = false;
+        update rdSettings;
+
         TDTM_Config_API.disableAllRollupTriggers();
 
         accounts = [SELECT Id, Name FROM Account WHERE Site = :TEST_SITE_NAME AND npe01__SYSTEMIsIndividual__c = true];
         contacts = [SELECT Id, FirstName, LastName FROM Contact WHERE Account.Site = :TEST_SITE_NAME];
         gau = [SELECT Id FROM General_Accounting_Unit__c WHERE Name = :GAU_NAME LIMIT 1];
 
-        List<Opportunity> opps = [
-            SELECT Id, AccountId, Amount, CloseDate, RecordTypeId, StageName
-            FROM Opportunity
-            WHERE Account.Site = :TEST_SITE_NAME
-        ];
+        UTIL_Query queryOpps = new UTIL_Query()
+            .withFrom(Opportunity.SObjectType)
+            .withSelectFields(new Set<String>{
+                'Id', 'AccountId', 'Amount', 'CloseDate', 'RecordTypeId', 'StageName'
+            })
+            .withWhere('Account.Site = :TEST_SITE_NAME');
+        if (UserInfo.isMultiCurrencyOrganization()) {
+            queryOpps.withSelectFields(new Set<String>{ 'CurrencyIsoCode' });
+        }
+        List<Opportunity> opps = Database.query(queryOpps.build());
 
         Account orgAcct = [
             SELECT Id, Name FROM Account

--- a/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls
+++ b/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls
@@ -75,7 +75,8 @@ public class CRLP_TEST_VALIDATE_ROLLUPS {
     private static final Decimal OPPORTUNITY_AMOUNT_USD = BASE_AMOUNT_USD;
     private static final Decimal OPPORTUNITY_AMOUNT = (UserInfo.isMultiCurrencyOrganization() ? BASE_AMOUNT_USD*CURR_EXCHANGE_RATE : BASE_AMOUNT_USD);
     
-    private static final Decimal ACCOUNT_SOFT_CREDIT_AMOUNT = OPPORTUNITY_AMOUNT / 2;
+    private static final Decimal ACCOUNT_SOFT_CREDIT_AMOUNT_USD = BASE_AMOUNT_USD / 2;
+    private static final Decimal ACCOUNT_SOFT_CREDIT_AMOUNT = (UserInfo.isMultiCurrencyOrganization() ? ACCOUNT_SOFT_CREDIT_AMOUNT_USD * CURR_EXCHANGE_RATE : ACCOUNT_SOFT_CREDIT_AMOUNT_USD);
 
     private static final Date MEMBERSHIP_FIRST_DATE = Date.newInstance(BASE_YEAR,6,30);
     private static final Decimal MEMBERSHIP_AMOUNT = 25;
@@ -313,8 +314,9 @@ public class CRLP_TEST_VALIDATE_ROLLUPS {
 
                 // Validate Account Soft Credits rollup to one Account, only when CRLPs is enabled
                 if (cs.Customizable_Rollups_Enabled__c == true && TEST_ACCOUNT_SOFT_CREDITS == true) {
-                    assertValue((ACCOUNT_SOFT_CREDIT_AMOUNT * CLOSED_OPP_COUNT_PER_ACCT * countAccts) + ACCOUNT_SOFT_CREDIT_AMOUNT, (Double) a.get('SC_Total__c'), a.Id + ' Acccount.SC_Total__c should be');
-                    assertValue(ACCOUNT_SOFT_CREDIT_AMOUNT * 2, (Double) a.get('Largest_SC_Amount__c'), a.Id + ' Acccount.Largest_SC_Amount__c should be');
+                    assertValue((ACCOUNT_SOFT_CREDIT_AMOUNT_USD * CLOSED_OPP_COUNT_PER_ACCT * countAccts) + ACCOUNT_SOFT_CREDIT_AMOUNT_USD, 
+                        (Double) a.get('SC_Total__c'), a.Id + ' Acccount.SC_Total__c should be');
+                    assertValue(ACCOUNT_SOFT_CREDIT_AMOUNT_USD * 2, (Double) a.get('Largest_SC_Amount__c'), a.Id + ' Acccount.Largest_SC_Amount__c should be');
                 }
 
             } else if (a.Id != orgAcct.Id) {

--- a/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls-meta.xml
+++ b/unpackaged/config/crlp_testing/classes/CRLP_TEST_VALIDATE_ROLLUPS.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/unpackaged/config/crlp_testing/package.xml
+++ b/unpackaged/config/crlp_testing/package.xml
@@ -146,5 +146,5 @@
         <members>CRLP_TEST_VALIDATE_ROLLUPS</members>
         <name>ApexClass</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>


### PR DESCRIPTION
In orgs that have multi-currency enabled, when you create a customizable rollup to rollup a custom number field on the opportunity to a custom number field on the contact the calculation should not apply currency conversions in situations where the currency of one or more opportunities differs from the contact's currency. 

# Critical Changes

# Changes

# Issues Closed
- Fixes #5159
- Fixes #4318
- Fixes #5185 

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
