### PR TITLE
[Bug Bounty] Unauthorized user can edit Opportunities via button

### DIFF
--- a/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls
+++ b/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls
@@ -353,6 +353,7 @@ private with sharing class ADDR_CopyAddrHHObjBTN_TEST {
         System.currentPageReference().getParameters().put('id', recordId);
         copyAddressCtrl = new ADDR_CopyAddrHHObjBTN_CTRL();
         copyAddressCtrl.perms = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, mockPerms);
+
         copyAddressCtrl.buttonClick();
     }
 

--- a/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls
+++ b/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls
@@ -38,7 +38,7 @@ private with sharing class ADDR_CopyAddrHHObjBTN_TEST {
     private static Contact contactRecord;
     private static npo02__Household__c householdRecord;
     private static ADDR_CopyAddrHHObjBTN_CTRL copyAddressCtrl;
-    private static PermissionsMock mockPerms = new PermissionsMock();
+    private static UTIL_Permissions_TEST.Stub mockPerms = new UTIL_Permissions_TEST.Stub();
 
     /***
     * @description Create records common to test methods
@@ -353,7 +353,7 @@ private with sharing class ADDR_CopyAddrHHObjBTN_TEST {
         System.currentPageReference().getParameters().put('id', recordId);
         copyAddressCtrl = new ADDR_CopyAddrHHObjBTN_CTRL();
         copyAddressCtrl.perms = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, mockPerms);
-
+        System.debug('what is in perms:' + copyAddressCtrl.perms);
         copyAddressCtrl.buttonClick();
     }
 
@@ -364,63 +364,6 @@ private with sharing class ADDR_CopyAddrHHObjBTN_TEST {
     */
     private static void verifyNoteRecordCount(Id parentId) {
         System.assertEquals(1, [SELECT count() FROM Note where ParentID = :parentId]);
-    }
-
-    /***
-    * @description Stub for UTIL_Permissions instance
-    */
-    private class PermissionsMock implements System.StubProvider {
-        private Boolean hasRead = true;
-        private Boolean hasUpdate = true;
-        private Boolean hasCreate = true;
-        private SObjectType readSObjType;
-        private SObjectType updateSObjType;
-        private SObjectType createSObjType;
-        private Set<SObjectField> readSObjFields = new Set<SObjectField>();
-        private Set<SObjectField> updateSObjFields = new Set<SObjectField>();
-        private Set<SObjectField> createSObjFields = new Set<SObjectField>();
-
-        public Object handleMethodCall(
-            Object stubbedObject,
-            String methodName,
-            Type returnType,
-            List<Type> paramTypes,
-            List<String> paramNames,
-            List<Object> args
-        ) {
-            switch on methodName {
-                when 'canRead' {
-                    readSObjType = (SObjectType) args[0];
-                    readSObjFields = getArgumentFields(args);
-
-                    return hasRead;
-
-                } when 'canUpdate' {
-                    updateSObjType = (SObjectType) args[0];
-                    updateSObjFields = getArgumentFields(args);
-
-                    return hasUpdate;
-
-                } when 'canCreate' {
-                    createSObjType = (SObjectType) args[0];
-                    createSObjFields = getArgumentFields(args);
-
-                    return hasCreate;
-
-                } when else {
-                    return null;
-                }
-            }
-        }
-
-        /***
-        * @description Extracts SObject fields from the second argument if specified
-        * @param args Method arguments
-        * @return Set<SObjectField> Fields specified in the second argument of the stubbed method
-        */
-        private Set<SObjectField> getArgumentFields(List<Object> args) {
-            return args.size() > 1 ? (Set<SObjectField>) args[1] : new Set<SObjectField>();
-        }
     }
 
 }

--- a/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls
+++ b/src/classes/ADDR_CopyAddrHHObjBTN_TEST.cls
@@ -353,7 +353,6 @@ private with sharing class ADDR_CopyAddrHHObjBTN_TEST {
         System.currentPageReference().getParameters().put('id', recordId);
         copyAddressCtrl = new ADDR_CopyAddrHHObjBTN_CTRL();
         copyAddressCtrl.perms = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, mockPerms);
-        System.debug('what is in perms:' + copyAddressCtrl.perms);
         copyAddressCtrl.buttonClick();
     }
 

--- a/src/classes/RD_AddDonationsBTN_CTRL.cls
+++ b/src/classes/RD_AddDonationsBTN_CTRL.cls
@@ -44,6 +44,19 @@ public with sharing class RD_AddDonationsBTN_CTRL {
     public Boolean showContinueBtn { get; set; }
 
     /***
+    * @description Permissions class used to determine if the running user has permissions
+    */
+    @TestVisible
+    private static UTIL_Permissions permissions {
+        get {
+            if (permissions == null) {
+                permissions = new UTIL_Permissions();
+            }
+            return permissions;
+        }
+        set;
+    }
+    /***
     * @description Class constructor
     * @param controller The StandardController to the Recurring Donation
     */
@@ -142,16 +155,17 @@ public with sharing class RD_AddDonationsBTN_CTRL {
      * @description Validate that the current User has the appropriate permissions and that Legacy RD is enabled
      */
     public void validate() {
+        SObjectType objType = Opportunity.sObjectType;
+
         if (RD2_EnablementService.isRecurringDonations2Enabled) {
             addMessageAndReturn(ApexPages.Severity.ERROR, System.Label.RD_ErrorAddDonationLimitedToLegacyMode);
 
         } else if (sc.getId() == null) {
             addMessageAndReturn(ApexPages.Severity.ERROR, System.Label.RD_ErrorAddDonationMissingId);
 
-        } else if (!Schema.SObjectType.Opportunity.isCreateable()
-            || !Schema.SObjectType.Opportunity.isUpdateable()
-            || !Schema.SObjectType.Opportunity.isDeletable()
-
+        } else if (!permissions.canCreate(objType)
+            || !permissions.canUpdate(objType)
+            || !permissions.canDelete(objType)
         ) {
             addMessageAndReturn(ApexPages.Severity.ERROR, System.Label.RD_ErrorAddDonationPermissionDenied);
 

--- a/src/classes/RD_AddDonationsBTN_CTRL.cls
+++ b/src/classes/RD_AddDonationsBTN_CTRL.cls
@@ -148,8 +148,12 @@ public with sharing class RD_AddDonationsBTN_CTRL {
         } else if (sc.getId() == null) {
             addMessageAndReturn(ApexPages.Severity.ERROR, System.Label.RD_ErrorAddDonationMissingId);
 
-        } else if (!Schema.SObjectType.Opportunity.isCreateable()) {
-            addMessageAndReturn(ApexPages.Severity.INFO, System.Label.RD_ErrorAddDonationPermissionDenied);
+        } else if (!Schema.SObjectType.Opportunity.isCreateable()
+            || !Schema.SObjectType.Opportunity.isUpdateable()
+            || !Schema.SObjectType.Opportunity.isDeletable()
+
+        ) {
+            addMessageAndReturn(ApexPages.Severity.ERROR, System.Label.RD_ErrorAddDonationPermissionDenied);
 
         } else {
             this.showContinueBtn = true;

--- a/src/classes/RD_AddDonationsBTN_TEST.cls
+++ b/src/classes/RD_AddDonationsBTN_TEST.cls
@@ -143,7 +143,7 @@ private with sharing class RD_AddDonationsBTN_TEST {
     }
 
     /***
-    * @description Verifies if it displays error message when the uer has no create permission
+    * @description Verifies if it displays error message when the user has no create permission
     * on the Opportunity SObject
     */
     @isTest

--- a/src/classes/RD_AddDonationsBTN_TEST.cls
+++ b/src/classes/RD_AddDonationsBTN_TEST.cls
@@ -40,8 +40,6 @@ private with sharing class RD_AddDonationsBTN_TEST {
 
     private static final TEST_SObjectGateway.OpportunityGateway oppGateway = new TEST_SObjectGateway.OpportunityGateway();
 
-    private static UTIL_Permissions_TEST.Stub permissionStub = new UTIL_Permissions_TEST.Stub();
-
     /***
     * @description Verifies Opportunities are recreated when the button is clicked on
     */
@@ -146,82 +144,41 @@ private with sharing class RD_AddDonationsBTN_TEST {
 
     /***
     * @description Verifies if it displays error message when the uer has no create permission
+    * on the Opportunity SObject
     */
     @isTest
     private static void shouldDisplayErrorMessageWhenUserHasNoCreatePermission() {
 
-        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
-        insert acc;
-
-        npe03__Recurring_Donation__c rd = getLegacyRDBuilder()
-            .withAccount(acc.Id)
-            .withNextDonationDate(System.today())
-            .build();
-        insert rd;
-
+        UTIL_Permissions_TEST.Stub permissionStub = new UTIL_Permissions_TEST.Stub();
         permissionStub.hasCreate = false;
-        RD_AddDonationsBTN_CTRL.permissions = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
 
-        RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
-            new ApexPages.StandardController(rd)
-        );
-
-        UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
-        System.assertEquals(false, ctrl.showContinueBtn, 'The continue button should be hidden');
+        testAndAssertUserDoesNotHavePermissions(permissionStub);
     }
 
     /***
-    * @description Verifies if it displays error message when the uer has no edit permission
+    * @description Verifies if it displays error message when the user has no edit permission
+    * on the Opportunity SObject
     */
     @isTest
     private static void shouldDisplayErrorMessageWhenUserHasNoEditPermission() {
 
-        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
-        insert acc;
-
-        npe03__Recurring_Donation__c rd = getLegacyRDBuilder()
-            .withAccount(acc.Id)
-            .withNextDonationDate(System.today())
-            .build();
-        insert rd;
-
+        UTIL_Permissions_TEST.Stub permissionStub = new UTIL_Permissions_TEST.Stub();
         permissionStub.hasUpdate = false;
-        RD_AddDonationsBTN_CTRL.permissions = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
 
-        RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
-            new ApexPages.StandardController(rd)
-        );
-
-        UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
-        System.assertEquals(false, ctrl.showContinueBtn, 'The continue button should be hidden');
-
+        testAndAssertUserDoesNotHavePermissions(permissionStub);
     }
 
     /***
     * @description Verifies if it displays error message when the uer has no delete permission
+    * on the Opportunity SObject
     */
     @isTest
     private static void shouldDisplayErrorMessageWhenUserHasNoDeletePermission() {
 
-        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
-        insert acc;
-
-        npe03__Recurring_Donation__c rd = getLegacyRDBuilder()
-            .withAccount(acc.Id)
-            .withNextDonationDate(System.today())
-            .build();
-        insert rd;
-
+        UTIL_Permissions_TEST.Stub permissionStub = new UTIL_Permissions_TEST.Stub();
         permissionStub.hasDelete = false;
-        RD_AddDonationsBTN_CTRL.permissions = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
 
-        RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
-            new ApexPages.StandardController(rd)
-        );
-
-        UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
-        System.assertEquals(false, ctrl.showContinueBtn, 'The continue button should be hidden');
-
+        testAndAssertUserDoesNotHavePermissions(permissionStub);
     }
 
     // Helpers
@@ -254,6 +211,32 @@ private with sharing class RD_AddDonationsBTN_TEST {
             npe03__Opportunity_Field__c = 'closedate',
             npe03__Recurring_Donation_Field__c = 'Name'
         );
+    }
+
+
+    /***
+    * @description builds test data for account and recurring donations and verifies if it generates
+    * error message if the user do not have required permissions on the opportunity SObject.
+    */
+    private static void testAndAssertUserDoesNotHavePermissions(UTIL_Permissions_TEST.Stub permissionStub) {
+        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
+        insert acc;
+
+        npe03__Recurring_Donation__c rd = getLegacyRDBuilder()
+            .withAccount(acc.Id)
+            .withNextDonationDate(System.today())
+            .build();
+        insert rd;
+
+        RD_AddDonationsBTN_CTRL.permissions = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
+
+        RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
+            new ApexPages.StandardController(rd)
+        );
+
+        UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
+        System.assertEquals(false, ctrl.showContinueBtn, 'The continue button should be hidden');
+
     }
 
 }

--- a/src/classes/RD_AddDonationsBTN_TEST.cls
+++ b/src/classes/RD_AddDonationsBTN_TEST.cls
@@ -40,6 +40,8 @@ private with sharing class RD_AddDonationsBTN_TEST {
 
     private static final TEST_SObjectGateway.OpportunityGateway oppGateway = new TEST_SObjectGateway.OpportunityGateway();
 
+    private static UTIL_Permissions_TEST.Stub permissionStub = new UTIL_Permissions_TEST.Stub();
+
     /***
     * @description Verifies Opportunities are recreated when the button is clicked on
     */
@@ -143,11 +145,10 @@ private with sharing class RD_AddDonationsBTN_TEST {
     }
 
     /***
-    * @description Verify if it displays error message if the user do not have Edit or Delete permissions
+    * @description Verifies if it displays error message when the uer has no create permission
     */
     @isTest
-    private static void shouldDisplayErrorMessageWhenUserHaveNoEditOrDeletePermission() {
-        String accessType = 'CreateOnly';
+    private static void shouldDisplayErrorMessageWhenUserHasNoCreatePermission() {
 
         Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
         insert acc;
@@ -156,42 +157,51 @@ private with sharing class RD_AddDonationsBTN_TEST {
             .withAccount(acc.Id)
             .withNextDonationDate(System.today())
             .build();
-
         insert rd;
 
-        User readOnlyUser = UTIL_UnitTestData_TEST.createUser(UTIL_UnitTestData_TEST.PROFILE_READONLY_USER);
+        permissionStub.hasCreate = false;
+        RD_AddDonationsBTN_CTRL.perms = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
 
-        User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
-        // Run as admin user to set the permission set with object level create permission for the readonlyuser
-        System.runas(adminUser) {
-            assignPermissionSet(accessType, readOnlyUser.id);
-        }
+        RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
+            new ApexPages.StandardController(rd)
+        );
 
+        UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
+        System.assertEquals(false, ctrl.showContinueBtn, 'The continue button should be hidden');
+    }
 
-        Test.startTest();
+    /***
+    * @description Verifies if it displays error message when the uer has no edit permission
+    */
+    @isTest
+    private static void shouldDisplayErrorMessageWhenUserHasNoEditPermission() {
 
-        System.runAs(readOnlyUser) {
-            RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
-                new ApexPages.StandardController(rd)
-            );
+        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
+        insert acc;
 
-            // The error should be generated and rendered by the constructor
-            UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
-            UTIL_UnitTestData_TEST.assertPageHasMessage(System.Label.RD_ErrorAddDonationPermissionDenied, ApexPages.Severity.ERROR);
-            System.assertEquals(false, ctrl.showContinueBtn, 'The continue button should be hidden');
+        npe03__Recurring_Donation__c rd = getLegacyRDBuilder()
+            .withAccount(acc.Id)
+            .withNextDonationDate(System.today())
+            .build();
+        insert rd;
 
-        }
+        permissionStub.hasUpdate = false;
+        RD_AddDonationsBTN_CTRL.perms = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
 
-        Test.stopTest();
+        RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
+            new ApexPages.StandardController(rd)
+        );
+
+        UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
+        System.assertEquals(false, ctrl.showContinueBtn, 'The continue button should be hidden');
 
     }
 
     /***
-    * @description Verify if it refreshes the opportunity when the read only user has all permissions
+    * @description Verifies if it displays error message when the uer has no delete permission
     */
     @isTest
-    private static void shouldContinueRefreshOpportunityWithAllPermissions() {
-        String accessType = 'All';
+    private static void shouldDisplayErrorMessageWhenUserHasNoDeletePermission() {
 
         Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
         insert acc;
@@ -200,35 +210,19 @@ private with sharing class RD_AddDonationsBTN_TEST {
             .withAccount(acc.Id)
             .withNextDonationDate(System.today())
             .build();
-
         insert rd;
 
-        User readOnlyUserWithAllPermission = UTIL_UnitTestData_TEST.createUser(UTIL_UnitTestData_TEST.PROFILE_READONLY_USER);
+        permissionStub.hasDelete = false;
+        RD_AddDonationsBTN_CTRL.perms = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
 
-        User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
-        // Run as admin user to set the permission set with object level create permission for the readonlyuser
-        System.runas(adminUser) {
-            assignPermissionSet(accessType, readOnlyUserWithAllPermission.id);
-        }
+        RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
+            new ApexPages.StandardController(rd)
+        );
 
-
-        Test.startTest();
-
-        System.runAs(readOnlyUserWithAllPermission) {
-            RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
-                new ApexPages.StandardController(rd)
-            );
-
-           System.assertEquals(true, ctrl.showContinueBtn, 'The continue button should be there');
-           System.assertEquals(rd.Id, ctrl.sc.getId());
-
-        }
-
-        Test.stopTest();
+        UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
+        System.assertEquals(false, ctrl.showContinueBtn, 'The continue button should be hidden');
 
     }
-
-
 
     // Helpers
     /////////////
@@ -260,38 +254,6 @@ private with sharing class RD_AddDonationsBTN_TEST {
             npe03__Opportunity_Field__c = 'closedate',
             npe03__Recurring_Donation_Field__c = 'Name'
         );
-    }
-
-    /***
-    * @description Creates and assigns the permission set with Create permission or with all
-    * permissions on Opportunity object
-    */
-    private static void assignPermissionSet(String access, Id userId) {
-        Boolean allPermission = false;
-
-        PermissionSet permission = new PermissionSet(
-            Name = 'PermissionTest',
-            Label = 'PermissionTest'
-        );
-
-        insert permission;
-
-        allPermission = access == 'All' ? allPermission = true : allPermission;
-
-        insert new ObjectPermissions (
-            SObjectType = 'Opportunity',
-            ParentId = permission.id,
-            PermissionsRead = true,
-            PermissionsEdit = allPermission,
-            PermissionsCreate = true,
-            PermissionsDelete = allPermission
-        );
-
-        insert new PermissionSetAssignment(
-            AssigneeId = userId,
-            PermissionSetId = permission.Id
-        );
-
     }
 
 }

--- a/src/classes/RD_AddDonationsBTN_TEST.cls
+++ b/src/classes/RD_AddDonationsBTN_TEST.cls
@@ -147,6 +147,8 @@ private with sharing class RD_AddDonationsBTN_TEST {
     */
     @isTest
     private static void shouldDisplayErrorMessageWhenUserHaveNoEditOrDeletePermission() {
+        String accessType = 'CreateOnly';
+
         Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
         insert acc;
 
@@ -162,7 +164,7 @@ private with sharing class RD_AddDonationsBTN_TEST {
         User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
         // Run as admin user to set the permission set with object level create permission for the readonlyuser
         System.runas(adminUser) {
-            assignCreateOnlyPermissionSet(readOnlyUser.id);
+            assignPermissionSet(accessType, readOnlyUser.id);
         }
 
 
@@ -176,12 +178,56 @@ private with sharing class RD_AddDonationsBTN_TEST {
             // The error should be generated and rendered by the constructor
             UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
             UTIL_UnitTestData_TEST.assertPageHasMessage(System.Label.RD_ErrorAddDonationPermissionDenied, ApexPages.Severity.ERROR);
+            System.assertEquals(false, ctrl.showContinueBtn, 'The continue button should be hidden');
 
         }
 
         Test.stopTest();
 
     }
+
+    /***
+    * @description Verify if it refreshes the opportunity when the read only user has all permissions
+    */
+    @isTest
+    private static void shouldContinueRefreshOpportunityWithAllPermissions() {
+        String accessType = 'All';
+
+        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
+        insert acc;
+
+        npe03__Recurring_Donation__c rd = getLegacyRDBuilder()
+            .withAccount(acc.Id)
+            .withNextDonationDate(System.today())
+            .build();
+
+        insert rd;
+
+        User readOnlyUserWithAllPermission = UTIL_UnitTestData_TEST.createUser(UTIL_UnitTestData_TEST.PROFILE_READONLY_USER);
+
+        User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
+        // Run as admin user to set the permission set with object level create permission for the readonlyuser
+        System.runas(adminUser) {
+            assignPermissionSet(accessType, readOnlyUserWithAllPermission.id);
+        }
+
+
+        Test.startTest();
+
+        System.runAs(readOnlyUserWithAllPermission) {
+            RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
+                new ApexPages.StandardController(rd)
+            );
+
+           System.assertEquals(true, ctrl.showContinueBtn, 'The continue button should be there');
+           System.assertEquals(rd.Id, ctrl.sc.getId());
+
+        }
+
+        Test.stopTest();
+
+    }
+
 
 
     // Helpers
@@ -217,10 +263,12 @@ private with sharing class RD_AddDonationsBTN_TEST {
     }
 
     /***
-    * @description Creates and assigns the permission set with Create permission without edit or delete
-    * permission on Opportunity object
+    * @description Creates and assigns the permission set with Create permission or with all
+    * permissions on Opportunity object
     */
-    private static void assignCreateOnlyPermissionSet(Id userId) {
+    private static void assignPermissionSet(String access, Id userId) {
+        Boolean allPermission = false;
+
         PermissionSet permission = new PermissionSet(
             Name = 'PermissionTest',
             Label = 'PermissionTest'
@@ -228,14 +276,15 @@ private with sharing class RD_AddDonationsBTN_TEST {
 
         insert permission;
 
+        allPermission = access == 'All' ? allPermission = true : allPermission;
 
         insert new ObjectPermissions (
             SObjectType = 'Opportunity',
             ParentId = permission.id,
             PermissionsRead = true,
-            PermissionsEdit = false,
+            PermissionsEdit = allPermission,
             PermissionsCreate = true,
-            PermissionsDelete = false
+            PermissionsDelete = allPermission
         );
 
         insert new PermissionSetAssignment(

--- a/src/classes/RD_AddDonationsBTN_TEST.cls
+++ b/src/classes/RD_AddDonationsBTN_TEST.cls
@@ -160,7 +160,7 @@ private with sharing class RD_AddDonationsBTN_TEST {
         insert rd;
 
         permissionStub.hasCreate = false;
-        RD_AddDonationsBTN_CTRL.perms = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
+        RD_AddDonationsBTN_CTRL.permissions = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
 
         RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
             new ApexPages.StandardController(rd)
@@ -186,7 +186,7 @@ private with sharing class RD_AddDonationsBTN_TEST {
         insert rd;
 
         permissionStub.hasUpdate = false;
-        RD_AddDonationsBTN_CTRL.perms = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
+        RD_AddDonationsBTN_CTRL.permissions = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
 
         RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
             new ApexPages.StandardController(rd)
@@ -213,7 +213,7 @@ private with sharing class RD_AddDonationsBTN_TEST {
         insert rd;
 
         permissionStub.hasDelete = false;
-        RD_AddDonationsBTN_CTRL.perms = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
+        RD_AddDonationsBTN_CTRL.permissions = (UTIL_Permissions) Test.createStub(UTIL_Permissions.class, permissionStub);
 
         RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
             new ApexPages.StandardController(rd)

--- a/src/classes/RD_AddDonationsBTN_TEST.cls
+++ b/src/classes/RD_AddDonationsBTN_TEST.cls
@@ -40,7 +40,6 @@ private with sharing class RD_AddDonationsBTN_TEST {
 
     private static final TEST_SObjectGateway.OpportunityGateway oppGateway = new TEST_SObjectGateway.OpportunityGateway();
 
-
     /***
     * @description Verifies Opportunities are recreated when the button is clicked on
     */
@@ -143,6 +142,47 @@ private with sharing class RD_AddDonationsBTN_TEST {
         Test.stopTest();
     }
 
+    /***
+    * @description Verify if it displays error message if the user do not have Edit or Delete permissions
+    */
+    @isTest
+    private static void shouldDisplayErrorMessageWhenUserHaveNoEditOrDeletePermission() {
+        Account acc = UTIL_UnitTestData_TEST.buildOrganizationAccount();
+        insert acc;
+
+        npe03__Recurring_Donation__c rd = getLegacyRDBuilder()
+            .withAccount(acc.Id)
+            .withNextDonationDate(System.today())
+            .build();
+
+        insert rd;
+
+        User readOnlyUser = UTIL_UnitTestData_TEST.createUser(UTIL_UnitTestData_TEST.PROFILE_READONLY_USER);
+
+        User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
+        // Run as admin user to set the permission set with object level create permission for the readonlyuser
+        System.runas(adminUser) {
+            assignCreateOnlyPermissionSet(readOnlyUser.id);
+        }
+
+
+        Test.startTest();
+
+        System.runAs(readOnlyUser) {
+            RD_AddDonationsBTN_CTRL ctrl = new RD_AddDonationsBTN_CTRL(
+                new ApexPages.StandardController(rd)
+            );
+
+            // The error should be generated and rendered by the constructor
+            UTIL_UnitTestData_TEST.assertPageHasError(System.Label.RD_ErrorAddDonationPermissionDenied);
+            UTIL_UnitTestData_TEST.assertPageHasMessage(System.Label.RD_ErrorAddDonationPermissionDenied, ApexPages.Severity.ERROR);
+
+        }
+
+        Test.stopTest();
+
+    }
+
 
     // Helpers
     /////////////
@@ -175,4 +215,34 @@ private with sharing class RD_AddDonationsBTN_TEST {
             npe03__Recurring_Donation_Field__c = 'Name'
         );
     }
+
+    /***
+    * @description Creates and assigns the permission set with Create permission without edit or delete
+    * permission on Opportunity object
+    */
+    private static void assignCreateOnlyPermissionSet(Id userId) {
+        PermissionSet permission = new PermissionSet(
+            Name = 'PermissionTest',
+            Label = 'PermissionTest'
+        );
+
+        insert permission;
+
+
+        insert new ObjectPermissions (
+            SObjectType = 'Opportunity',
+            ParentId = permission.id,
+            PermissionsRead = true,
+            PermissionsEdit = false,
+            PermissionsCreate = true,
+            PermissionsDelete = false
+        );
+
+        insert new PermissionSetAssignment(
+            AssigneeId = userId,
+            PermissionSetId = permission.Id
+        );
+
+    }
+
 }

--- a/src/classes/UTIL_Permissions.cls
+++ b/src/classes/UTIL_Permissions.cls
@@ -396,6 +396,17 @@ public with sharing class UTIL_Permissions {
         return canCreate(String.valueOf(sObjType), false);
     }
 
+    /***
+    * @description Determines whether the running user has delete permissions for the object
+    * provided
+    *
+    * @param sObjType the sObjectType to check delete permissions
+    * @return Boolean true when the user has permissions for the SObjType provided
+    */
+    public Boolean canDelete(SObjectType sObjType) {
+        return canDelete(String.valueOf(sObjType), false);
+    }
+
     /*******************************************************************************************************************
     * @description Determines whether the running user has update permissions on the sObject and fields provided
     *

--- a/src/classes/UTIL_Permissions_TEST.cls
+++ b/src/classes/UTIL_Permissions_TEST.cls
@@ -28,7 +28,7 @@
     POSSIBILITY OF SUCH DAMAGE.
 */
 @isTest
-private with sharing class UTIL_Permissions_TEST {
+public with sharing class UTIL_Permissions_TEST {
 
     // Read Only users don't have access to custom objects or fields
     private static User getReadOnlyUser() {
@@ -236,6 +236,70 @@ private with sharing class UTIL_Permissions_TEST {
         System.runAs(getSysAdmin()) {
             System.assert(perms.canRead(customSObjType, new Set<SObjectField>{ customSObjField }), 'Admin user should have read access to the custom object/field.');
             System.assert(perms.canUpdate(customSObjType, new Set<SObjectField>{ customSObjField }), 'Admin user should have read access to the custom object/field.');
+        }
+    }
+
+    /***
+    * @description Stub for UTIL_Permissions instance
+    */
+    public class Stub implements System.StubProvider {
+        public Boolean hasRead = true;
+        public Boolean hasUpdate = true;
+        public Boolean hasCreate = true;
+        public Boolean hasDelete = true;
+        public SObjectType readSObjType;
+        public SObjectType updateSObjType;
+        public SObjectType createSObjType;
+        public SObjectType deleteSObjType;
+        public Set<SObjectField> readSObjFields = new Set<SObjectField>();
+        public Set<SObjectField> updateSObjFields = new Set<SObjectField>();
+        public Set<SObjectField> createSObjFields = new Set<SObjectField>();
+
+        public Object handleMethodCall(
+            Object stubbedObject,
+            String methodName,
+            Type returnType,
+            List<Type> paramTypes,
+            List<String> paramNames,
+            List<Object> args
+        ) {
+            switch on methodName {
+                when 'canRead' {
+                    readSObjType = (SObjectType) args[0];
+                    readSObjFields = getArgumentFields(args);
+
+                    return hasRead;
+
+                } when 'canUpdate' {
+                    updateSObjType = (SObjectType) args[0];
+                    updateSObjFields = getArgumentFields(args);
+
+                    return hasUpdate;
+
+                } when 'canCreate' {
+                    createSObjType = (SObjectType) args[0];
+                    createSObjFields = getArgumentFields(args);
+
+                    return hasCreate;
+
+                } when 'canDelete' {
+                    deleteSObjType = (SObjectType) args[0];
+
+                    return hasDelete;
+
+                } when else {
+                    return null;
+                }
+            }
+        }
+
+        /***
+        * @description Extracts SObject fields from the second argument if specified
+        * @param args Method arguments
+        * @return Set<SObjectField> Fields specified in the second argument of the stubbed method
+        */
+        private Set<SObjectField> getArgumentFields(List<Object> args) {
+            return args.size() > 1 ? (Set<SObjectField>) args[1] : new Set<SObjectField>();
         }
     }
 

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2126,8 +2126,8 @@ If you&apos;re not sure how to resolve these errors, post a message in the Nonpr
         <categories>Recurring-Donations, Error</categories>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>You do not have permission to create a donation record</shortDescription>
-        <value>You do not have permission to create a donation record. Please contact your system administrator for more information.</value>
+        <shortDescription>You do not have permission to Refresh opportunities</shortDescription>
+        <value>You don't have the required permissions to Refresh Opportunities. Contact your system administrator for assistance.</value>
     </labels>
     <labels>
         <fullName>RD_ErrorLegacyBatchJobCannotBeRun</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2127,7 +2127,7 @@ If you&apos;re not sure how to resolve these errors, post a message in the Nonpr
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>You do not have permission to Refresh opportunities</shortDescription>
-        <value>You don't have the required permissions to Refresh Opportunities. Contact your system administrator for assistance.</value>
+        <value>You don&apos;t  have the required permissions to Refresh Opportunities. Contact your system administrator for assistance.</value>
     </labels>
     <labels>
         <fullName>RD_ErrorLegacyBatchJobCannotBeRun</fullName>


### PR DESCRIPTION
As a user I want to ensure that those without the correct permissions are not able to modify records.

# Critical Changes

# Changes

 - To use Refresh Opportunities on Recurring Donations, users must now have Read, Create, Edit, and Delete access to the Opportunity object. Previously, a user could use Refresh Opportunities without these permissions.

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
