### PR TITLE
NPSP Settings: Store API values when configuration is updated

### DIFF
--- a/src/classes/STG_DataBoundMultiSelect_CTRL.cls
+++ b/src/classes/STG_DataBoundMultiSelect_CTRL.cls
@@ -119,20 +119,21 @@ public with sharing class STG_DataBoundMultiSelect_CTRL {
     * @param apiValues The api value to be converted
     */
     private String convertApiToLabel(String apiValues) {
-        if (String.isBlank(apiValues)) {
+        if (String.isBlank(apiValues) || listSelectOption == null) {
             return apiValues;
         }
 
         Map<String, String> apiToLabelMap = constructApiToLabelMap();
-        String labelValue = '';
+        String labelValues = '';
 
         for (String apiValue : apiValues.split(';', 0)) {
-            labelValue += apiToLabelMap.get(apiValue) + ';';
+            
+            labelValues += apiToLabelMap.get(apiValue) + ';';
         }
 
-        labelValue = labelValue.left(labelValue.length()-1);
+        labelValues = labelValues.left(labelValues.length()-1);
 
-        return labelValue;
+        return labelValues;
     }
 
     /**

--- a/src/classes/STG_DataBoundMultiSelect_CTRL.cls
+++ b/src/classes/STG_DataBoundMultiSelect_CTRL.cls
@@ -68,21 +68,21 @@ public with sharing class STG_DataBoundMultiSelect_CTRL {
     * @description The control's constructor 
     */
     public STG_DataBoundMultiSelect_CTRL() {
-    	isDisabled = false;
-    	isEditMode = false;
+        isDisabled = false;
+        isEditMode = false;
     }
     
     /*********************************************************************************************************
     * @description A semicolon separated string of values pulled from the object's field 
     */
     public string strValues { 
-    	get {
-    		if (strValues == null) {
+        get {
+            if (strValues == null) {
                 strValues = convertApiToLabel(String.valueOf(sobjBinding.get(strField)));
-    		}
-    		return strValues;
-    	}
-    	private set;
+            }
+            return strValues;
+        }
+        private set;
     }
 
     /*********************************************************************************************************
@@ -98,10 +98,10 @@ public with sharing class STG_DataBoundMultiSelect_CTRL {
             return listStrValues;
         }
         set {
-        	listStrValues = value;
-        	String apiValues = '';
+            listStrValues = value;
+            String apiValues = '';
             for (string str : listStrValues) {
-            	apiValues += str + ';';
+                apiValues += str + ';';
             }
             if (apiValues != '') {
                 apiValues = apiValues.left(apiValues.length()-1);

--- a/src/classes/STG_DataBoundMultiSelect_CTRL.cls
+++ b/src/classes/STG_DataBoundMultiSelect_CTRL.cls
@@ -78,11 +78,13 @@ public with sharing class STG_DataBoundMultiSelect_CTRL {
     public string strValues { 
     	get {
     		if (strValues == null) {
-    			strValues = string.valueOf(sobjBinding.get(strField));
+                String apiValues = (String) String.valueOf(sobjBinding.get(strField));
+
+                strValues = convertApiToLabel((String) String.valueOf(sobjBinding.get(strField)));
     		}
     		return strValues;
     	}
-    	private set; 
+    	private set;
     }
 
     /*********************************************************************************************************
@@ -91,22 +93,59 @@ public with sharing class STG_DataBoundMultiSelect_CTRL {
     */
     public list<string> listStrValues {
         get {
-            if (listStrValues == null && strValues != null) {
-                listStrValues = strValues.split(';',0);
+            String apiValues = (String) String.valueOf(sobjBinding.get(strField));
+            if (listStrValues == null && apiValues != null) {
+                listStrValues = apiValues.split(';',0);
             }
             return listStrValues;
         }
         set {
         	listStrValues = value;
-        	strValues = '';
+        	String apiValues = '';
             for (string str : listStrValues) {
-            	strValues += str + ';';
+            	apiValues += str + ';';
             }
-            if (strValues != '')
-                strValues = strValues.left(strValues.length()-1);
-            sobjBinding.put(strField, strValues);	
+            if (apiValues != '') {
+                apiValues = apiValues.left(apiValues.length()-1);
+            }
+            sobjBinding.put(strField, apiValues);
+            
+            strValues = convertApiToLabel(apiValues);
         }
     }
-    
-    
+
+    /**
+    * @description Convert the api value into the label for display
+    * @param apiValues The api value to be converted
+    */
+    private String convertApiToLabel(String apiValues) {
+        if (String.isBlank(apiValues)) {
+            return apiValues;
+        }
+
+        Map<String, String> apiToLabelMap = constructApiToLabelMap();
+        String labelValue = '';
+
+        for (String apiValue : apiValues.split(';', 0)) {
+            labelValue += apiToLabelMap.get(apiValue) + ';';
+        }
+
+        labelValue = labelValue.left(labelValue.length()-1);
+
+        return labelValue;
+    }
+
+    /**
+    * @description Construct the Api to Label map from the passed in SelectOption
+    * @return Map<String, String>
+    */
+    private Map<String, String> constructApiToLabelMap() {
+        Map<String, String> apiToLabelMap = new Map<String, String>();
+
+        for (SelectOption option : listSelectOption) {
+            apiToLabelMap.put(option.getValue(), option.getLabel());
+        }
+
+        return apiToLabelMap;
+    }
 }

--- a/src/classes/STG_DataBoundMultiSelect_CTRL.cls
+++ b/src/classes/STG_DataBoundMultiSelect_CTRL.cls
@@ -33,11 +33,18 @@
 * @group Settings
 * @description Controller for the DataBoundMultiSelect component used in 
 * many of our settings pages.  It basically takes a sobject field that
-* contains a semicolon separated string of values, and displays them in
+* contains a semicolon separated String of values, and displays them in
 * a multiselect picklist.  On saving, it renders the selections back into
-* a single semicolon separated string of values.
+* a single semicolon separated String of values.
 */
 public with sharing class STG_DataBoundMultiSelect_CTRL {
+
+    /*********************************************************************************************************
+    * @description Separator used to separate picklist field values.
+    * It is used to separate picklist field labels when the page is in read mode, and
+    * to separate picklist field API values when they are being saved.
+    */
+    private static final String SEPARATOR = ';';
 
     /*********************************************************************************************************
     * @description The list of SelectOptions 
@@ -62,7 +69,7 @@ public with sharing class STG_DataBoundMultiSelect_CTRL {
     /*********************************************************************************************************
     * @description The field on the object the control is databinding to 
     */
-    public string strField { get; set; }
+    public String strField { get; set; }
     
     /*********************************************************************************************************
     * @description The control's constructor 
@@ -73,12 +80,13 @@ public with sharing class STG_DataBoundMultiSelect_CTRL {
     }
     
     /*********************************************************************************************************
-    * @description A semicolon separated string of values pulled from the object's field 
+    * @description Values are displayed as a semicolon separated labels selected 
+    * for the picklist field when the page is in view (read) mode.
     */
-    public string strValues { 
+    public String strValues {
         get {
             if (strValues == null) {
-                strValues = convertApiToLabel(String.valueOf(sobjBinding.get(strField)));
+                strValues = getPicklistLabels(String.valueOf(sobjBinding.get(strField)));
             }
             return strValues;
         }
@@ -86,65 +94,67 @@ public with sharing class STG_DataBoundMultiSelect_CTRL {
     }
 
     /*********************************************************************************************************
-    * @description The list of strings values databound to the object's field.  Setting this list will
-    * save those values into the object's field.
+    * @description A multi-select picklist field API values for the specified picklist field when the page is in edit mode.  
+    * Setting this list will save those values into the object's field.
     */
-    public list<string> listStrValues {
+    public List<String> listStrValues { 
         get {
             String apiValues = (String) String.valueOf(sobjBinding.get(strField));
             if (listStrValues == null && apiValues != null) {
-                listStrValues = apiValues.split(';',0);
+                listStrValues = apiValues.split(SEPARATOR, 0);
             }
             return listStrValues;
         }
         set {
-            listStrValues = value;
-            String apiValues = '';
-            for (string str : listStrValues) {
-                apiValues += str + ';';
-            }
-            if (apiValues != '') {
-                apiValues = apiValues.left(apiValues.length()-1);
-            }
-            sobjBinding.put(strField, apiValues);
-            
-            strValues = convertApiToLabel(apiValues);
+            listStrValues = value;//assign the picklist field API values
+            strValues = null;//reset the picklist field labels
+
+            //store the API values as a semiclon separated values into the picklist field
+            String apiValues = listStrValues == null ? '' : String.join(listStrValues, SEPARATOR);
+            sobjBinding.put(strField, apiValues);            
         }
     }
 
     /**
-    * @description Convert the api value into the label for display
-    * @param apiValues The api value to be converted
+    * @description Maps specified picklist field API values into labels
+    * @param apiValues Semicolon separated API values
+    * @return String Semicolon separated labels
     */
-    private String convertApiToLabel(String apiValues) {
-        if (String.isBlank(apiValues) || listSelectOption == null) {
-            return apiValues;
+    private String getPicklistLabels(String apiValues) {
+        String labels = '';
+
+        if (String.isBlank(apiValues)) {
+            return labels;
         }
 
-        Map<String, String> apiToLabelMap = constructApiToLabelMap();
-        String labelValues = '';
+        Map<String, String> valueByLabel = getPicklistValueByLabel();
 
-        for (String apiValue : apiValues.split(';', 0)) {
-            
-            labelValues += apiToLabelMap.get(apiValue) + ';';
+        for (String apiValue : apiValues.split(SEPARATOR, 0)) { 
+            if (String.isBlank(labels)) {
+                labels = valueByLabel.get(apiValue);
+            } else {      
+                labels += SEPARATOR + valueByLabel.get(apiValue);
+            }
         }
 
-        labelValues = labelValues.left(labelValues.length()-1);
-
-        return labelValues;
+        return labels;
     }
 
     /**
-    * @description Construct the Api to Label map from the passed in SelectOption
-    * @return Map<String, String>
+    * @description Constructs the picklist field SelectOption field values and labels
+    * @return Map<String, String> Value by the label map
     */
-    private Map<String, String> constructApiToLabelMap() {
-        Map<String, String> apiToLabelMap = new Map<String, String>();
+    private Map<String, String> getPicklistValueByLabel() {
+        Map<String, String> valueByLabel = new Map<String, String>();
+
+        if (listSelectOption == null) {
+            return valueByLabel;
+        }
 
         for (SelectOption option : listSelectOption) {
-            apiToLabelMap.put(option.getValue(), option.getLabel());
+            valueByLabel.put(option.getValue(), option.getLabel());
         }
 
-        return apiToLabelMap;
+        return valueByLabel;
     }
 }

--- a/src/classes/STG_DataBoundMultiSelect_CTRL.cls
+++ b/src/classes/STG_DataBoundMultiSelect_CTRL.cls
@@ -78,9 +78,7 @@ public with sharing class STG_DataBoundMultiSelect_CTRL {
     public string strValues { 
     	get {
     		if (strValues == null) {
-                String apiValues = (String) String.valueOf(sobjBinding.get(strField));
-
-                strValues = convertApiToLabel((String) String.valueOf(sobjBinding.get(strField)));
+                strValues = convertApiToLabel(String.valueOf(sobjBinding.get(strField)));
     		}
     		return strValues;
     	}

--- a/src/classes/STG_Panel.cls
+++ b/src/classes/STG_Panel.cls
@@ -334,7 +334,7 @@ public with sharing virtual class STG_Panel {
                 Schema.DescribeFieldResult F = Schema.sObjectType.npe4__Relationship__c.fields.npe4__Type__c;
                 List<Schema.PicklistEntry> P = F.getPicklistValues();
                 for (Schema.PicklistEntry pe : P) {
-                    listSORelTypes.add(new SelectOption(pe.getLabel(), pe.getLabel()));
+                    listSORelTypes.add(new SelectOption(pe.getValue(), pe.getLabel()));
                 }
             }
             return listSORelTypes;
@@ -353,7 +353,7 @@ public with sharing virtual class STG_Panel {
                 Schema.DescribeFieldResult F = Schema.sObjectType.Campaign.fields.Type;
                 List<Schema.PicklistEntry> P = F.getPicklistValues();
                 for (Schema.PicklistEntry pe : P) {
-                    listSOCampaignTypes.add(new SelectOption(pe.getLabel(), pe.getLabel()));
+                    listSOCampaignTypes.add(new SelectOption(pe.getValue(), pe.getLabel()));
                 }
             }
             return listSOCampaignTypes;

--- a/src/classes/STG_Panel.cls
+++ b/src/classes/STG_Panel.cls
@@ -179,25 +179,6 @@ public with sharing virtual class STG_Panel {
     }
 
     /*******************************************************************************************************
-    * @description list of SelectOptions for Opportunity Contact Roles
-    */
-    static public list<SelectOption> listSOContactRoles {
-        get {
-            if (listSOContactRoles == null) {
-                listSOContactRoles = new list<SelectOption>();
-                listSOContactRoles.add(new SelectOption('', Label.stgLabelNone));
-                Schema.DescribeFieldResult F = Schema.sObjectType.OpportunityContactRole.fields.Role;
-                List<Schema.PicklistEntry> P = F.getPicklistValues();
-                for (Schema.PicklistEntry pe : P) {
-                    listSOContactRoles.add(new SelectOption(pe.getLabel(), pe.getLabel()));
-                }
-            }
-            return listSOContactRoles;
-        }
-        private set;
-    }
-
-    /*******************************************************************************************************
     * @description list of SelectOptions for Household Object Creation Rules
     */
     static public list<SelectOption> listSOHHRules {
@@ -314,7 +295,7 @@ public with sharing virtual class STG_Panel {
                 Schema.DescribeFieldResult F = Schema.sObjectType.OpportunityContactRole.fields.Role;
                 List<Schema.PicklistEntry> P = F.getPicklistValues();
                 for(Schema.PicklistEntry pe : P) {
-                    listSOOppContactRoles.add(new SelectOption(pe.getLabel(), pe.getLabel()));
+                    listSOOppContactRoles.add(new SelectOption(pe.getValue(), pe.getLabel()));
                 }
             }
             return listSOOppContactRoles;

--- a/src/classes/STG_Panel.cls
+++ b/src/classes/STG_Panel.cls
@@ -315,7 +315,7 @@ public with sharing virtual class STG_Panel {
 	            list<Schema.PicklistEntry> P = F.getPicklistValues();
 
 	            for (Schema.PicklistEntry plistentry: P) {
-	                listSOOppTypes.add(new SelectOption(plistentry.getLabel(),plistentry.getLabel()));
+	                listSOOppTypes.add(new SelectOption(plistentry.getValue(),plistentry.getLabel()));
 	            }
 	        }
 	        return listSOOppTypes;

--- a/src/classes/STG_Panel.cls
+++ b/src/classes/STG_Panel.cls
@@ -304,6 +304,25 @@ public with sharing virtual class STG_Panel {
     }
 
     /*******************************************************************************************************
+    * @description list of SelectOptions for Opportunity Contact Roles
+    */
+    static public list<SelectOption> listSOContactRoles {
+        get {
+            if (listSOContactRoles == null) {
+                listSOContactRoles = new list<SelectOption>();
+                listSOContactRoles.add(new SelectOption('', Label.stgLabelNone));
+                Schema.DescribeFieldResult F = Schema.sObjectType.OpportunityContactRole.fields.Role;
+                List<Schema.PicklistEntry> P = F.getPicklistValues();
+                for(Schema.PicklistEntry pe : P) {
+                    listSOContactRoles.add(new SelectOption(pe.getValue(), pe.getLabel()));
+                }
+            }
+            return listSOContactRoles;
+        }
+        private set;
+    }
+
+    /*******************************************************************************************************
     * @description list of SelectOptions for Opportunity Types
     */
     static public list<SelectOption> listSOOppTypes {

--- a/src/classes/STG_Panel.cls
+++ b/src/classes/STG_Panel.cls
@@ -448,4 +448,29 @@ public with sharing virtual class STG_Panel {
         return USER_UserService.isSysAdmin(new List<User>{(new User(Id = runningUserId, ProfileId = runningUserProfileId))}).get(runningUserId);
 
     }
+
+    /*******************************************************************************************************
+    * @description Get the label of the picklist value
+    * @param objectName The Sobject name of the picklist field
+    * @param fieldName The field name of the picklist field
+    * @param apiValue The value of the picklist field
+    * @return String The label value of the picklist field
+    */
+    public static String getPicklistLabelFromValue(String objectName, String fieldName, String apiValue) {
+        Schema.DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe(objectName, fieldName);
+        
+        if (fieldResult.getType() !== Schema.DisplayType.PICKLIST && fieldResult.getType() !== Schema.DisplayType.MULTIPICKLIST) {
+            return apiValue;
+        }
+        if (String.isBlank(apiValue)) {
+            return System.Label.stgLabelNone;
+        }
+        for (Schema.PicklistEntry entry : fieldResult.getPicklistValues()) {
+            if (entry.getValue() == apiValue) {
+                return entry.getLabel();
+            }
+        }
+
+        return apiValue;
+    }
 }

--- a/src/classes/STG_PanelContactRoles_CTRL.cls
+++ b/src/classes/STG_PanelContactRoles_CTRL.cls
@@ -194,4 +194,94 @@ public with sharing class STG_PanelContactRoles_CTRL extends STG_Panel {
         }
         return results;
     }
+
+    /**
+    * @description The current setting being stored on the Opportunity Contact Role Default Role
+    */
+    public String individualOppsContactRole {
+        get {
+            individualOppsContactRole =
+                STG_Panel.getPicklistLabelFromValue(
+                    'OpportunityContactRole',
+                    'Role',
+                    STG_Panel.stgService.stgCon.npe01__Opportunity_Contact_Role_Default_role__c
+                );
+            return individualOppsContactRole;
+        }set;
+    }
+
+    /**
+    * @description The current setting being stored on the Contact Role for Organizational Opps
+    */
+    public String organizationOppsContactRole {
+        get {
+            organizationOppsContactRole =
+                STG_Panel.getPicklistLabelFromValue(
+                    'OpportunityContactRole',
+                    'Role',
+                    STG_Panel.stgService.stgCon.Contact_Role_for_Organizational_Opps__c
+                );
+            return organizationOppsContactRole;
+        }set;
+    }
+
+    /**
+    * @description The current setting being stored on the Household Matched Donor Role
+    */
+    public String matchedDonorRole {
+        get{
+            matchedDonorRole =
+                STG_Panel.getPicklistLabelFromValue(
+                    'OpportunityContactRole',
+                    'Role',
+                    STG_Panel.stgService.stgHH.Matched_Donor_Role__c
+                );
+            return matchedDonorRole;
+        }set;
+    }
+
+    /**
+    * @description The current setting being stored on the Household Member Contact Role
+    */
+    public String hhMemberContactRole {
+        get {
+            hhMemberContactRole =
+                STG_Panel.getPicklistLabelFromValue(
+                    'OpportunityContactRole',
+                    'Role',
+                    STG_Panel.stgService.stgHH.npo02__Household_Member_Contact_Role__c
+                );
+            return hhMemberContactRole;
+        }set;
+    }
+
+    /**
+    * @description The current setting being stored on the Honoree Opportunity Contact Role
+    */
+    public String honoreeOppContactRole {
+        get {
+            honoreeOppContactRole =
+                STG_Panel.getPicklistLabelFromValue(
+                    'OpportunityContactRole',
+                    'Role',
+                    STG_Panel.stgService.stgCon.Honoree_Opportunity_Contact_Role__c
+                );
+            return honoreeOppContactRole;
+        }set;
+    }  
+
+    /**
+    * @description The current setting being stored on the Notification Recipient Opportunity Contact Role
+    */
+    public String recipientOppContactRole {
+        get{
+        recipientOppContactRole =
+            STG_Panel.getPicklistLabelFromValue(
+                'OpportunityContactRole',
+                'Role',
+                STG_Panel.stgService.stgCon.Notification_Recipient_Opp_Contact_Role__c
+            );
+            return recipientOppContactRole;
+        }set;
+    }
 }

--- a/src/classes/STG_PanelContactRoles_CTRL.cls
+++ b/src/classes/STG_PanelContactRoles_CTRL.cls
@@ -198,90 +198,90 @@ public with sharing class STG_PanelContactRoles_CTRL extends STG_Panel {
     /**
     * @description The current setting being stored on the Opportunity Contact Role Default Role
     */
-    public String individualOppsContactRole {
+    public String selectedOptionDefaultContactRole {
         get {
-            individualOppsContactRole =
+            selectedOptionDefaultContactRole =
                 STG_Panel.getPicklistLabelFromValue(
                     'OpportunityContactRole',
                     'Role',
                     STG_Panel.stgService.stgCon.npe01__Opportunity_Contact_Role_Default_role__c
                 );
-            return individualOppsContactRole;
+            return selectedOptionDefaultContactRole;
         }set;
     }
 
     /**
     * @description The current setting being stored on the Contact Role for Organizational Opps
     */
-    public String organizationOppsContactRole {
+    public String selectedOptionOrgDefaultContactRole {
         get {
-            organizationOppsContactRole =
+            selectedOptionOrgDefaultContactRole =
                 STG_Panel.getPicklistLabelFromValue(
                     'OpportunityContactRole',
                     'Role',
                     STG_Panel.stgService.stgCon.Contact_Role_for_Organizational_Opps__c
                 );
-            return organizationOppsContactRole;
+            return selectedOptionOrgDefaultContactRole;
         }set;
     }
 
     /**
     * @description The current setting being stored on the Household Matched Donor Role
     */
-    public String matchedDonorRole {
+    public String selectedOptionMatchedDonorRole {
         get{
-            matchedDonorRole =
+            selectedOptionMatchedDonorRole =
                 STG_Panel.getPicklistLabelFromValue(
                     'OpportunityContactRole',
                     'Role',
                     STG_Panel.stgService.stgHH.Matched_Donor_Role__c
                 );
-            return matchedDonorRole;
+            return selectedOptionMatchedDonorRole;
         }set;
     }
 
     /**
     * @description The current setting being stored on the Household Member Contact Role
     */
-    public String hhMemberContactRole {
+    public String selectedOptionHHMemberContactRole {
         get {
-            hhMemberContactRole =
+            selectedOptionHHMemberContactRole =
                 STG_Panel.getPicklistLabelFromValue(
                     'OpportunityContactRole',
                     'Role',
                     STG_Panel.stgService.stgHH.npo02__Household_Member_Contact_Role__c
                 );
-            return hhMemberContactRole;
+            return selectedOptionHHMemberContactRole;
         }set;
     }
 
     /**
     * @description The current setting being stored on the Honoree Opportunity Contact Role
     */
-    public String honoreeOppContactRole {
+    public String selectedOptionHonoreeContactRole {
         get {
-            honoreeOppContactRole =
+            selectedOptionHonoreeContactRole =
                 STG_Panel.getPicklistLabelFromValue(
                     'OpportunityContactRole',
                     'Role',
                     STG_Panel.stgService.stgCon.Honoree_Opportunity_Contact_Role__c
                 );
-            return honoreeOppContactRole;
+            return selectedOptionHonoreeContactRole;
         }set;
     }  
 
     /**
     * @description The current setting being stored on the Notification Recipient Opportunity Contact Role
     */
-    public String recipientOppContactRole {
+    public String selectedOptionNotficationRecipientRole {
         get{
-        recipientOppContactRole =
+        selectedOptionNotficationRecipientRole =
             STG_Panel.getPicklistLabelFromValue(
                 'OpportunityContactRole',
                 'Role',
                 STG_Panel.stgService.stgCon.Notification_Recipient_Opp_Contact_Role__c
             );
-            return recipientOppContactRole;
+            return selectedOptionNotficationRecipientRole;
         }set;
     }
 }

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -177,7 +177,7 @@ private with sharing class STG_SettingsManager_TEST {
     }
 
     /**
-    * @description Verifies that when the options are selected, the display string will be converted to Label and the
+    * @description Verifies that when the options are selected, the displayed string will be converted to Label and the
     * actual values will stay in Api format
     */
     @isTest

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -1166,6 +1166,23 @@ private with sharing class STG_SettingsManager_TEST {
         Test.stopTest();
     }
 
+    /**
+    * @description Verifies that the api value of the picklist will be converted into corresponding label
+    */
+    @isTest
+    private static void shouldConvertPicklistApiValueIntoLabelValue() {
+        System.runAs(UTIL_UnitTestData_TEST.createNonEnglishUserWithoutInsert(UTIL_UnitTestData_TEST.PROFILE_STANDARD_USER)) {
+            Schema.DescribeFieldResult fieldResult = UTIL_Describe.getFieldDescribe('OpportunityContactRole', 'Role');
+            String label = fieldResult.getPicklistValues()[0].getLabel();
+            String apiValue = fieldResult.getPicklistValues()[0].getValue();
+
+            Test.startTest();
+            String convertedLabel = STG_Panel.getPicklistLabelFromValue('OpportunityContactRole', 'Role', apiValue);
+            Test.stopTest();
+
+            System.assertEquals(label, convertedLabel, 'The api value should be correctly converted into the corressponding label');
+        }
+    }
 
     /*********************************************************************************************************
     * @description Tests the Run RD Batch panel

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -181,7 +181,7 @@ private with sharing class STG_SettingsManager_TEST {
     * actual values will stay in Api format
     */
     @isTest
-    private static void shouldConvertToLabelForDispalyAndApiValueForSaving() {
+    private static void shouldConvertToLabelForDisplayAndApiValueForSaving() {
         STG_DataBoundMultiSelect_CTRL ctrl = new STG_DataBoundMultiSelect_CTRL();
         List<SelectOption> options = new List<SelectOption> {
             new SelectOption('value1', 'label1'),
@@ -190,6 +190,7 @@ private with sharing class STG_SettingsManager_TEST {
         };
 
         Contact con = new Contact();
+
         con.npo02__Naming_Exclusions__c = 'value1;value2';
         ctrl.sobjBinding = con;
         ctrl.listSelectOption = options;

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -176,24 +176,34 @@ private with sharing class STG_SettingsManager_TEST {
         System.assertEquals(null, ctrl.errorMsg);
     }
 
-
-    /*********************************************************************************************************
-    * @description Tests the DataBoundMultiSelect control used in Settings
-    * @return void
+    /**
+    * @description Verifies that when the options are selected, the display string will be converted to Label and the
+    * actual values will stay in Api format
     */
     @isTest
-    private static void testDataBoundMultiSelect() {
+    private static void shouldConvertToLabelForDispalyAndApiValueForSaving() {
         STG_DataBoundMultiSelect_CTRL ctrl = new STG_DataBoundMultiSelect_CTRL();
+        List<SelectOption> options = new List<SelectOption> {
+            new SelectOption('value1', 'label1'),
+            new SelectOption('value2', 'label2'),
+            new SelectOption('value3', 'label3')
+        };
+
         Contact con = new Contact();
-        con.npo02__Naming_Exclusions__c = 'a;b;c';
+        con.npo02__Naming_Exclusions__c = 'value1;value2';
         ctrl.sobjBinding = con;
+        ctrl.listSelectOption = options;
         ctrl.strField = 'npo02__Naming_Exclusions__c';
-        system.assertNotEquals(null, ctrl.listStrValues);
-        system.assertEquals(3, ctrl.listStrValues.size());
-        system.assertEquals('a;b;c', ctrl.strValues);
-        list<string> listStr = new list<string>{'x', 'y', 'z'};
-        ctrl.listStrValues = listStr;
-        system.assertEquals('x;y;z', ctrl.strValues);
+
+        System.assertEquals('label1;label2', ctrl.strValues, 'strValues should be convert to label for display');
+        System.assertEquals('value1;value2', con.npo02__Naming_Exclusions__c, 'Field value should remain the API value');
+
+        Test.startTest();
+        ctrl.listStrValues = new List<String>{'value2', 'value3'};        
+        Test.stopTest();
+
+        System.assertEquals('label2;label3', ctrl.strValues, 'strValues should be convert to label for display');
+        System.assertEquals('value2;value3', con.npo02__Naming_Exclusions__c, 'Field value should remain the API value');
     }
 
     /*********************************************************************************************************

--- a/src/classes/STG_SettingsManager_TEST.cls
+++ b/src/classes/STG_SettingsManager_TEST.cls
@@ -215,7 +215,6 @@ private with sharing class STG_SettingsManager_TEST {
         system.assertEquals(null, ctrl.cancelEdit());
         system.assertEquals(false, ctrl.isEditMode);
         system.assertEquals(3, STG_Panel.listSOAccountModels.size());
-        system.assertNotEquals(null, STG_Panel.listSOContactRoles);
         system.assertNotEquals(null, STG_Panel.listSOHHRules);
         system.assertNotEquals(null, STG_Panel.listSOContactRecTypes);
         system.assertNotEquals(null, STG_Panel.listSOAccountRecTypeIds);

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -633,6 +633,16 @@ public class UTIL_UnitTestData_TEST {
     }
 
     /**
+     * @description Build a User having specified profile and language assigned, but do not insert
+     * @param profileName Profile Name
+     * @param localSidKey An NPSP supported locale key (EN_us, es, de, fr, or NL_nl, ja)
+     * @return User
+     */
+    public static User createNonEnglishUserWithoutInsert(String profileName) {
+        return buildUser(buildUniqueLastName(), profileName, 'es');
+    }
+
+    /**
       * @description Generate a unique string to append to indexed fields to make them unique
       */
     public static String getUniqueString() {

--- a/src/classes/UTIL_UnitTestData_TEST.cls
+++ b/src/classes/UTIL_UnitTestData_TEST.cls
@@ -633,9 +633,8 @@ public class UTIL_UnitTestData_TEST {
     }
 
     /**
-     * @description Build a User having specified profile and language assigned, but do not insert
+     * @description Build a non-English User having specified profile, but do not insert
      * @param profileName Profile Name
-     * @param localSidKey An NPSP supported locale key (EN_us, es, de, fr, or NL_nl, ja)
      * @return User
      */
     public static User createNonEnglishUserWithoutInsert(String profileName) {

--- a/src/pages/STG_PanelContactRoles.page
+++ b/src/pages/STG_PanelContactRoles.page
@@ -20,7 +20,7 @@
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgCon.npe01__Opportunity_Contact_Role_Default_role__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.npe01__Opportunity_Contact_Role_Default_role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slOCRDR" html-aria-describedby="{!$Component.slOCRDRHelp}" styleClass="slds-select" >
-                        <apex:selectOptions value="{!listSOContactRoles}"/>
+                        <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
                     <apex:outputPanel id="slOCRDRHelp" layout="block">
                         <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpOCRDefaultRole}" />
@@ -34,7 +34,7 @@
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgCon.Contact_Role_for_Organizational_Opps__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.Contact_Role_for_Organizational_Opps__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slOrgOCRDR" html-aria-describedby="{!$Component.slOrgOCRDRHelp}" styleClass="slds-select" >
-                        <apex:selectOptions value="{!listSOContactRoles}"/>
+                        <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
                     <apex:outputPanel id="slOrgOCRDRHelp" layout="block">
                         <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpOrgOCRDefaultRole}" />
@@ -59,7 +59,7 @@
                 <div class="slds-form-element__control">
                     <apex:outputField value="{!stgService.stgHH.Matched_Donor_Role__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgHH.Matched_Donor_Role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slMDR" html-aria-describedby="{!$Component.slMDRHelp}" styleClass="slds-select" >
-                        <apex:selectOptions value="{!listSOContactRoles}"/>
+                        <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
                     <apex:outputPanel id="slMDRHelp" layout="block">
                         <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpMatchedDonorRole}" />

--- a/src/pages/STG_PanelContactRoles.page
+++ b/src/pages/STG_PanelContactRoles.page
@@ -18,7 +18,7 @@
                 <!-- Individual Default OCR -->
                 <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.npe01__Opportunity_Contact_Role_Default_role__c.Label}" for="slOCRDR" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputField value="{!stgService.stgCon.npe01__Opportunity_Contact_Role_Default_role__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                <apex:outputText value="{!individualOppsContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.npe01__Opportunity_Contact_Role_Default_role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slOCRDR" html-aria-describedby="{!$Component.slOCRDRHelp}" styleClass="slds-select" >
                         <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
@@ -32,7 +32,7 @@
                 <!-- Organizational Default OCR -->
                 <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.Contact_Role_for_Organizational_Opps__c.Label}" for="slOrgOCRDR" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputField value="{!stgService.stgCon.Contact_Role_for_Organizational_Opps__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!organizationOppsContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.Contact_Role_for_Organizational_Opps__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slOrgOCRDR" html-aria-describedby="{!$Component.slOrgOCRDRHelp}" styleClass="slds-select" >
                         <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
@@ -57,7 +57,7 @@
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npo02__Households_Settings__c.Fields.Matched_Donor_Role__c.Label}" for="slMDR" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputField value="{!stgService.stgHH.Matched_Donor_Role__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!matchedDonorRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgHH.Matched_Donor_Role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slMDR" html-aria-describedby="{!$Component.slMDRHelp}" styleClass="slds-select" >
                         <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
@@ -110,7 +110,7 @@
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npo02__Households_Settings__c.Fields.npo02__Household_Member_Contact_Role__c.Label}" for="slHMCR" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputField value="{!stgService.stgHH.npo02__Household_Member_Contact_Role__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!hhMemberContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgHH.npo02__Household_Member_Contact_Role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slHMCR" html-aria-describedby="{!$Component.slHMCRHelp}" styleClass="slds-select" >
                         <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
@@ -138,7 +138,7 @@
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.Honoree_Opportunity_Contact_Role__c.Label}" for="slHonoreeRole" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputField value="{!stgService.stgCon.Honoree_Opportunity_Contact_Role__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!honoreeOppCOntactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.Honoree_Opportunity_Contact_Role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slHonoreeRole" html-aria-describedby="{!$Component.slHonoreeRoleHelp}" styleClass="slds-select" >
                         <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
@@ -150,7 +150,7 @@
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.Notification_Recipient_Opp_Contact_Role__c.Label}" for="slNotificationRecipientRole" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputField value="{!stgService.stgCon.Notification_Recipient_Opp_Contact_Role__c}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!recipientOppContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.Notification_Recipient_Opp_Contact_Role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slNotificationRecipientRole" html-aria-describedby="{!$Component.slNotificationRecipientRoleHelp}" styleClass="slds-select" >
                         <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>

--- a/src/pages/STG_PanelContactRoles.page
+++ b/src/pages/STG_PanelContactRoles.page
@@ -18,9 +18,9 @@
                 <!-- Individual Default OCR -->
                 <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.npe01__Opportunity_Contact_Role_Default_role__c.Label}" for="slOCRDR" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                <apex:outputText value="{!individualOppsContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                <apex:outputText value="{!selectedOptionDefaultContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.npe01__Opportunity_Contact_Role_Default_role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slOCRDR" html-aria-describedby="{!$Component.slOCRDRHelp}" styleClass="slds-select" >
-                        <apex:selectOptions value="{!listSOOppContactRoles}"/>
+                        <apex:selectOptions value="{!listSOContactRoles}"/>
                     </apex:selectList>
                     <apex:outputPanel id="slOCRDRHelp" layout="block">
                         <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpOCRDefaultRole}" />
@@ -32,9 +32,9 @@
                 <!-- Organizational Default OCR -->
                 <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.Contact_Role_for_Organizational_Opps__c.Label}" for="slOrgOCRDR" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputText value="{!organizationOppsContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!selectedOptionOrgDefaultContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.Contact_Role_for_Organizational_Opps__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slOrgOCRDR" html-aria-describedby="{!$Component.slOrgOCRDRHelp}" styleClass="slds-select" >
-                        <apex:selectOptions value="{!listSOOppContactRoles}"/>
+                        <apex:selectOptions value="{!listSOContactRoles}"/>
                     </apex:selectList>
                     <apex:outputPanel id="slOrgOCRDRHelp" layout="block">
                         <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpOrgOCRDefaultRole}" />
@@ -57,9 +57,9 @@
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npo02__Households_Settings__c.Fields.Matched_Donor_Role__c.Label}" for="slMDR" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputText value="{!matchedDonorRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!selectedOptionMatchedDonorRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgHH.Matched_Donor_Role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slMDR" html-aria-describedby="{!$Component.slMDRHelp}" styleClass="slds-select" >
-                        <apex:selectOptions value="{!listSOOppContactRoles}"/>
+                        <apex:selectOptions value="{!listSOContactRoles}"/>
                     </apex:selectList>
                     <apex:outputPanel id="slMDRHelp" layout="block">
                         <apex:outputText styleClass="slds-form-element__help" value="{!$Label.stgHelpMatchedDonorRole}" />
@@ -110,7 +110,7 @@
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npo02__Households_Settings__c.Fields.npo02__Household_Member_Contact_Role__c.Label}" for="slHMCR" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputText value="{!hhMemberContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!selectedOptionHHMemberContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgHH.npo02__Household_Member_Contact_Role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slHMCR" html-aria-describedby="{!$Component.slHMCRHelp}" styleClass="slds-select" >
                         <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
@@ -138,7 +138,7 @@
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.Honoree_Opportunity_Contact_Role__c.Label}" for="slHonoreeRole" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputText value="{!honoreeOppCOntactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!selectedOptionHonoreeContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.Honoree_Opportunity_Contact_Role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slHonoreeRole" html-aria-describedby="{!$Component.slHonoreeRoleHelp}" styleClass="slds-select" >
                         <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>
@@ -150,7 +150,7 @@
             <div class="slds-form-element">
                 <apex:outputLabel value="{!$ObjectType.npe01__Contacts_And_Orgs_Settings__c.Fields.Notification_Recipient_Opp_Contact_Role__c.Label}" for="slNotificationRecipientRole" styleClass="slds-form-element__label" />
                 <div class="slds-form-element__control">
-                    <apex:outputText value="{!recipientOppContactRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
+                    <apex:outputText value="{!selectedOptionNotficationRecipientRole}" rendered="{!isReadOnlyMode}" styleClass="slds-form-element__static" />
                     <apex:selectList value="{!stgService.stgCon.Notification_Recipient_Opp_Contact_Role__c}" multiselect="false" size="1" rendered="{!isEditMode}" id="slNotificationRecipientRole" html-aria-describedby="{!$Component.slNotificationRecipientRoleHelp}" styleClass="slds-select" >
                         <apex:selectOptions value="{!listSOOppContactRoles}"/>
                     </apex:selectList>


### PR DESCRIPTION
As a non-English Admin User, I want NPSP to operate consistently for all Users in my Organization regardless of which language or locale any given user has configured for themselves.

# Critical Changes

# Changes

# Issues Closed

Fixes #3021

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
