### PR TITLE
RD2: Fix missing translations for the schedule components

### DIFF
--- a/src/classes/RD2_VisualizeScheduleController.cls
+++ b/src/classes/RD2_VisualizeScheduleController.cls
@@ -61,7 +61,7 @@ public with sharing class RD2_VisualizeScheduleController {
     }
 
     /***
-    * @description Specifies the earliest date when searching for Opportunities 
+    * @description Specifies the earliest date when searching for Opportunities
     */
     private static Date startDate {
         get {
@@ -188,7 +188,7 @@ public with sharing class RD2_VisualizeScheduleController {
     }
 
     /**
-     * @description Constructs the data table RD schedule columns 
+     * @description Constructs the data table RD schedule columns
      * @param rd Recurring Donation
      * @return DataTable
      */
@@ -241,11 +241,11 @@ public with sharing class RD2_VisualizeScheduleController {
             return;//all columns are visible
         }
 
-        for (Object obj : dataTable.getRecords()) {  
-            Installment record = (Installment) obj;          
+        for (Object obj : dataTable.getRecords()) {
+            Installment record = (Installment) obj;
             if (!dataTable.isAccessible(INSTALLMENT_DONATION_DATE)) {
                 record.donationDate = null;
-            } 
+            }
             if (!dataTable.isAccessible(INSTALLMENT_AMOUNT)) {
                 record.amount = null;
             }
@@ -254,7 +254,7 @@ public with sharing class RD2_VisualizeScheduleController {
             }
         }
     }
-    
+
     /**
      * @description Sets null on fields that are not accessible
      * @param dataTable Data table containing columns and schedule records
@@ -266,29 +266,29 @@ public with sharing class RD2_VisualizeScheduleController {
             return;//all columns are visible
         }
 
-        for (Object obj : dataTable.getRecords()) {  
-            Schedule record = (Schedule) obj;   
+        for (Object obj : dataTable.getRecords()) {
+            Schedule record = (Schedule) obj;
             if (!dataTable.isAccessible(SCHEDULE_AMOUNT)) {
                 record.amount = null;
             }
             if (!dataTable.isAccessible(SCHEDULE_PAYMENT_METHOD)) {
                 record.paymentMethod = null;
-            }  
+            }
             if (!dataTable.isAccessible(SCHEDULE_CAMPAIGN)) {
                 record.campaign = null;
             }
             if (!dataTable.isAccessible(SCHEDULE_START_DATE)) {
                 record.startDate = null;
-            }  
+            }
             if (!dataTable.isAccessible(SCHEDULE_END_DATE)) {
                 record.endDate = null;
-            }  
+            }
             if (!dataTable.isAccessible(SCHEDULE_PERIOD)) {
                 record.period = null;
-            }  
+            }
             if (!dataTable.isAccessible(SCHEDULE_FREQUENCY)) {
                 record.frequency = null;
-            }  
+            }
             if (!dataTable.isAccessible(SCHEDULE_DAY_OF_MONTH)) {
                 record.dayOfMonth = null;
             }
@@ -323,8 +323,8 @@ public with sharing class RD2_VisualizeScheduleController {
 
             RD2_OpportunityEvaluationService oppEvalService = new RD2_OpportunityEvaluationService();
             queryFields.add(oppEvalService.getScheduleSubQuery());
-            queryFields.add(oppEvalService.getOpportunitySubQuery());            
-                
+            queryFields.add(oppEvalService.getOpportunitySubQuery());
+
             String soql = new UTIL_Query()
                 .withFrom(npe03__Recurring_Donation__c.SObjectType)
                 .withSelectFields(queryFields)
@@ -377,7 +377,9 @@ public with sharing class RD2_VisualizeScheduleController {
 
         public Installment(Integer num, RD2_ScheduleService.Installment installment) {
             this.installmentNumber = num;
-            this.paymentMethod = installment.paymentMethod;
+            this.paymentMethod =
+                UTIL_Describe.getTranslatedPicklistLabel(npe03__Recurring_Donation__c.SObjectType,
+                    npe03__Recurring_Donation__c.PaymentMethod__c, installment.paymentMethod);
             this.donationDate = installment.nextDonationDate;
             this.amount = installment.installmentAmount;
         }
@@ -402,13 +404,22 @@ public with sharing class RD2_VisualizeScheduleController {
             this.scheduleNumber = num;
             this.isCurrent = schedule.isCurrent;
             this.amount = schedule.installmentAmount;
-            this.paymentMethod = schedule.paymentMethod;
+            this.paymentMethod = UTIL_Describe.getTranslatedPicklistLabel(
+                npe03__Recurring_Donation__c.SObjectType,
+                npe03__Recurring_Donation__c.PaymentMethod__c,
+                schedule.paymentMethod);
             this.campaign = schedule.campaignName;
             this.startDate = schedule.startDate;
             this.endDate = schedule.endDate;
-            this.period = schedule.installmentPeriod;
+            this.period = UTIL_Describe.getTranslatedPicklistLabel(
+                npe03__Recurring_Donation__c.SObjectType,
+                npe03__Recurring_Donation__c.npe03__Installment_Period__c,
+                schedule.installmentPeriod);
             this.frequency = schedule.installmentFrequency;
-            this.dayOfMonth = schedule.dayOfMonth;
+            this.dayOfMonth = UTIL_Describe.getTranslatedPicklistLabel(
+                npe03__Recurring_Donation__c.SObjectType,
+                npe03__Recurring_Donation__c.Day_of_Month__c,
+                schedule.dayOfMonth);
         }
     }
 
@@ -535,8 +546,8 @@ public with sharing class RD2_VisualizeScheduleController {
         }
 
         /**
-         * @description Sets the field name used to connect the column 
-         * and the record field value. For example, 
+         * @description Sets the field name used to connect the column
+         * and the record field value. For example,
          * the Installment object has "donationDate" field that will be
          * mapped to the column with fieldName = donationDate in the LWC component.
          * @param fieldName Record field name so column and field value can be connected

--- a/src/classes/UTIL_Describe.cls
+++ b/src/classes/UTIL_Describe.cls
@@ -43,13 +43,14 @@ public class UTIL_Describe {
     // throw custom exceptions when a bogus object or field is provided.
     public class SchemaDescribeException extends Exception {}
 
-    //maps to hold the describe info
+    // maps to hold the describe info
     private static Map<String, Schema.SObjectType> gd;
     private static Map<String, Schema.DescribeSObjectResult> objectDescribes = new Map<String, Schema.DescribeSObjectResult>();
     private static Map<Schema.SObjectType, Schema.DescribeSObjectResult> objectDescribesByType = new Map<Schema.SObjectType, Schema.DescribeSObjectResult>();
     private static Map<String, Map<String, Schema.SObjectField>> fieldTokens = new Map<String,Map<String, Schema.SObjectField>>();
     private static Map<String, Map<String, Schema.DescribeFieldResult>> fieldDescribes = new Map<String,Map<String, Schema.DescribeFieldResult>>();
     private static UTIL_Describe utilDescribeInstance;
+    private static Map<Schema.SObjectField, Map<String, String>> picklistTranslations = new Map<Schema.SObjectField, Map<String, String>>();
 
     /**
     * @description Returns static instance of this class.  Primarily used to facilitate
@@ -73,7 +74,7 @@ public class UTIL_Describe {
     private static void setInstance(UTIL_Describe utilDescribe){
         utilDescribeInstance = utilDescribe;
     }
-    
+
     /*******************************************************************************************************
     * @description Map display types to a friendly user-readable label.
     */
@@ -287,7 +288,7 @@ public class UTIL_Describe {
                 }
             }
         }
-        
+
         return nameField;
     }
 
@@ -540,9 +541,9 @@ public class UTIL_Describe {
             DescribeFieldResult dfr = UTIL_Describe.getFieldDescribe(strObject, strF);
             if (dfr == null || !dfr.isCreateable() || !dfr.isUpdateable())
                 throw (new permsException(string.format(label.flsError, new string[]{strObject + '.' + strF})));
-            
+
             // don't copy null for checkbox fields, or they will give an error on update
-            if (dfr.isNillable() || src.get(strF)!= null) {    
+            if (dfr.isNillable() || src.get(strF)!= null) {
                 dst.put(strF, src.get(strF));
             }
         }
@@ -607,19 +608,39 @@ public class UTIL_Describe {
         return options;
     }
 
+    /**
+    * @description Retrieve the localized picklist label for any given picklist api name
+    * @param objectType SObjectType
+    * @param fieldType SObjectField
+    * @param apiName picklist api name
+    * @return Translated picklist label (could be English if the language is English)
+    */
+    public static String getTranslatedPicklistLabel(SObjectType objectType, SObjectField fieldType, String apiName) {
+        if (!picklistTranslations.containsKey(fieldType)) {
+            picklistTranslations.put(fieldType, new Map<String, String>());
+            String fieldName = String.valueOf(fieldType);
+            String objectName = String.valueOf(objectType);
+            for (SelectOption option : UTIL_Describe.getSelectOptions(objectName, fieldName)) {
+                picklistTranslations.get(fieldType).put(option.getValue(), option.getLabel());
+            }
+        }
+        return picklistTranslations.get(fieldType).get(apiName);
+    }
+
+
     /** @description For a given object and field, verifies that the field is accessible and updateable
      * throwing an exception if it isn't.*/
     public static void checkFieldFLS(String objectName, String fieldName) {
 
         DescribeFieldResult dfr = getFieldDescribe(
-            UTIL_Namespace.StrTokenNSPrefix(objectName), 
+            UTIL_Namespace.StrTokenNSPrefix(objectName),
             fieldName.endsWith('__c')?UTIL_Namespace.StrTokenNSPrefix(fieldName):fieldName
         );
         if (dfr == null || !dfr.isAccessible() || !dfr.isUpdateable()) {
             throw (new permsException(
                 string.format(
-                    label.flsError, 
-                    new string[]{UTIL_Namespace.StrTokenNSPrefix(objectName) + '.' + 
+                    label.flsError,
+                    new string[]{UTIL_Namespace.StrTokenNSPrefix(objectName) + '.' +
                                  UTIL_Namespace.StrTokenNSPrefix(fieldName)}
                 )
             ));
@@ -690,7 +711,7 @@ public class UTIL_Describe {
     * @param displayType The all caps version of the display type provided from a field describe
     * @return String the friendly label name for the display type
     */
-    public static String getLabelForDisplayType(String displayType) {   
+    public static String getLabelForDisplayType(String displayType) {
         return LABELS_BY_DISPLAY_TYPE.get(displayType);
     }
 }

--- a/src/classes/UTIL_Describe_TEST.cls
+++ b/src/classes/UTIL_Describe_TEST.cls
@@ -1,10 +1,10 @@
 /*
     Copyright (c) 2014 Salesforce.org
     All rights reserved.
-    
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
-    
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -13,18 +13,18 @@
     * Neither the name of Salesforce.org nor the names of
       its contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
- 
+
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 /**
 * @author Salesforce.org
@@ -38,51 +38,120 @@
 * that are made, making the total transaction more efficient.
 */
 @isTest
-public with sharing class UTIL_Describe_TEST {
+private with sharing class UTIL_Describe_TEST {
 
-    // TEST
-    static testmethod void testDescribe() {
-        
-        string s;
-        
-        Schema.DescribeSObjectResult res = UTIL_Describe.getObjectDescribe('Contact');        
-        system.assertEquals(res.getName(), 'Contact');
+    @IsTest
+    private static void shouldReturnExpectedDescribes() {
+        String s;
+
+        Schema.DescribeSObjectResult res = UTIL_Describe.getObjectDescribe('Contact');
+        System.assertEquals(res.getName(), 'Contact');
         s = UTIL_Describe.getObjectLabel('Contact');
-        system.assertEquals (s, res.getLabel());
+        System.assertEquals (s, res.getLabel());
 
-        account a = new account(name='Test');
-        insert a;
-        system.assert(UTIL_Describe.isObjectIdThisType(a.id, 'Account'));
-        
+        Account a = UTIL_UnitTestData_TEST.buildHouseholdAccount();
+        a.Id = UTIL_UnitTestData_TEST.MOCK_ACCOUNT_ID;
+        System.assert(UTIL_Describe.isObjectIdThisType(a.Id, 'Account'));
+
         s = UTIL_Describe.getFieldLabel('Account', 'LastModifiedDate');
-        
-        Schema.DescribeFieldResult fr = UTIL_Describe.getFieldDescribe('Account', 'CreatedDate');     
+
+        Schema.DescribeFieldResult fr = UTIL_Describe.getFieldDescribe('Account', 'CreatedDate');
         s = UTIL_Describe.getFieldLabel('Account', 'CreatedDate');
-        system.assertEquals (s, fr.getLabel());
+        System.assertEquals (s, fr.getLabel());
 
         Map<String, Schema.DescribeFieldResult> afd = UTIL_Describe.getAllFieldsDescribe('Account');
-        system.assertEquals ('BillingCity', afd.get('billingcity').getName());
+        System.assertEquals ('BillingCity', afd.get('billingcity').getName());
         afd = UTIL_Describe.getAllFieldsDescribe('Account');
 
         SObject acctObj = UTIL_Describe.getPrototypeObject('Account');
-        // should be able to cast to account
-        account acct = (account)(acctObj);
+        // should be able to cast to Account
+        Account acct = (Account)(acctObj);
 
         s = UTIL_Describe.getFieldType('Account', 'CreatedDate');
-        system.assertEquals('DATETIME', s);
-        
+        System.assertEquals('DATETIME', s);
+
         s = UTIL_Describe.getNameField('Account');
-        system.assertEquals('name', s);
+        System.assertEquals('name', s);
 
         try {
             s = UTIL_Describe.getObjectLabel('sdlkfjsdlkfjsldkfjlsdkfj');
-        } catch (exception e) {
-            system.assertEquals('Invalid object name \'sdlkfjsdlkfjsldkfjlsdkfj\'', e.getMessage());
-        } 
+        } catch (Exception e) {
+            System.assertEquals('Invalid object name \'sdlkfjsdlkfjsldkfjlsdkfj\'', e.getMessage());
+        }
         try {
             s = UTIL_Describe.getFieldLabel('Opportunity', 'sdlkfjsdlkfjsldkfjlsdkfj');
-        } catch (exception e) {
-            system.assertEquals('Invalid field name \'sdlkfjsdlkfjsldkfjlsdkfj\'', e.getMessage());
-        } 
-    }  
+        } catch (Exception e) {
+            System.assertEquals('Invalid field name \'sdlkfjsdlkfjsldkfjlsdkfj\'', e.getMessage());
+        }
+    }
+
+    /**
+    * @description Validate that the Picklist value for "Open" is returned as the English value.
+    */
+    @IsTest
+    private static void shouldReturnEnglishPicklist() {
+        npe03__Recurring_Donation__c rd = TEST_RecurringDonationBuilder.constructLegacyBuilder()
+            .withDefaultValues()
+            .withOpenEndedStatusOpen()
+            .build();
+
+        System.assertEquals(RD_Constants.OPEN_ENDED_STATUS_OPEN, rd.npe03__Open_Ended_Status__c);
+        User englishUser = buildEnglishUser();
+        System.runAs(englishUser) {
+            System.assertEquals(RD_Constants.OPEN_ENDED_STATUS_OPEN,
+                UTIL_Describe.getTranslatedPicklistLabel(npe03__Recurring_Donation__c.SObjectType,
+                    npe03__Recurring_Donation__c.npe03__Open_Ended_Status__c,
+                    rd.npe03__Open_Ended_Status__c),
+                'The English translation for Open should be Open');
+        }
+    }
+
+    /**
+    * @description Validate that the translated Spanish Picklist value for "Open" is returned.
+    * This npe03__Open_Ended_Status__c field is translated in the RD underlying package.
+    */
+    @IsTest
+    private static void shouldReturnSpanishPicklist() {
+        npe03__Recurring_Donation__c rd = TEST_RecurringDonationBuilder.constructLegacyBuilder()
+            .withDefaultValues()
+            .withOpenEndedStatusOpen()
+            .build();
+
+        System.assertEquals(RD_Constants.OPEN_ENDED_STATUS_OPEN, rd.npe03__Open_Ended_Status__c);
+
+        User spanishUser = buildSpanishUser();
+        System.runAs(spanishUser) {
+            System.debug('> ' + UserInfo.getLanguage());
+            System.assertEquals('Abierto',
+                UTIL_Describe.getTranslatedPicklistLabel(npe03__Recurring_Donation__c.SObjectType,
+                    npe03__Recurring_Donation__c.npe03__Open_Ended_Status__c,
+                    rd.npe03__Open_Ended_Status__c),
+                'The Spanish translation for Open should be Abierto');
+        }
+    }
+
+    // Helpers
+    //////////////
+
+    /***
+     * @description Builds a user using English language and locale
+     * @return User
+     */
+    private static User buildEnglishUser() {
+        User usr = UTIL_UnitTestData_Test.createUserWithoutInsert(UTIL_Profile.PROFILE_STANDARD_USER);
+
+        usr.LanguageLocaleKey = 'en_US';
+        return usr;
+    }
+
+    /***
+     * @description Builds a user using Spanish language and locale
+     * @return User
+     */
+    private static User buildSpanishUser() {
+        User usr = UTIL_UnitTestData_Test.createUserWithoutInsert(UTIL_Profile.PROFILE_STANDARD_USER);
+
+        usr.LanguageLocaleKey = 'es';
+        return usr;
+    }
 }


### PR DESCRIPTION
- When Enhanced Recurirng Donations is enabled, always display the translated picklist label in the lightning components

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
