### PR TITLE
RD2: Schedule Service Handles DayOfMonth 29 and 30

### DIFF
--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -477,6 +477,7 @@ public without sharing class RD2_ScheduleService {
             adjusted = addDateUnits(adjusted, adjustedFrequency, schedule.InstallmentPeriod__c);
         }
 
+        //TODO: Shouldn't this test for any day > days of month??
         if (schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY && schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY) {
             adjusted = Date.newInstance(adjusted.year(), adjusted.month(), Date.daysInMonth(adjusted.year(),adjusted.month()));
         }
@@ -543,12 +544,17 @@ public without sharing class RD2_ScheduleService {
             schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY ||
             schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_FIRST_AND_FIFTEENTH))
         {
+            //TODO: Problem is that the current calculation works for last day in most situations, but not for greater
+            //      than 30.  Why do the tests work for 29 and 30????
+            Boolean adjustLastDay = (
+                schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY ||
+                Integer.valueOf(schedule.DayOfMonth__c) > Date.daysInMonth(nextDate.year(), nextDate.month())
+            );
             nextDate = Date.newInstance(
                 nextDate.year(),
                 nextDate.month(),
-                schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY ?
-                    Date.daysInMonth(nextDate.year(), nextDate.month()) :
-                    Integer.valueOf(schedule.DayOfMonth__c)
+                adjustLastDay ? Date.daysInMonth(nextDate.year(), nextDate.month()) :
+                                Integer.valueOf(schedule.DayOfMonth__c)
             );
             nextDate = nextDate >= schedule.StartDate__c ? nextDate : nextDate.addMonths(1);
         }

--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -480,6 +480,9 @@ public without sharing class RD2_ScheduleService {
         if (schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY && schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY) {
             adjusted = Date.newInstance(adjusted.year(), adjusted.month(), Date.daysInMonth(adjusted.year(),adjusted.month()));
         }
+        else if (Schedule.DayOfMonth__c != null && Integer.valueOf(schedule.DayOfMonth__c) > Date.daysInMonth(firstValid.year(), firstValid.month())) {
+            adjusted = Date.newInstance(adjusted.year(), adjusted.month(), Integer.valueOf(schedule.DayOfMonth__c));
+        }
 
         return adjusted;
     }

--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -477,11 +477,12 @@ public without sharing class RD2_ScheduleService {
             adjusted = addDateUnits(adjusted, adjustedFrequency, schedule.InstallmentPeriod__c);
         }
 
-        if (schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY && schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY) {
-            adjusted = Date.newInstance(adjusted.year(), adjusted.month(), Date.daysInMonth(adjusted.year(),adjusted.month()));
-        }
-        else if (Schedule.DayOfMonth__c != null && Integer.valueOf(schedule.DayOfMonth__c) > Date.daysInMonth(firstValid.year(), firstValid.month())) {
-            adjusted = Date.newInstance(adjusted.year(), adjusted.month(), Integer.valueOf(schedule.DayOfMonth__c));
+        if (schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY) {
+            Integer nextDayOfMonth =
+                schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY ?
+                    Date.daysInMonth(adjusted.year(),adjusted.month()) :
+                    Integer.valueOf(schedule.DayOfMonth__c);
+            adjusted = Date.newInstance(adjusted.year(), adjusted.month(), nextDayOfMonth);
         }
 
         return adjusted;

--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -477,7 +477,6 @@ public without sharing class RD2_ScheduleService {
             adjusted = addDateUnits(adjusted, adjustedFrequency, schedule.InstallmentPeriod__c);
         }
 
-        //TODO: Shouldn't this test for any day > days of month??
         if (schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY && schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY) {
             adjusted = Date.newInstance(adjusted.year(), adjusted.month(), Date.daysInMonth(adjusted.year(),adjusted.month()));
         }

--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -478,10 +478,13 @@ public without sharing class RD2_ScheduleService {
         }
 
         if (schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY) {
-            Integer nextDayOfMonth =
-                schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY ?
-                    Date.daysInMonth(adjusted.year(),adjusted.month()) :
-                    Integer.valueOf(schedule.DayOfMonth__c);
+            Integer nextDayOfMonth;
+            if (schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY || Integer.valueOf(schedule.DayOfMonth__c) > Date.daysInMonth(adjusted.year(), adjusted.month())) {
+                nextDayOfMonth = Date.daysInMonth(adjusted.year(),adjusted.month());
+            }
+            else {
+                nextDayOfMonth = Integer.valueOf(schedule.DayOfMonth__c);
+            }
             adjusted = Date.newInstance(adjusted.year(), adjusted.month(), nextDayOfMonth);
         }
 

--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -478,8 +478,13 @@ public without sharing class RD2_ScheduleService {
         }
 
         if (schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY) {
+            if (schedule.DayOfMonth__c == null) {
+                return adjusted;
+            }
             Integer nextDayOfMonth;
-            if (schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY || Integer.valueOf(schedule.DayOfMonth__c) > Date.daysInMonth(adjusted.year(), adjusted.month())) {
+            if (schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY ||
+                Integer.valueOf(schedule.DayOfMonth__c) > Date.daysInMonth(adjusted.year(), adjusted.month()))
+            {
                 nextDayOfMonth = Date.daysInMonth(adjusted.year(),adjusted.month());
             }
             else {

--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -544,8 +544,6 @@ public without sharing class RD2_ScheduleService {
             schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY ||
             schedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_FIRST_AND_FIFTEENTH))
         {
-            //TODO: Problem is that the current calculation works for last day in most situations, but not for greater
-            //      than 30.  Why do the tests work for 29 and 30????
             Boolean adjustLastDay = (
                 schedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY ||
                 Integer.valueOf(schedule.DayOfMonth__c) > Date.daysInMonth(nextDate.year(), nextDate.month())

--- a/src/classes/RD2_ScheduleService_TEST.cls
+++ b/src/classes/RD2_ScheduleService_TEST.cls
@@ -262,6 +262,63 @@ private with sharing class RD2_ScheduleService_TEST {
     * @description Verifies next donation date for monthly donation when donation falls in next month.
     */
     @isTest
+    private static void shouldGenerateNextDonationDateLastDayInFebruaryWhenDayIs29() {
+        Date startDate = Date.newInstance(2020, 11, 29);
+        Date today = Date.newInstance(2021, 2, 10);
+        Date nextDonationDate = Date.newInstance(2021, 2, 28);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
+                .withStartDate(startDate)
+                .withDayOfMonth('29')
+                .build();
+
+        RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
+
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match');
+    }
+
+    /***
+    * @description Verifies next donation date for monthly donation when donation falls in next month.
+    */
+    @isTest
+    private static void shouldGenerateNextDonationDateLastDayInFebruaryWhenDayIs30() {
+        Date startDate = Date.newInstance(2020, 11, 30);
+        Date today = Date.newInstance(2021, 2, 10);
+        Date nextDonationDate = Date.newInstance(2021, 2, 28);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
+                .withStartDate(startDate)
+                .withDayOfMonth('30')
+                .build();
+
+        RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
+
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match');
+    }
+
+    /***
+    * @description Verifies next donation date for monthly donation when donation falls in next month.
+    */
+    @isTest
+    private static void shouldGenerateNextDonationDateLastDayInFebruaryWhenDayIs31() {
+        Date startDate = Date.newInstance(2020, 11, 29);
+        Date today = Date.newInstance(2021, 2, 10);
+        Date nextDonationDate = Date.newInstance(2021, 2, 28);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
+                .withStartDate(startDate)
+                .withDayOfMonth('31')
+                .build();
+
+        RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
+
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match');
+    }
+
+    /***
+    * @description Verifies next donation date for monthly donation when donation falls in next month.
+    */
+    @isTest
     private static void shouldGenerateNextDonationDateLastDayInFebruaryLeapYear() {
         Date startDate = Date.newInstance(2019, 11, 30);
         Date today = Date.newInstance(2020, 2, 10);

--- a/src/classes/RD2_ScheduleService_TEST.cls
+++ b/src/classes/RD2_ScheduleService_TEST.cls
@@ -259,7 +259,7 @@ private with sharing class RD2_ScheduleService_TEST {
     }
 
     /***
-    * @description Verifies next donation date for monthly donation when donation falls in next month.
+    * @description Verifies next donation date for February when DayOfMonth == 29.
     */
     @isTest
     private static void shouldGenerateNextDonationDateLastDayInFebruaryWhenDayIs29() {
@@ -278,7 +278,7 @@ private with sharing class RD2_ScheduleService_TEST {
     }
 
     /***
-    * @description Verifies next donation date for monthly donation when donation falls in next month.
+    * @description Verifies next donation date for February when DayOfMonth == 30.
     */
     @isTest
     private static void shouldGenerateNextDonationDateLastDayInFebruaryWhenDayIs30() {
@@ -297,26 +297,7 @@ private with sharing class RD2_ScheduleService_TEST {
     }
 
     /***
-    * @description Verifies next donation date for monthly donation when donation falls in next month.
-    */
-    @isTest
-    private static void shouldGenerateNextDonationDateLastDayInFebruaryWhenDayIs31() {
-        Date startDate = Date.newInstance(2020, 11, 29);
-        Date today = Date.newInstance(2021, 2, 10);
-        Date nextDonationDate = Date.newInstance(2021, 2, 28);
-
-        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-                .withStartDate(startDate)
-                .withDayOfMonth('31')
-                .build();
-
-        RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
-
-        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match');
-    }
-
-    /***
-    * @description Verifies next donation date for monthly donation when donation falls in next month.
+    * @description Verifies next donation date for February during leap year.
     */
     @isTest
     private static void shouldGenerateNextDonationDateLastDayInFebruaryLeapYear() {

--- a/src/classes/RD2_ScheduleService_TEST.cls
+++ b/src/classes/RD2_ScheduleService_TEST.cls
@@ -925,7 +925,7 @@ private with sharing class RD2_ScheduleService_TEST {
 
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
         RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
-        
+
         npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder().build();
 
         Test.startTest();
@@ -949,13 +949,214 @@ private with sharing class RD2_ScheduleService_TEST {
             AND Active__c = true];
 
         List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
-            new List<npe03__Recurring_Donation__c>{ rd }, startDate, null, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
+                new List<npe03__Recurring_Donation__c>{ rd }, startDate, null, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
         ).values()[0];
 
         Integer expectedNumber = 12;
         System.assertEquals(expectedNumber, installments.size(), 'There should be 12 installments.');
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate, 
-            'Final installment date should be 10/1/2020.');
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate,
+                'Final installment date should be 10/1/2020.');
+    }
+
+    /***
+    * @description Verifies visualization works as expected across short month with day of month > days in short month
+    */
+    @isTest
+    private static void shouldReturnThreeInstallmentsSpanningFebruaryInNormalYear() {
+        final Date startDate = Date.newInstance(2021, 1, 1);
+        String dayOfMonth = '29';
+
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
+                .withDayOfMonth(dayOfMonth)
+                .build();
+
+        Test.startTest();
+        insert rd;
+        Test.stopTest();
+
+        List<RecurringDonationSchedule__c> schedules = [
+            SELECT
+                Campaign__c,
+                Campaign__r.Name,
+                DayOfMonth__c,
+                EndDate__c,
+                InstallmentAmount__c,
+                InstallmentFrequency__c,
+                InstallmentPeriod__c,
+                PaymentMethod__c,
+                RecurringDonation__c,
+                StartDate__c
+            FROM RecurringDonationSchedule__c
+            WHERE RecurringDonation__c = :rd.Id
+            AND Active__c = true];
+
+        List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
+                new List<npe03__Recurring_Donation__c>{ rd }, startDate, 3, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
+        ).values()[0];
+
+        Integer expectedNumber = 3;
+        System.assertEquals(expectedNumber, installments.size(), 'There should be 3 installments.');
+        Date nextDonationDate = Date.newInstance(2021, 1, 29);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 3].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);
+        nextDonationDate = Date.newInstance(2021, 2, 28);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 2].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);
+        nextDonationDate = Date.newInstance(2021, 3, 29);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);
+    }
+
+    /***
+    * @description Verifies visualization works as expected across short month with day of month > days in short month
+    */
+    @isTest
+    private static void shouldReturnTwoInstallmentsStaringFebruaryInNormalYear() {
+        final Date startDate = Date.newInstance(2021, 2, 1);
+        String dayOfMonth = '29';
+
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
+                .withDayOfMonth(dayOfMonth)
+                .build();
+
+        Test.startTest();
+        insert rd;
+        Test.stopTest();
+
+        List<RecurringDonationSchedule__c> schedules = [
+            SELECT
+                Campaign__c,
+                Campaign__r.Name,
+                DayOfMonth__c,
+                EndDate__c,
+                InstallmentAmount__c,
+                InstallmentFrequency__c,
+                InstallmentPeriod__c,
+                PaymentMethod__c,
+                RecurringDonation__c,
+                StartDate__c
+            FROM RecurringDonationSchedule__c
+            WHERE RecurringDonation__c = :rd.Id
+            AND Active__c = true];
+
+        List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
+                new List<npe03__Recurring_Donation__c>{ rd }, startDate, 2, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
+        ).values()[0];
+
+        Integer expectedNumber = 2;
+        System.assertEquals(expectedNumber, installments.size(), 'There should be 2 installments.');
+        Date nextDonationDate = Date.newInstance(2021, 2, 28);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 2].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);
+        nextDonationDate = Date.newInstance(2021, 3, 29);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);    }
+
+    /***
+    * @description Verifies visualization works as expected across short month with day of month > days in short month
+    */
+    @isTest
+    private static void shouldReturnThreeInstallmentsSpanningFebruaryInLeapYear() {
+        final Date startDate = Date.newInstance(2020, 1, 1);
+        String dayOfMonth = '30';
+
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
+                .withDayOfMonth(dayOfMonth)
+                .build();
+
+        Test.startTest();
+        insert rd;
+        Test.stopTest();
+
+        List<RecurringDonationSchedule__c> schedules = [
+            SELECT
+                Campaign__c,
+                Campaign__r.Name,
+                DayOfMonth__c,
+                EndDate__c,
+                InstallmentAmount__c,
+                InstallmentFrequency__c,
+                InstallmentPeriod__c,
+                PaymentMethod__c,
+                RecurringDonation__c,
+                StartDate__c
+            FROM RecurringDonationSchedule__c
+            WHERE RecurringDonation__c = :rd.Id
+            AND Active__c = true];
+
+        List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
+                new List<npe03__Recurring_Donation__c>{ rd }, startDate, 3, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
+        ).values()[0];
+
+        Integer expectedNumber = 3;
+        System.assertEquals(expectedNumber, installments.size(), 'There should be 3 installments.');
+        Date nextDonationDate = Date.newInstance(2020, 1, 30);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 3].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);
+        nextDonationDate = Date.newInstance(2020, 2, 29);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 2].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);
+        nextDonationDate = Date.newInstance(2020, 3, 30);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);
+    }
+
+    /***
+    * @description Verifies visualization works as expected across short month with day of month > days in short month
+    */
+    @isTest
+    private static void shouldReturnTwoInstallmentsStaringFebruaryInLeapYear() {
+        final Date startDate = Date.newInstance(2020, 2, 1);
+        String dayOfMonth = '30';
+
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
+                .withDayOfMonth(dayOfMonth)
+                .build();
+
+        Test.startTest();
+        insert rd;
+        Test.stopTest();
+
+        List<RecurringDonationSchedule__c> schedules = [
+            SELECT
+                Campaign__c,
+                Campaign__r.Name,
+                DayOfMonth__c,
+                EndDate__c,
+                InstallmentAmount__c,
+                InstallmentFrequency__c,
+                InstallmentPeriod__c,
+                PaymentMethod__c,
+                RecurringDonation__c,
+                StartDate__c
+            FROM RecurringDonationSchedule__c
+            WHERE RecurringDonation__c = :rd.Id
+            AND Active__c = true];
+
+        List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
+                new List<npe03__Recurring_Donation__c>{ rd }, startDate, 2, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
+        ).values()[0];
+
+        Integer expectedNumber = 2;
+        System.assertEquals(expectedNumber, installments.size(), 'There should be 2 installments.');
+        Date nextDonationDate = Date.newInstance(2020, 2, 29);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 2].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);
+        nextDonationDate = Date.newInstance(2020, 3, 30);
+        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate,
+                'Final installment date should be ' + nextDonationDate);
     }
 
     /***

--- a/src/classes/RD2_ScheduleService_TEST.cls
+++ b/src/classes/RD2_ScheduleService_TEST.cls
@@ -259,60 +259,77 @@ private with sharing class RD2_ScheduleService_TEST {
     }
 
     /***
-    * @description Verifies next donation date for February when DayOfMonth == 29.
+    * @description Verifies next donation date for February when Day Of Month is 29.
     */
     @isTest
     private static void shouldGenerateNextDonationDateLastDayInFebruaryWhenDayIs29() {
-        Date startDate = Date.newInstance(2020, 11, 29);
+        final Integer dayOfMonth = 29;
+        final Date startDate = Date.newInstance(2021, 2, 1);
         Date today = Date.newInstance(2021, 2, 10);
         Date nextDonationDate = Date.newInstance(2021, 2, 28);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
                 .withStartDate(startDate)
-                .withDayOfMonth('29')
+                .withDayOfMonth(String.valueOf(dayOfMonth))
                 .build();
 
         RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match for Feb installment');
 
-        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match');
+        today = Date.newInstance(2021, 3, 1);
+        nextDonationDate = Date.newInstance(2021, 3, dayOfMonth);
+
+        service = getScheduleServiceForCurrentDate(today);
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match for March installment');
     }
 
     /***
-    * @description Verifies next donation date for February when DayOfMonth == 30.
+    * @description Verifies next donation date for February when Day Of Month is 30.
     */
     @isTest
     private static void shouldGenerateNextDonationDateLastDayInFebruaryWhenDayIs30() {
-        Date startDate = Date.newInstance(2020, 11, 30);
+        final Integer dayOfMonth = 30;
+        final Date startDate = Date.newInstance(2021, 2, 1);
         Date today = Date.newInstance(2021, 2, 10);
         Date nextDonationDate = Date.newInstance(2021, 2, 28);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
                 .withStartDate(startDate)
-                .withDayOfMonth('30')
+                .withDayOfMonth(String.valueOf(dayOfMonth))
                 .build();
 
         RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match for Feb installment');
 
-        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match');
+        today = Date.newInstance(2021, 3, 1);
+        nextDonationDate = Date.newInstance(2021, 3, dayOfMonth);
+
+        service = getScheduleServiceForCurrentDate(today);
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match for March installment');
     }
 
     /***
-    * @description Verifies next donation date for February during leap year.
+    * @description Verifies next donation date for monthly donation when donation falls in next month.
     */
     @isTest
     private static void shouldGenerateNextDonationDateLastDayInFebruaryLeapYear() {
-        Date startDate = Date.newInstance(2019, 11, 30);
+        final Date startDate = Date.newInstance(2020, 2, 1);
         Date today = Date.newInstance(2020, 2, 10);
         Date nextDonationDate = Date.newInstance(2020, 2, 29);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-            .withStartDate(startDate)
-            .withDayOfMonth(RD2_Constants.DAY_OF_MONTH_LAST_DAY)
-            .build();
+                .withStartDate(startDate)
+                .withDayOfMonth(RD2_Constants.DAY_OF_MONTH_LAST_DAY)
+                .build();
 
         RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match for Feb installment');
 
-        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match');
+        today = Date.newInstance(2020, 3, 1);
+        nextDonationDate = Date.newInstance(2020, 3, 31);
+
+        service = getScheduleServiceForCurrentDate(today);
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match for March installment');
     }
 
     /***

--- a/src/classes/RD2_ScheduleService_TEST.cls
+++ b/src/classes/RD2_ScheduleService_TEST.cls
@@ -959,207 +959,6 @@ private with sharing class RD2_ScheduleService_TEST {
     }
 
     /***
-    * @description Verifies visualization works as expected across short month with day of month > days in short month
-    */
-    @isTest
-    private static void shouldReturnThreeInstallmentsSpanningFebruaryInNormalYear() {
-        final Date startDate = Date.newInstance(2021, 1, 1);
-        String dayOfMonth = '29';
-
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
-        RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
-
-        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-                .withDayOfMonth(dayOfMonth)
-                .build();
-
-        Test.startTest();
-        insert rd;
-        Test.stopTest();
-
-        List<RecurringDonationSchedule__c> schedules = [
-            SELECT
-                Campaign__c,
-                Campaign__r.Name,
-                DayOfMonth__c,
-                EndDate__c,
-                InstallmentAmount__c,
-                InstallmentFrequency__c,
-                InstallmentPeriod__c,
-                PaymentMethod__c,
-                RecurringDonation__c,
-                StartDate__c
-            FROM RecurringDonationSchedule__c
-            WHERE RecurringDonation__c = :rd.Id
-            AND Active__c = true];
-
-        List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
-                new List<npe03__Recurring_Donation__c>{ rd }, startDate, 3, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
-        ).values()[0];
-
-        Integer expectedNumber = 3;
-        System.assertEquals(expectedNumber, installments.size(), 'There should be 3 installments.');
-        Date nextDonationDate = Date.newInstance(2021, 1, 29);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 3].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);
-        nextDonationDate = Date.newInstance(2021, 2, 28);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 2].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);
-        nextDonationDate = Date.newInstance(2021, 3, 29);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);
-    }
-
-    /***
-    * @description Verifies visualization works as expected across short month with day of month > days in short month
-    */
-    @isTest
-    private static void shouldReturnTwoInstallmentsStaringFebruaryInNormalYear() {
-        final Date startDate = Date.newInstance(2021, 2, 1);
-        String dayOfMonth = '29';
-
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
-        RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
-
-        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-                .withDayOfMonth(dayOfMonth)
-                .build();
-
-        Test.startTest();
-        insert rd;
-        Test.stopTest();
-
-        List<RecurringDonationSchedule__c> schedules = [
-            SELECT
-                Campaign__c,
-                Campaign__r.Name,
-                DayOfMonth__c,
-                EndDate__c,
-                InstallmentAmount__c,
-                InstallmentFrequency__c,
-                InstallmentPeriod__c,
-                PaymentMethod__c,
-                RecurringDonation__c,
-                StartDate__c
-            FROM RecurringDonationSchedule__c
-            WHERE RecurringDonation__c = :rd.Id
-            AND Active__c = true];
-
-        List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
-                new List<npe03__Recurring_Donation__c>{ rd }, startDate, 2, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
-        ).values()[0];
-
-        Integer expectedNumber = 2;
-        System.assertEquals(expectedNumber, installments.size(), 'There should be 2 installments.');
-        Date nextDonationDate = Date.newInstance(2021, 2, 28);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 2].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);
-        nextDonationDate = Date.newInstance(2021, 3, 29);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);    }
-
-    /***
-    * @description Verifies visualization works as expected across short month with day of month > days in short month
-    */
-    @isTest
-    private static void shouldReturnThreeInstallmentsSpanningFebruaryInLeapYear() {
-        final Date startDate = Date.newInstance(2020, 1, 1);
-        String dayOfMonth = '30';
-
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
-        RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
-
-        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-                .withDayOfMonth(dayOfMonth)
-                .build();
-
-        Test.startTest();
-        insert rd;
-        Test.stopTest();
-
-        List<RecurringDonationSchedule__c> schedules = [
-            SELECT
-                Campaign__c,
-                Campaign__r.Name,
-                DayOfMonth__c,
-                EndDate__c,
-                InstallmentAmount__c,
-                InstallmentFrequency__c,
-                InstallmentPeriod__c,
-                PaymentMethod__c,
-                RecurringDonation__c,
-                StartDate__c
-            FROM RecurringDonationSchedule__c
-            WHERE RecurringDonation__c = :rd.Id
-            AND Active__c = true];
-
-        List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
-                new List<npe03__Recurring_Donation__c>{ rd }, startDate, 3, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
-        ).values()[0];
-
-        Integer expectedNumber = 3;
-        System.assertEquals(expectedNumber, installments.size(), 'There should be 3 installments.');
-        Date nextDonationDate = Date.newInstance(2020, 1, 30);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 3].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);
-        nextDonationDate = Date.newInstance(2020, 2, 29);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 2].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);
-        nextDonationDate = Date.newInstance(2020, 3, 30);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);
-    }
-
-    /***
-    * @description Verifies visualization works as expected across short month with day of month > days in short month
-    */
-    @isTest
-    private static void shouldReturnTwoInstallmentsStaringFebruaryInLeapYear() {
-        final Date startDate = Date.newInstance(2020, 2, 1);
-        String dayOfMonth = '30';
-
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
-        RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
-
-        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-                .withDayOfMonth(dayOfMonth)
-                .build();
-
-        Test.startTest();
-        insert rd;
-        Test.stopTest();
-
-        List<RecurringDonationSchedule__c> schedules = [
-            SELECT
-                Campaign__c,
-                Campaign__r.Name,
-                DayOfMonth__c,
-                EndDate__c,
-                InstallmentAmount__c,
-                InstallmentFrequency__c,
-                InstallmentPeriod__c,
-                PaymentMethod__c,
-                RecurringDonation__c,
-                StartDate__c
-            FROM RecurringDonationSchedule__c
-            WHERE RecurringDonation__c = :rd.Id
-            AND Active__c = true];
-
-        List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
-                new List<npe03__Recurring_Donation__c>{ rd }, startDate, 2, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
-        ).values()[0];
-
-        Integer expectedNumber = 2;
-        System.assertEquals(expectedNumber, installments.size(), 'There should be 2 installments.');
-        Date nextDonationDate = Date.newInstance(2020, 2, 29);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 2].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);
-        nextDonationDate = Date.newInstance(2020, 3, 30);
-        System.assertEquals(nextDonationDate, installments[ expectedNumber - 1].nextDonationDate,
-                'Final installment date should be ' + nextDonationDate);
-    }
-
-    /***
     * @description Verifies visualization substitutes default when null maxDates are requested
     */
     @isTest
@@ -1735,10 +1534,113 @@ private with sharing class RD2_ScheduleService_TEST {
             'The Next Donation Date should be the first open Opp installment');
     }
 
+    /***
+    * @description Verifies visualization works as expected across short month with day of month > days in short month
+    */
+    @isTest
+    private static void shouldReturnExpectedNextDonationDatesSpanningFebruaryInNormalYear() {
+        final Date startDate = Date.newInstance(2021, 1, 1);
+        final String dayOfMonth = '29';
+
+        Map<Integer, Date> nextDonationDateByIndex = new Map<Integer, Date>{
+                0 => Date.newInstance(2021, 1, 29),
+                1 => Date.newInstance(2021, 2, 28),
+                2 => Date.newInstance(2021, 3, 29)
+        };
+
+        testAndAssertVisualizedInstallments(startDate, dayOfMonth, nextDonationDateByIndex);
+    }
+
+    /***
+    * @description Verifies visualization works as expected across short month with day of month > days in short month
+    */
+    @isTest
+    private static void shouldReturnExpectedNextDonationDatesStaringFebruaryInNormalYear() {
+        final Date startDate = Date.newInstance(2021, 2, 1);
+        final String dayOfMonth = '29';
+
+        Map<Integer, Date> nextDonationDateByIndex = new Map<Integer, Date>{
+                0 => Date.newInstance(2021, 2, 28),
+                1 => Date.newInstance(2021, 3, 29)
+        };
+
+        testAndAssertVisualizedInstallments(startDate, dayOfMonth, nextDonationDateByIndex);
+    }
+
+    /***
+    * @description Verifies visualization works as expected across short month with day of month > days in short month
+    */
+    @isTest
+    private static void shouldReturnExpectedNextDonationDatesSpanningFebruaryInLeapYear() {
+        final Date startDate = Date.newInstance(2020, 1, 1);
+        final String dayOfMonth = '30';
+
+        Map<Integer, Date> nextDonationDateByIndex = new Map<Integer, Date>{
+                0 => Date.newInstance(2020, 1, 30),
+                1 => Date.newInstance(2020, 2, 29),
+                2 => Date.newInstance(2020, 3, 30)
+        };
+
+        testAndAssertVisualizedInstallments(startDate, dayOfMonth, nextDonationDateByIndex);
+    }
+
+    /***
+    * @description Verifies visualization works as expected across short month with day of month > days in short month
+    */
+    @isTest
+    private static void shouldReturnExpectedNextDonationDatesStaringFebruaryInLeapYear() {
+        final Date startDate = Date.newInstance(2020, 2, 1);
+        final String dayOfMonth = '30';
+
+        Map<Integer, Date> nextDonationDateByIndex = new Map<Integer, Date>{
+                0 => Date.newInstance(2020, 2, 29),
+                1 => Date.newInstance(2020, 3, 30)
+        };
+
+        testAndAssertVisualizedInstallments(startDate, dayOfMonth, nextDonationDateByIndex);
+    }
+
 
 
     //// Helpers
     //////////////////////////
+
+    /***
+    * @description Creates data and verifies the visualized installments have expected next donation dates
+    * @param startDate Start date to set on Recurring Donation
+    * @param dayOfMonth Day of month to set on the Recurring Donation
+    * @param nextDonationDateByIndex Next Donation Date by the visualized installment list index
+    * @return void
+    */
+    private static void testAndAssertVisualizedInstallments(Date startDate, String dayOfMonth, Map<Integer, Date> nextDonationDateByIndex) {
+        final Integer numberOfInstallments = nextDonationDateByIndex.size();
+
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
+                .withDayOfMonth(dayOfMonth)
+                .build();
+
+        Test.startTest();
+        insert rd;
+        Test.stopTest();
+
+        List<RecurringDonationSchedule__c> schedules = new RD2_OpportunityEvaluationService()
+                .getRecurringDonations(new Set<Id>{ rd.Id })[0].RecurringDonationSchedules__r;
+
+        List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
+                new List<npe03__Recurring_Donation__c>{ rd }, startDate, numberOfInstallments, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
+        ).values()[0];
+
+        System.assertEquals(numberOfInstallments, installments.size(), 'Number of installments should match');
+
+        for (Integer i : nextDonationDateByIndex.keySet()) {
+            Date nextDonationDate = nextDonationDateByIndex.get(i);
+            System.assertEquals(nextDonationDate, installments[i].nextDonationDate,
+                    'Installment ' + i + ' date should be: ' + nextDonationDate);
+        }
+    }
 
     /****
     * @description Returns Recurring Donation with Yearly Installment Period

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -277,23 +277,24 @@ public with sharing class RD2_ValidationService {
             return;
         }
 
-        if (rd.Day_of_Month__c != RD2_Constants.DAY_OF_MONTH_LAST_DAY) {
-            Integer dayOfMonth;
-            try {
-                dayOfMonth = Integer.valueOf(rd.Day_of_Month__c);
+        if (rd.Day_of_Month__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY) {
+            return;
+        }
 
-            } catch (Exception e) {
-            }
+        Integer dayOfMonth;
+        try {
+            dayOfMonth = Integer.valueOf(rd.Day_of_Month__c);
+        } catch (Exception e) {
+        }
 
-            Boolean isValid = dayOfMonth > 0 && dayOfMonth < 31;
+        Boolean isValid = dayOfMonth > 0 && dayOfMonth < 31;
 
-            if (!isValid) {
-                rd.addError(
+        if (!isValid) {
+            rd.addError(
                     String.format(
-                        System.Label.RD2_DayOfMonthMustBeValid,
-                        new String[]{ rd.Day_of_Month__c })
-                );
-            }
+                            System.Label.RD2_DayOfMonthMustBeValid,
+                            new String[]{ rd.Day_of_Month__c })
+            );
         }
     }
 

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -291,9 +291,9 @@ public with sharing class RD2_ValidationService {
 
         if (!isValid) {
             rd.addError(
-                    String.format(
-                            System.Label.RD2_DayOfMonthMustBeValid,
-                            new String[]{ rd.Day_of_Month__c })
+                String.format(
+                    System.Label.RD2_DayOfMonthMustBeValid,
+                    new String[]{ rd.Day_of_Month__c })
             );
         }
     }

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -285,7 +285,7 @@ public with sharing class RD2_ValidationService {
             } catch (Exception e) {
             }
 
-            Boolean isValid = dayOfMonth > 0 && dayOfMonth < 32;
+            Boolean isValid = dayOfMonth > 0 && dayOfMonth < 31;
 
             if (!isValid) {
                 rd.addError(

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -285,7 +285,7 @@ public with sharing class RD2_ValidationService {
             } catch (Exception e) {
             }
 
-            Boolean isValid = dayOfMonth > 0 && dayOfMonth < 29;
+            Boolean isValid = dayOfMonth > 0 && dayOfMonth < 32;
 
             if (!isValid) {
                 rd.addError(

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -312,9 +312,9 @@ private with sharing class RD2_ValidationService_TEST {
 
         String day = '31';
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
-                .withContact(getContact().Id)
-                .withDayOfMonth(day)
-                .build();
+            .withContact(getContact().Id)
+            .withDayOfMonth(day)
+            .build();
 
         String errMessage = '';
         try {
@@ -324,8 +324,8 @@ private with sharing class RD2_ValidationService_TEST {
         }
 
         String expectedMessage = String.format(
-                System.Label.RD2_DayOfMonthMustBeValid,
-                new String[]{ day }
+            System.Label.RD2_DayOfMonthMustBeValid,
+            new String[]{ day }
         );
         System.assert(errMessage.contains(expectedMessage),
                 'The error message should contain invalud Day Of Month message: ' + errMessage);
@@ -339,14 +339,14 @@ private with sharing class RD2_ValidationService_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         TEST_RecurringDonationBuilder rdBuilder = getRecurringDonationBuilder()
-                .withContact(getContact().Id);
+            .withContact(getContact().Id);
 
         for (String day : new Set<String>{
-                '15', '10', '28', '29', '30'
+            '15', '10', '28', '29', '30'
         }) {
             npe03__Recurring_Donation__c rd = rdBuilder
-                    .withDayOfMonth(day)
-                    .build();
+                .withDayOfMonth(day)
+                .build();
 
             String errMessage = '';
             try {

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -314,7 +314,7 @@ private with sharing class RD2_ValidationService_TEST {
             .withContact(getContact().Id);
 
         for (String day : new Set<String>{
-            '29', '30', '31'
+            '29', '30', '31', RD2_Constants.DAY_OF_MONTH_LAST_DAY
         }) {
             npe03__Recurring_Donation__c rd = rdBuilder
                 .withDayOfMonth(day)
@@ -326,12 +326,7 @@ private with sharing class RD2_ValidationService_TEST {
             } catch (Exception e) {
                 errMessage = e.getMessage();
             }
-            String expectedMessage = String.format(
-                System.Label.RD2_DayOfMonthMustBeValid,
-                new String[]{day }
-            );
-            System.assert(errMessage.contains(expectedMessage),
-                'Day Of Month should be valid: ' + errMessage);
+            System.assert(errMessage.length() == 0);
         }
 
     }

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -310,25 +310,25 @@ private with sharing class RD2_ValidationService_TEST {
     private static void shouldFailWhenDayOfMonthIsNotValidForMonthlyInstallments() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
-        TEST_RecurringDonationBuilder rdBuilder = getRecurringDonationBuilder()
-            .withContact(getContact().Id);
-
-        for (String day : new Set<String>{
-            '29', '30', '31', RD2_Constants.DAY_OF_MONTH_LAST_DAY
-        }) {
-            npe03__Recurring_Donation__c rd = rdBuilder
+        String day = '31';
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
+                .withContact(getContact().Id)
                 .withDayOfMonth(day)
                 .build();
 
-            String errMessage = '';
-            try {
-                insert rd;
-            } catch (Exception e) {
-                errMessage = e.getMessage();
-            }
-            System.assert(errMessage.length() == 0);
+        String errMessage = '';
+        try {
+            insert rd;
+        } catch (Exception e) {
+            errMessage = e.getMessage();
         }
 
+        String expectedMessage = String.format(
+                System.Label.RD2_DayOfMonthMustBeValid,
+                new String[]{ day }
+        );
+        System.assert(errMessage.contains(expectedMessage),
+                'The error message should contain invalud Day Of Month message: ' + errMessage);
     }
 
     /***
@@ -339,14 +339,14 @@ private with sharing class RD2_ValidationService_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         TEST_RecurringDonationBuilder rdBuilder = getRecurringDonationBuilder()
-            .withContact(getContact().Id);
+                .withContact(getContact().Id);
 
         for (String day : new Set<String>{
-            '15', '10', '28'
+                '15', '10', '28', '29', '30'
         }) {
             npe03__Recurring_Donation__c rd = rdBuilder
-                .withDayOfMonth(day)
-                .build();
+                    .withDayOfMonth(day)
+                    .build();
 
             String errMessage = '';
             try {

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1587,7 +1587,7 @@ If you&apos;re not sure how to resolve these errors, post a message in the Nonpr
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Validate Recurring Donations data if it is valid day of month</shortDescription>
-        <value>{0} is not a supported value for Day of Month. Select a value between 1 and 28 or select Last Day of Month.</value>
+        <value>{0} is not a supported value for Day of Month. Select a value between 1 and 30 or select Last Day of Month.</value>
     </labels>
     <labels>
         <fullName>RD2_DayOfMonthIsRequiredForMonthlyInstallment</fullName>

--- a/src/objects/RecurringDonationSchedule__c.object
+++ b/src/objects/RecurringDonationSchedule__c.object
@@ -334,6 +334,16 @@
                     <label>28</label>
                 </value>
                 <value>
+                    <fullName>29</fullName>
+                    <default>false</default>
+                    <label>29</label>
+                </value>
+                <value>
+                    <fullName>30</fullName>
+                    <default>false</default>
+                    <label>30</label>
+                </value>
+                <value>
                     <fullName>Last_Day</fullName>
                     <default>false</default>
                     <label>Last Day Of Month</label>

--- a/src/objects/RecurringDonationSchedule__c.object
+++ b/src/objects/RecurringDonationSchedule__c.object
@@ -344,6 +344,11 @@
                     <label>30</label>
                 </value>
                 <value>
+                    <fullName>31</fullName>
+                    <default>false</default>
+                    <label>31</label>
+                </value>
+                <value>
                     <fullName>Last_Day</fullName>
                     <default>false</default>
                     <label>Last Day Of Month</label>

--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -253,6 +253,11 @@
                     <label>30</label>
                 </value>
                 <value>
+                    <fullName>31</fullName>
+                    <default>false</default>
+                    <label>31</label>
+                </value>
+                <value>
                     <fullName>Last_Day</fullName>
                     <default>false</default>
                     <label>Last Day Of Month</label>

--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -253,9 +253,9 @@
                     <label>30</label>
                 </value>
                 <value>
-                    <fullName>31</fullName>
+                    <fullName>Last_Day</fullName>
                     <default>false</default>
-                    <label>31</label>
+                    <label>Last Day Of Month</label>
                 </value>
             </valueSetDefinition>
         </valueSet>


### PR DESCRIPTION
We've added explicit support for monthly recurring donation days 29 and 30 (via Day of Month field).  Previously, these days were all considered the last day of the month.  Now we will respect the explicit selection in all months where that is possible and treat the selection as the last day of the month in all other cases.  Last Day of Month is still supported as an option.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
