### PR TITLE
RD2: Schedule Service Handles DayOfMonth 29 and 30 - part 2

### DIFF
--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -619,26 +619,7 @@ public without sharing class RD2_ScheduleService {
             isCurrent =             rdSchedule.StartDate__c <= RD2_ScheduleService.currentDate ? true : false;
             campaignId =            rdSchedule.Campaign__c;
             campaignName =          rdSchedule.Campaign__r.Name;
-            if (rdSchedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY) {
-                if (rdSchedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY) {
-
-                    Schema.DescribeFieldResult dfr = UTIL_Describe.getFieldDescribe(
-                        UTIL_Namespace.getNamespace() + 'RecurringDonationSchedule__c',
-                        UTIL_Namespace.getNamespace() + 'DayOfMonth__c'
-                    );
-                    List<Schema.PicklistEntry> picklistEntries = dfr.getPicklistValues();
-
-                    for (Schema.PicklistEntry ple : picklistEntries) {
-                        if (ple.getValue() == RD2_Constants.DAY_OF_MONTH_LAST_DAY) {
-                            dayOfMonth = ple.getLabel();
-                            break;
-                        }
-                    }
-                }
-                else {
-                    dayOfMonth = rdSchedule.DayOfMonth__c;
-                }
-            }
+            dayOfMonth =            rdSchedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY ? rdSchedule.DayOfMonth__c : null;
             endDate =               rdSchedule.EndDate__c;
             installmentAmount =     rdSchedule.InstallmentAmount__c;
             installmentFrequency =  rdSchedule.InstallmentFrequency__c != null ? Integer.valueOf(rdSchedule.InstallmentFrequency__c) : null;
@@ -648,7 +629,6 @@ public without sharing class RD2_ScheduleService {
             scheduleId =            rdSchedule.Id;
             startDate =             rdSchedule.StartDate__c;
         }
-    }
 
     /***
     * @description Performs a full analysis and rebuild of the Schedule records for a Recurring Donation,

--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -602,33 +602,34 @@ public without sharing class RD2_ScheduleService {
     */
     public class ActiveSchedule {
 
-        public Boolean  isCurrent {get;set;}
-        public Id       campaignId {get; set;}
-        public String   campaignName {get; set;}
-        public String   dayOfMonth {get; set;}
-        public Date     endDate {get; set;}
-        public Decimal  installmentAmount {get; set;}
-        public Integer  installmentFrequency {get; set;}
-        public String   installmentPeriod {get; set;}
-        public String   paymentMethod {get; set;}
-        public String   recurringDonationId {get; set;}
-        public Id       scheduleId {get; set;}
-        public Date     startDate {get; set;}
+        public Boolean isCurrent { get; set; }
+        public Id campaignId { get; set; }
+        public String campaignName { get; set; }
+        public String dayOfMonth { get; set; }
+        public Date endDate { get; set; }
+        public Decimal installmentAmount { get; set; }
+        public Integer installmentFrequency { get; set; }
+        public String installmentPeriod { get; set; }
+        public String paymentMethod { get; set; }
+        public String recurringDonationId { get; set; }
+        public Id scheduleId { get; set; }
+        public Date startDate { get; set; }
 
         public ActiveSchedule(RecurringDonationSchedule__c rdSchedule) {
-            isCurrent =             rdSchedule.StartDate__c <= RD2_ScheduleService.currentDate ? true : false;
-            campaignId =            rdSchedule.Campaign__c;
-            campaignName =          rdSchedule.Campaign__r.Name;
-            dayOfMonth =            rdSchedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY ? rdSchedule.DayOfMonth__c : null;
-            endDate =               rdSchedule.EndDate__c;
-            installmentAmount =     rdSchedule.InstallmentAmount__c;
-            installmentFrequency =  rdSchedule.InstallmentFrequency__c != null ? Integer.valueOf(rdSchedule.InstallmentFrequency__c) : null;
-            installmentPeriod =     rdSchedule.InstallmentPeriod__c;
-            paymentMethod =         rdSchedule.PaymentMethod__c;
-            recurringDonationId =   rdSchedule.RecurringDonation__c;
-            scheduleId =            rdSchedule.Id;
-            startDate =             rdSchedule.StartDate__c;
+            isCurrent = rdSchedule.StartDate__c <= RD2_ScheduleService.currentDate ? true : false;
+            campaignId = rdSchedule.Campaign__c;
+            campaignName = rdSchedule.Campaign__r.Name;
+            dayOfMonth = rdSchedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY ? rdSchedule.DayOfMonth__c : null;
+            endDate = rdSchedule.EndDate__c;
+            installmentAmount = rdSchedule.InstallmentAmount__c;
+            installmentFrequency = rdSchedule.InstallmentFrequency__c != null ? Integer.valueOf(rdSchedule.InstallmentFrequency__c) : null;
+            installmentPeriod = rdSchedule.InstallmentPeriod__c;
+            paymentMethod = rdSchedule.PaymentMethod__c;
+            recurringDonationId = rdSchedule.RecurringDonation__c;
+            scheduleId = rdSchedule.Id;
+            startDate = rdSchedule.StartDate__c;
         }
+    }
 
     /***
     * @description Performs a full analysis and rebuild of the Schedule records for a Recurring Donation,

--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -619,7 +619,26 @@ public without sharing class RD2_ScheduleService {
             isCurrent =             rdSchedule.StartDate__c <= RD2_ScheduleService.currentDate ? true : false;
             campaignId =            rdSchedule.Campaign__c;
             campaignName =          rdSchedule.Campaign__r.Name;
-            dayOfMonth =            rdSchedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY ? rdSchedule.DayOfMonth__c : null;
+            if (rdSchedule.InstallmentPeriod__c == RD2_Constants.INSTALLMENT_PERIOD_MONTHLY) {
+                if (rdSchedule.DayOfMonth__c == RD2_Constants.DAY_OF_MONTH_LAST_DAY) {
+
+                    Schema.DescribeFieldResult dfr = UTIL_Describe.getFieldDescribe(
+                        UTIL_Namespace.getNamespace() + 'RecurringDonationSchedule__c',
+                        UTIL_Namespace.getNamespace() + 'DayOfMonth__c'
+                    );
+                    List<Schema.PicklistEntry> picklistEntries = dfr.getPicklistValues();
+
+                    for (Schema.PicklistEntry ple : picklistEntries) {
+                        if (ple.getValue() == RD2_Constants.DAY_OF_MONTH_LAST_DAY) {
+                            dayOfMonth = ple.getLabel();
+                            break;
+                        }
+                    }
+                }
+                else {
+                    dayOfMonth = rdSchedule.DayOfMonth__c;
+                }
+            }
             endDate =               rdSchedule.EndDate__c;
             installmentAmount =     rdSchedule.InstallmentAmount__c;
             installmentFrequency =  rdSchedule.InstallmentFrequency__c != null ? Integer.valueOf(rdSchedule.InstallmentFrequency__c) : null;

--- a/src/classes/RD2_ScheduleService_TEST.cls
+++ b/src/classes/RD2_ScheduleService_TEST.cls
@@ -269,9 +269,9 @@ private with sharing class RD2_ScheduleService_TEST {
         Date nextDonationDate = Date.newInstance(2021, 2, 28);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-                .withStartDate(startDate)
-                .withDayOfMonth(String.valueOf(dayOfMonth))
-                .build();
+            .withStartDate(startDate)
+            .withDayOfMonth(String.valueOf(dayOfMonth))
+            .build();
 
         RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
         System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match for Feb installment');
@@ -294,9 +294,9 @@ private with sharing class RD2_ScheduleService_TEST {
         Date nextDonationDate = Date.newInstance(2021, 2, 28);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-                .withStartDate(startDate)
-                .withDayOfMonth(String.valueOf(dayOfMonth))
-                .build();
+            .withStartDate(startDate)
+            .withDayOfMonth(String.valueOf(dayOfMonth))
+            .build();
 
         RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
         System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match for Feb installment');
@@ -318,9 +318,9 @@ private with sharing class RD2_ScheduleService_TEST {
         Date nextDonationDate = Date.newInstance(2020, 2, 29);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-                .withStartDate(startDate)
-                .withDayOfMonth(RD2_Constants.DAY_OF_MONTH_LAST_DAY)
-                .build();
+            .withStartDate(startDate)
+            .withDayOfMonth(RD2_Constants.DAY_OF_MONTH_LAST_DAY)
+            .build();
 
         RD2_ScheduleService service = getScheduleServiceForCurrentDate(today);
         System.assertEquals(nextDonationDate, service.getNextDonationDate(rd), 'Next Donation Date should match for Feb installment');
@@ -1159,21 +1159,21 @@ private with sharing class RD2_ScheduleService_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         List<npe03__Recurring_Donation__c> oldRds = new List<npe03__Recurring_Donation__c>{
-                getRecurringDonationMonthlyBuilder()
-                        .withStartDate(startDate)
-                        .withMockId()
-                        .build()
+            getRecurringDonationMonthlyBuilder()
+                .withStartDate(startDate)
+                .withMockId()
+                .build()
         };
 
         Decimal newAmount = 250;
         List<npe03__Recurring_Donation__c> updatedRds = new List<npe03__Recurring_Donation__c>{
-                oldRds[0].clone(true)
+            oldRds[0].clone(true)
         };
         updatedRds[0].npe03__Amount__c = newAmount;
 
         RD2_ScheduleService service = new RD2_ScheduleService();
         Map<Id, npe03__Recurring_Donation__c> rdsNeedUpdate = service.getRecurringDonationsNeedingScheduleUpdates(
-                updatedRds, oldRds, TDTM_Runnable.Action.BeforeUpdate
+            updatedRds, oldRds, TDTM_Runnable.Action.BeforeUpdate
         );
 
         System.assertEquals(1, rdsNeedUpdate.size(), 'Recurring Donation should be marked for update');
@@ -1189,21 +1189,21 @@ private with sharing class RD2_ScheduleService_TEST {
         Date startDate = Date.today().addYears(12);
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
         List<npe03__Recurring_Donation__c> oldRds = new List<npe03__Recurring_Donation__c>{
-                getRecurringDonationMonthlyBuilder()
-                        .withStartDate(startDate)
-                        .withMockId()
-                        .build()
+            getRecurringDonationMonthlyBuilder()
+                .withStartDate(startDate)
+                .withMockId()
+                .build()
         };
 
         Decimal newAmount = 250;
         List<npe03__Recurring_Donation__c> updatedRds = new List<npe03__Recurring_Donation__c>{
-                oldRds[0].clone(true)
+            oldRds[0].clone(true)
         };
         updatedRds[0].npe03__Amount__c = newAmount;
 
         RD2_ScheduleService service = new RD2_ScheduleService();
         Map<Id, npe03__Recurring_Donation__c> rdsNeedUpdate = service.getRecurringDonationsNeedingScheduleUpdates(
-                updatedRds, oldRds, TDTM_Runnable.Action.BeforeUpdate
+            updatedRds, oldRds, TDTM_Runnable.Action.BeforeUpdate
         );
 
         System.assertEquals(1, rdsNeedUpdate.size(), 'Recurring Donation should be marked for update');
@@ -1543,9 +1543,9 @@ private with sharing class RD2_ScheduleService_TEST {
         final String dayOfMonth = '29';
 
         Map<Integer, Date> nextDonationDateByIndex = new Map<Integer, Date>{
-                0 => Date.newInstance(2021, 1, 29),
-                1 => Date.newInstance(2021, 2, 28),
-                2 => Date.newInstance(2021, 3, 29)
+            0 => Date.newInstance(2021, 1, 29),
+            1 => Date.newInstance(2021, 2, 28),
+            2 => Date.newInstance(2021, 3, 29)
         };
 
         testAndAssertVisualizedInstallments(startDate, dayOfMonth, nextDonationDateByIndex);
@@ -1560,8 +1560,8 @@ private with sharing class RD2_ScheduleService_TEST {
         final String dayOfMonth = '29';
 
         Map<Integer, Date> nextDonationDateByIndex = new Map<Integer, Date>{
-                0 => Date.newInstance(2021, 2, 28),
-                1 => Date.newInstance(2021, 3, 29)
+            0 => Date.newInstance(2021, 2, 28),
+            1 => Date.newInstance(2021, 3, 29)
         };
 
         testAndAssertVisualizedInstallments(startDate, dayOfMonth, nextDonationDateByIndex);
@@ -1576,9 +1576,9 @@ private with sharing class RD2_ScheduleService_TEST {
         final String dayOfMonth = '30';
 
         Map<Integer, Date> nextDonationDateByIndex = new Map<Integer, Date>{
-                0 => Date.newInstance(2020, 1, 30),
-                1 => Date.newInstance(2020, 2, 29),
-                2 => Date.newInstance(2020, 3, 30)
+            0 => Date.newInstance(2020, 1, 30),
+            1 => Date.newInstance(2020, 2, 29),
+            2 => Date.newInstance(2020, 3, 30)
         };
 
         testAndAssertVisualizedInstallments(startDate, dayOfMonth, nextDonationDateByIndex);
@@ -1593,8 +1593,8 @@ private with sharing class RD2_ScheduleService_TEST {
         final String dayOfMonth = '30';
 
         Map<Integer, Date> nextDonationDateByIndex = new Map<Integer, Date>{
-                0 => Date.newInstance(2020, 2, 29),
-                1 => Date.newInstance(2020, 3, 30)
+            0 => Date.newInstance(2020, 2, 29),
+            1 => Date.newInstance(2020, 3, 30)
         };
 
         testAndAssertVisualizedInstallments(startDate, dayOfMonth, nextDonationDateByIndex);
@@ -1619,18 +1619,18 @@ private with sharing class RD2_ScheduleService_TEST {
         RD2_ScheduleService service = getScheduleServiceForCurrentDate(startDate);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder()
-                .withDayOfMonth(dayOfMonth)
-                .build();
+            .withDayOfMonth(dayOfMonth)
+            .build();
 
         Test.startTest();
         insert rd;
         Test.stopTest();
 
         List<RecurringDonationSchedule__c> schedules = new RD2_OpportunityEvaluationService()
-                .getRecurringDonations(new Set<Id>{ rd.Id })[0].RecurringDonationSchedules__r;
+            .getRecurringDonations(new Set<Id>{ rd.Id })[0].RecurringDonationSchedules__r;
 
         List<RD2_ScheduleService.Installment> installments = service.getVisualizedInstallments(
-                new List<npe03__Recurring_Donation__c>{ rd }, startDate, numberOfInstallments, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
+            new List<npe03__Recurring_Donation__c>{ rd }, startDate, numberOfInstallments, new Map<Id, List<RecurringDonationSchedule__c>>{ rd.Id => schedules }
         ).values()[0];
 
         System.assertEquals(numberOfInstallments, installments.size(), 'Number of installments should match');
@@ -1638,7 +1638,7 @@ private with sharing class RD2_ScheduleService_TEST {
         for (Integer i : nextDonationDateByIndex.keySet()) {
             Date nextDonationDate = nextDonationDateByIndex.get(i);
             System.assertEquals(nextDonationDate, installments[i].nextDonationDate,
-                    'Installment ' + i + ' date should be: ' + nextDonationDate);
+                'Installment ' + i + ' date should be: ' + nextDonationDate);
         }
     }
 

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -328,7 +328,7 @@ private with sharing class RD2_ValidationService_TEST {
             new String[]{ day }
         );
         System.assert(errMessage.contains(expectedMessage),
-                'The error message should contain invalud Day Of Month message: ' + errMessage);
+            'The error message should contain invalid Day Of Month message: ' + errMessage);
     }
 
     /***


### PR DESCRIPTION
We've added explicit support for monthly recurring donation days 29 and 30 (via Day of Month field). Previously, these days were all considered the last day of the month. Now we will respect the explicit selection in all months where that is possible and treat the selection as the last day of the month in all other cases. Last Day of Month is still supported as an option.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
