### PR TITLE
RD2:  Do not auto-create Opportunities for Elevate originated RDs

### DIFF
--- a/src/classes/PS_IntegrationServiceConfig.cls
+++ b/src/classes/PS_IntegrationServiceConfig.cls
@@ -1,0 +1,74 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Recurring Donations
+* @description Determines the Elevate Payment Integration Services status and permissions
+*/
+public with sharing class PS_IntegrationServiceConfig {
+
+    /**
+    * @description Determines if the Elevate integration service is configured and enabled.
+    * The Elevate Payment Services integration is considered "enabled" (for now) when there
+    * is at least a single record in the protected Payment Services Configuration object
+    * @return Boolean
+    */
+    private Boolean isEnabled {
+        get {
+            if (isEnabled == null) {
+                //Integer configCount = Database.countQuery('SELECT Count() FROM Payment_Services_Configuration__c');
+                Integer configCount = 0;//TODO: hard-coded, disable the integration service until full implementation
+                isEnabled = configCount > 0;
+            }
+            return isEnabled;
+        }
+        set;
+    }
+
+    /**
+    * @description Returns the Elevate integration service enablement status
+    * @return Boolean
+    */
+    public Boolean isIntegrationEnabled() {
+        return isEnabled;
+    }
+
+    /**
+    * @description Determines if the current user has the appropriate permissions to modify Elevate records
+    * @return Boolean
+    */
+    public Boolean hasIntegrationPermissions() {
+        // If the integration service is not enabled, user does not have the integration permissions
+        if (!isEnabled) {
+            return false;
+        }
+
+        return false;//TODO: hard-coded until the full implementation
+    }
+
+}

--- a/src/classes/PS_IntegrationServiceConfig.cls-meta.xml
+++ b/src/classes/PS_IntegrationServiceConfig.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/PS_IntegrationServiceConfig_TEST.cls
+++ b/src/classes/PS_IntegrationServiceConfig_TEST.cls
@@ -1,0 +1,74 @@
+/*
+    Copyright (c) 2020, Salesforce.org
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Recurring Donations
+* @description Unit Tests for the Elevate Integration Service configuration and enablement
+*/
+@IsTest
+public with sharing class PS_IntegrationServiceConfig_TEST {
+
+    /***
+    * @description Stub for the integration service config instance
+    */
+    public class Stub implements System.StubProvider {
+        private Boolean isEnabled = false;
+        private Boolean hasPermissions = false;
+
+        public Stub withIsIntegrationEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            return this;
+        }
+
+        public Stub withHasIntegrationPermissions(Boolean hasPermissions) {
+            this.hasPermissions = hasPermissions;
+            return this;
+        }
+
+        public Object handleMethodCall(
+            Object stubbedObject,
+            String methodName,
+            Type returnType,
+            List<Type> paramTypes,
+            List<String> paramNames,
+            List<Object> args
+        ) {
+            switch on methodName {
+                when 'isIntegrationEnabled' {
+                    return isEnabled;
+
+                } when 'hasIntegrationPermissions' {
+                    return hasPermissions;
+
+                } when else {
+                    return null;
+                }
+            }
+        }
+    }
+}

--- a/src/classes/PS_IntegrationServiceConfig_TEST.cls-meta.xml
+++ b/src/classes/PS_IntegrationServiceConfig_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/RD2_ElevateIntegrationService.cls
+++ b/src/classes/RD2_ElevateIntegrationService.cls
@@ -39,7 +39,7 @@ public inherited sharing class RD2_ElevateIntegrationService {
     * @description Contains configuration related to the Elevate integration service config and permissions
     */
     @TestVisible
-    private PS_IntegrationServiceConfig config {
+    private static PS_IntegrationServiceConfig config {
         get {
             if (config == null) {
                 config = new PS_IntegrationServiceConfig();
@@ -53,7 +53,7 @@ public inherited sharing class RD2_ElevateIntegrationService {
     * @description Returns the Elevate Integration service enablement status
     * @return Boolean
     */
-    public Boolean isIntegrationEnabled() {
+    public static Boolean isIntegrationEnabled() {
         return config.isIntegrationEnabled();
     }
 

--- a/src/classes/RD2_ElevateIntegrationService.cls
+++ b/src/classes/RD2_ElevateIntegrationService.cls
@@ -35,6 +35,29 @@
 */
 public inherited sharing class RD2_ElevateIntegrationService {
 
+    /***
+    * @description Contains configuration related to the Elevate integration service config and permissions
+    */
+    @TestVisible
+    private PS_IntegrationServiceConfig config {
+        get {
+            if (config == null) {
+                config = new PS_IntegrationServiceConfig();
+            }
+            return config;
+        }
+        set;
+    }
+
+    /***
+    * @description Returns the Elevate Integration service enablement status
+    * @return Boolean
+    */
+    public Boolean isIntegrationEnabled() {
+        return config.isIntegrationEnabled();
+    }
+
+
     /**
     * @description For each CommitmentId, find any existing Opportunities with the matching Commitmentid
     * and update the RecuringDonation lookup field (only if null).

--- a/src/classes/RD2_ElevateIntegrationService_TEST.cls
+++ b/src/classes/RD2_ElevateIntegrationService_TEST.cls
@@ -34,11 +34,11 @@
 * @description Unit Tests for the Elevate Integration Service
 */
 @IsTest
-private class RD2_ElevateIntegrationService_TEST {
+public class RD2_ElevateIntegrationService_TEST {
     private static final TEST_SObjectGateway.RecurringDonationGateway rdGateway = new TEST_SObjectGateway.RecurringDonationGateway();
     private static final TEST_SObjectGateway.OpportunityGateway oppGateway = new TEST_SObjectGateway.OpportunityGateway();
 
-    private static final String COMMITMENT_ID = '0009989378376210918302112371207242332342432';
+    public static final String COMMITMENT_ID = '0009989378376210918302112371207242332342432';
 
     /****
     * @description Creates data required for unit tests

--- a/src/classes/RD2_OpportunityEvaluationService.cls
+++ b/src/classes/RD2_OpportunityEvaluationService.cls
@@ -62,10 +62,6 @@ public inherited sharing class RD2_OpportunityEvaluationService {
      */
     public static Boolean skipEvaluationService = false;
 
-    public Boolean isIntegrationEnabled() {
-        return RD2_ElevateIntegrationService.isIntegrationEnabled();
-    }
-
     /**
     * @description Indicates if the Opportunity evaluation is invoked from a nightly batch job
     */
@@ -424,7 +420,7 @@ public inherited sharing class RD2_OpportunityEvaluationService {
         Boolean hasMandatoryConditions = rd.isActive()
             && rd.hasNextDonationDate()
             && rd.hasSchedule()
-            && (!isIntegrationEnabled() || !rd.isElevateRecord());
+            && (!RD2_ElevateIntegrationService.isIntegrationEnabled() || !rd.isElevateRecord());
 
         if (!hasMandatoryConditions) {
             return false;

--- a/src/classes/RD2_OpportunityEvaluationService.cls
+++ b/src/classes/RD2_OpportunityEvaluationService.cls
@@ -62,6 +62,10 @@ public inherited sharing class RD2_OpportunityEvaluationService {
      */
     public static Boolean skipEvaluationService = false;
 
+    public Boolean isIntegrationEnabled() {
+        return RD2_ElevateIntegrationService.isIntegrationEnabled();
+    }
+
     /**
     * @description Indicates if the Opportunity evaluation is invoked from a nightly batch job
     */
@@ -416,11 +420,11 @@ public inherited sharing class RD2_OpportunityEvaluationService {
      * @param rd Recurring Donation record
      * @return Boolean
      */
-    private Boolean isNewOpportunityCandidate(RD2_RecurringDonation rd) {
+    private  Boolean isNewOpportunityCandidate(RD2_RecurringDonation rd) {
         Boolean hasMandatoryConditions = rd.isActive()
             && rd.hasNextDonationDate()
             && rd.hasSchedule()
-            && rd.isElevateIntegrationDisabled();
+            && (!isIntegrationEnabled() || !rd.isElevateRecord());
 
         if (!hasMandatoryConditions) {
             return false;

--- a/src/classes/RD2_OpportunityEvaluationService.cls
+++ b/src/classes/RD2_OpportunityEvaluationService.cls
@@ -171,7 +171,7 @@ public inherited sharing class RD2_OpportunityEvaluationService {
                 customFieldMapper = new RD2_CustomFieldMapper();
             }
             return customFieldMapper;
-        } 
+        }
         set;
     }
 
@@ -368,7 +368,7 @@ public inherited sharing class RD2_OpportunityEvaluationService {
      * @return RD2_OpportunityEvaluationService This service instance
      */
     private RD2_OpportunityEvaluationService handleOutdatedRecurringDonations(List<RD2_RecurringDonation> rdRecords) {
-        //reset Recurring Donations so just created/updated Opps are retrieved 
+        //reset Recurring Donations so just created/updated Opps are retrieved
         //in order to calculate the Current/Next Year Values
         rds = null;
 
@@ -419,7 +419,8 @@ public inherited sharing class RD2_OpportunityEvaluationService {
     private Boolean isNewOpportunityCandidate(RD2_RecurringDonation rd) {
         Boolean hasMandatoryConditions = rd.isActive()
             && rd.hasNextDonationDate()
-            && rd.hasSchedule();
+            && rd.hasSchedule()
+            && rd.isElevateIntegrationDisabled();
 
         if (!hasMandatoryConditions) {
             return false;
@@ -493,7 +494,7 @@ public inherited sharing class RD2_OpportunityEvaluationService {
     }
 
     /**
-     * @description Returns query on Recurring Donation Schedule 
+     * @description Returns query on Recurring Donation Schedule
      * Return all schedules for the RD Schedule visualization.
      * The Schedule Service will filter them out if not applicable within the time period.
      * @return String RD Schedule subquery used in the Recurring Donation SOQL
@@ -542,8 +543,8 @@ public inherited sharing class RD2_OpportunityEvaluationService {
                 'OR CloseDate >= :startDate '
             )
             .withOrderBy('npe03__Recurring_Donation__c, CloseDate ASC')
-            .build();       
-            
+            .build();
+
         return '(' + oppSubquery + ')';
     }
 
@@ -599,7 +600,7 @@ public inherited sharing class RD2_OpportunityEvaluationService {
         ]) {
             paidInstallmentsByRDId.put((Id) result.get('npe03__Recurring_Donation__c'), (Integer) result.get('paidInstallments'));
         }
-           
+
         return paidInstallmentsByRDId;
     }
 

--- a/src/classes/RD2_OpportunityEvaluationService_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluationService_TEST.cls
@@ -419,10 +419,8 @@ private class RD2_OpportunityEvaluationService_TEST {
     */
     @IsTest
     private static void shouldNotCreateFutureOppWhenRDisFromElevateWithCommitmentID() {
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
-        Boolean isEnabled = true;
-        mockperms.withIsIntegrationEnabled(isEnabled);
+        mockperms.withIsIntegrationEnabled(true);
 
         List<Opportunity> opps = testDataForElevateRD(mockperms, MOCK_COMMITMENT_ID);
 
@@ -437,10 +435,8 @@ private class RD2_OpportunityEvaluationService_TEST {
     */
     @IsTest
     private static void shouldCreateFutureOppWhenRDisFromElevateWithoutCommitmentId() {
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
-        Boolean isEnabled = true;
-        mockperms.withIsIntegrationEnabled(isEnabled);
+        mockperms.withIsIntegrationEnabled(true);
 
         Id MockId = null;
         List<Opportunity> opps = testDataForElevateRD(mockperms, MockId);
@@ -457,10 +453,8 @@ private class RD2_OpportunityEvaluationService_TEST {
     */
     @IsTest
     private static void shouldCreateFutureOppWhenRDIsNotFromElevateWithCommitmentId() {
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
-        Boolean isEnabled = false;
-        mockperms.withIsIntegrationEnabled(isEnabled);
+        mockperms.withIsIntegrationEnabled(false);
 
         List<Opportunity> opps = testDataForElevateRD(mockperms, MOCK_COMMITMENT_ID);
 

--- a/src/classes/RD2_OpportunityEvaluationService_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluationService_TEST.cls
@@ -413,9 +413,9 @@ private class RD2_OpportunityEvaluationService_TEST {
             'The installment Opportunity should be created: ' + opps);
     }
 
-     /**
-    * @description Verifies on installment Opportunity is created on RD insert
-    * when Installment Auto Creation Setting is set to Always Create Next Installment.
+    /**
+    * @description Verifies no opportunity is created on RD insert when elevate integration
+    * is enabled and RD is created with commitment Id.
     */
     @IsTest
     private static void shouldNotCreateFutureOppWhenRDisFromElevateWithCommitmentID() {
@@ -431,6 +431,10 @@ private class RD2_OpportunityEvaluationService_TEST {
 
     }
 
+    /**
+    * @description Verifies opportunity is created on RD insert when elevate integration
+    * is enabled and RD is created without commitment Id.
+    */
     @IsTest
     private static void shouldCreateFutureOppWhenRDisFromElevateWithoutCommitmentId() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
@@ -447,6 +451,10 @@ private class RD2_OpportunityEvaluationService_TEST {
 
     }
 
+    /**
+    * @description Verifies opportunity is created on RD insert when elevate integration
+    * is disabled and RD is created with commitment Id.
+    */
     @IsTest
     private static void shouldCreateFutureOppWhenRDIsNotFromElevateWithCommitmentId() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();

--- a/src/classes/RD2_OpportunityEvaluationService_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluationService_TEST.cls
@@ -1601,7 +1601,7 @@ private class RD2_OpportunityEvaluationService_TEST {
     private static npe03__Recurring_Donation__c setUpElevateTestData(PS_IntegrationServiceConfig_TEST.Stub configStub, String commitmentId) {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
-        RD2_RecurringDonation.config = (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, configStub);
+        RD2_ElevateIntegrationService.config = (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, configStub);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact())
             .withDayOfMonth('20')

--- a/src/classes/RD2_OpportunityEvaluationService_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluationService_TEST.cls
@@ -44,7 +44,7 @@ private class RD2_OpportunityEvaluationService_TEST {
     private static final String OPTION_NAME_DISABLE_FIRST = RD2_Constants.InstallmentCreateOptions.Disable_First_Installment.name();
     private static final String OPTION_NAME_DISABLE_ALL = RD2_Constants.InstallmentCreateOptions.Disable_All_Installments.name();
     private static final String OPTION_NAME_ALWAYS_CREATE_NEXT = RD2_Constants.InstallmentCreateOptions.Always_Create_Next_Installment.name();
-    private static final Id MOCK_COMMITMENT_ID = '707f100007HyXHJAA3';
+    private static final String MOCK_COMMITMENT_ID = RD2_ElevateIntegrationService_TEST.COMMITMENT_ID;
 
     private static final Date START_DATE = Date.newInstance(2019, 9, 15);
     private static final Integer MONTHS_TO_DEC = START_DATE.monthsBetween(Date.newInstance(2019, 12, 15));
@@ -53,9 +53,6 @@ private class RD2_OpportunityEvaluationService_TEST {
     private static final String PAYMENT_CHECK = 'Check';
     private static final Decimal RD_AMOUNT = 100;
     private static final Decimal RD_NEW_AMOUNT = 200;
-
-    private static PS_IntegrationServiceConfig_TEST.Stub mockperms = new PS_IntegrationServiceConfig_TEST.Stub();
-
 
     /****
     * @description Creates data required for unit tests
@@ -413,54 +410,53 @@ private class RD2_OpportunityEvaluationService_TEST {
             'The installment Opportunity should be created: ' + opps);
     }
 
+
     /**
-    * @description Verifies no opportunity is created on RD insert when elevate integration
-    * is enabled and RD is created with commitment Id.
+    * @description Verifies no installment Opportunity is created on RD insert when
+    * Elevate integration is enabled and Commitment Id is specified on the RD.
     */
     @IsTest
-    private static void shouldNotCreateFutureOppWhenRDisFromElevateWithCommitmentID() {
+    private static void shouldNotCreateOppOnElevateRdInsertWhenIntegrationIsEnabled() {
+        PS_IntegrationServiceConfig_TEST.Stub configStub = new PS_IntegrationServiceConfig_TEST.Stub()
+            .withIsIntegrationEnabled(true);
 
-        mockperms.withIsIntegrationEnabled(true);
-
-        List<Opportunity> opps = testDataForElevateRD(mockperms, MOCK_COMMITMENT_ID);
+        npe03__Recurring_Donation__c rd = setUpElevateTestData(configStub, MOCK_COMMITMENT_ID);
+        List<Opportunity> opps = oppGateway.getRecords(rd);
 
         System.assertEquals(0, opps.size(),
-            'The installment Opportunity should not be created: ' + opps);
-
+            'No installment Opportunity should be created for the Elevate RD when integration is enabled: ' + opps);
     }
 
     /**
-    * @description Verifies opportunity is created on RD insert when elevate integration
-    * is enabled and RD is created without commitment Id.
+    * @description Verifies an installment Opportunity is created on RD insert when
+    * Elevate integration is enabled and Commitment Id is not specified on the RD.
     */
     @IsTest
-    private static void shouldCreateFutureOppWhenRDisFromElevateWithoutCommitmentId() {
+    private static void shouldCreateOppOnNonElevateRDInsertWhenIntegrationIsEnabled() {
+        PS_IntegrationServiceConfig_TEST.Stub configStub = new PS_IntegrationServiceConfig_TEST.Stub()
+            .withIsIntegrationEnabled(true);
 
-        mockperms.withIsIntegrationEnabled(true);
-
-        Id MockId = null;
-        List<Opportunity> opps = testDataForElevateRD(mockperms, MockId);
+        npe03__Recurring_Donation__c rd = setUpElevateTestData(configStub, null);
+        List<Opportunity> opps = oppGateway.getRecords(rd);
 
         System.assertEquals(1, opps.size(),
-            'The installment Opportunity should not be created: ' + opps);
-
-
+            'An installment Opportunity should be created for the non-Elevate RD: ' + opps);
     }
 
     /**
-    * @description Verifies opportunity is created on RD insert when elevate integration
-    * is disabled and RD is created with commitment Id.
+    * @description Verifies an installment Opportunity is created on RD insert when
+    * Elevate integration is disabled and Commitment Id is specified on the RD.
     */
     @IsTest
-    private static void shouldCreateFutureOppWhenRDIsNotFromElevateWithCommitmentId() {
+    private static void shouldCreateOppOnElevateRDInsertWhenIntegrationIsDisabled() {
+        PS_IntegrationServiceConfig_TEST.Stub configStub = new PS_IntegrationServiceConfig_TEST.Stub()
+            .withIsIntegrationEnabled(false);
 
-        mockperms.withIsIntegrationEnabled(false);
-
-        List<Opportunity> opps = testDataForElevateRD(mockperms, MOCK_COMMITMENT_ID);
+        npe03__Recurring_Donation__c rd = setUpElevateTestData(configStub, MOCK_COMMITMENT_ID);
+        List<Opportunity> opps = oppGateway.getRecords(rd);
 
         System.assertEquals(1, opps.size(),
-            'The installment Opportunity should not be created: ' + opps);
-
+            'An installment Opportunity should be created for the Elevate RD when integration is disabled: ' + opps);
     }
 
     /***
@@ -1597,27 +1593,25 @@ private class RD2_OpportunityEvaluationService_TEST {
     }
 
     /****
-    * @description Sets up test data for elevate Recurring donations
-    * @param configStub Elevate Integration Service stub
-    * @param Id is the Mock commitment Id for setting up elevate Recurring Donations
-    * @return List of opportunities
+    * @description Sets up a Recurring Donation used in the Elevate tests
+    * @param configStub Elevate Integration Service configuration stub
+    * @param commitmentId RD Commitment Id
+    * @return npe03__Recurring_Donation__c
     */
-    private static List<Opportunity> testDataForElevateRD(PS_IntegrationServiceConfig_TEST.Stub configStub, Id MOCK_COMMITMENT_ID) {
+    private static npe03__Recurring_Donation__c setUpElevateTestData(PS_IntegrationServiceConfig_TEST.Stub configStub, String commitmentId) {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
-        RD2_RecurringDonation.config =  (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, configStub);
+        RD2_RecurringDonation.config = (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, configStub);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact())
             .withDayOfMonth('20')
-            .withCalculateNextDonationDate()
-            .withCommitmentId(MOCK_COMMITMENT_ID)
+            .withCommitmentId(commitmentId)
             .build();
 
         Test.startTest();
         insert rd;
         Test.stopTest();
 
-        return  oppGateway.getRecords(rd);
-
+        return rd;
     }
 }

--- a/src/classes/RD2_OpportunityEvaluationService_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluationService_TEST.cls
@@ -39,11 +39,12 @@ private class RD2_OpportunityEvaluationService_TEST {
     private static final TEST_SObjectGateway.ErrorGateway errorGateway = new TEST_SObjectGateway.ErrorGateway();
 
     /***
-    * @description Installment Opportunities Auto Creation Setting API value 
+    * @description Installment Opportunities Auto Creation Setting API value
     */
     private static final String OPTION_NAME_DISABLE_FIRST = RD2_Constants.InstallmentCreateOptions.Disable_First_Installment.name();
     private static final String OPTION_NAME_DISABLE_ALL = RD2_Constants.InstallmentCreateOptions.Disable_All_Installments.name();
     private static final String OPTION_NAME_ALWAYS_CREATE_NEXT = RD2_Constants.InstallmentCreateOptions.Always_Create_Next_Installment.name();
+    private static final Id MOCK_COMMITMENT_ID = '707f100007HyXHJAA3';
 
     private static final Date START_DATE = Date.newInstance(2019, 9, 15);
     private static final Integer MONTHS_TO_DEC = START_DATE.monthsBetween(Date.newInstance(2019, 12, 15));
@@ -52,6 +53,8 @@ private class RD2_OpportunityEvaluationService_TEST {
     private static final String PAYMENT_CHECK = 'Check';
     private static final Decimal RD_AMOUNT = 100;
     private static final Decimal RD_NEW_AMOUNT = 200;
+
+    private static PS_IntegrationServiceConfig_TEST.Stub mockperms = new PS_IntegrationServiceConfig_TEST.Stub();
 
 
     /****
@@ -188,10 +191,10 @@ private class RD2_OpportunityEvaluationService_TEST {
         RD2_OpportunityEvaluationService evalService = new RD2_OpportunityEvaluationService();
         evalService.rds = new List<npe03__Recurring_Donation__c>{ rdNew, rdOld };
 
-        System.assertEquals(true, evalService.isNewOpportunityCandidate(rdNew), 
+        System.assertEquals(true, evalService.isNewOpportunityCandidate(rdNew),
             'RD having Schedules and no related Opp should be eligible for an Installment Opp');
 
-        System.assertEquals(false, evalService.isNewOpportunityCandidate(rdOld), 
+        System.assertEquals(false, evalService.isNewOpportunityCandidate(rdOld),
             'RD having Schedules and a related Opp should not be eligible for an Installment Opp');
     }
 
@@ -256,7 +259,7 @@ private class RD2_OpportunityEvaluationService_TEST {
      * @param closeAction Recurring Donation settings Open Opportunity Behaviour close action
      * @return npe03__Recurring_Donation__c Created Recurring Donation with related Opps
      */
-    private static npe03__Recurring_Donation__c setupDataAndCloseRD(String closeAction) {        
+    private static npe03__Recurring_Donation__c setupDataAndCloseRD(String closeAction) {
         RD2_Settings_TEST.setUpConfiguration(new Map<String, Object> {
             'npe03__Open_Opportunity_Behavior__c' => closeAction
         });
@@ -315,9 +318,9 @@ private class RD2_OpportunityEvaluationService_TEST {
         RD2_Settings_TEST.setUpConfiguration(new Map<String, Object> {
             'InstallmentOppAutoCreateOption__c' => OPTION_NAME_DISABLE_FIRST
         });
-        
+
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact()).build();
-        
+
         Test.startTest();
         insert rd;
         Test.stopTest();
@@ -345,7 +348,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         Test.startTest();
         insert rd;
         Test.stopTest();
-        
+
         List<Opportunity> opps = oppGateway.getRecords(rd);
 
         System.assertEquals(0, opps.size(),
@@ -354,7 +357,7 @@ private class RD2_OpportunityEvaluationService_TEST {
 
     /**
     * @description Verifies on installment Opportunity is created
-    * when RD is updated, there is already a Closed current Opp 
+    * when RD is updated, there is already a Closed current Opp
     * and Installment Auto Creation Setting is set to Disable First Installment.
     */
     @IsTest
@@ -364,7 +367,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         RD2_Settings_TEST.setUpConfiguration(new Map<String, Object> {
             'InstallmentOppAutoCreateOption__c' => OPTION_NAME_DISABLE_FIRST
         });
-        
+
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact()).build();
         insert rd;
 
@@ -375,14 +378,14 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
 
         rd.npe03__Amount__c = 2000;
-        
+
         Test.startTest();
         update rd;
         Test.stopTest();
 
         List<Opportunity> opps = oppGateway.getRecords(rd);
 
-        System.assertEquals(2, opps.size(), 
+        System.assertEquals(2, opps.size(),
             'A new Opportunity should be created: ' + opps);
     }
 
@@ -403,11 +406,59 @@ private class RD2_OpportunityEvaluationService_TEST {
         Test.startTest();
         insert rd;
         Test.stopTest();
-        
+
         List<Opportunity> opps = oppGateway.getRecords(rd);
 
         System.assertEquals(1, opps.size(),
             'The installment Opportunity should be created: ' + opps);
+    }
+
+     /**
+    * @description Verifies on installment Opportunity is created on RD insert
+    * when Installment Auto Creation Setting is set to Always Create Next Installment.
+    */
+    @IsTest
+    private static void shouldNotCreateFutureOppWhenRDisFromElevateWithCommitmentID() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        Boolean isEnabled = true;
+        mockperms.withIsIntegrationEnabled(isEnabled);
+
+        List<Opportunity> opps = testDataForElevateRD(mockperms, MOCK_COMMITMENT_ID);
+
+        System.assertEquals(0, opps.size(),
+            'The installment Opportunity should not be created: ' + opps);
+
+    }
+
+    @IsTest
+    private static void shouldCreateFutureOppWhenRDisFromElevateWithoutCommitmentId() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        Boolean isEnabled = true;
+        mockperms.withIsIntegrationEnabled(isEnabled);
+
+        Id MockId = null;
+        List<Opportunity> opps = testDataForElevateRD(mockperms, MockId);
+
+        System.assertEquals(1, opps.size(),
+            'The installment Opportunity should not be created: ' + opps);
+
+
+    }
+
+    @IsTest
+    private static void shouldCreateFutureOppWhenRDIsNotFromElevateWithCommitmentId() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        Boolean isEnabled = false;
+        mockperms.withIsIntegrationEnabled(isEnabled);
+
+        List<Opportunity> opps = testDataForElevateRD(mockperms, MOCK_COMMITMENT_ID);
+
+        System.assertEquals(1, opps.size(),
+            'The installment Opportunity should not be created: ' + opps);
+
     }
 
     /***
@@ -430,7 +481,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         Test.startTest();
         insert rd;
         Test.stopTest();
-        
+
         List<Opportunity> opps = oppGateway.getRecords(rd);
 
         System.assertEquals(1, opps.size(),
@@ -444,7 +495,7 @@ private class RD2_OpportunityEvaluationService_TEST {
     @IsTest
     private static void shouldNotThrowExceptionWhenRDIsClosedAndHasNoOpp() {
         Exception actualException;
-        
+
         RD2_Settings_TEST.setUpConfiguration(new Map<String, Object> {
             'npe03__Open_Opportunity_Behavior__c' => RD2_Constants.CloseActions.Mark_Opportunities_Closed_Lost.name()
         });
@@ -513,7 +564,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         List<Error__c> errors = errorGateway.getRecords();
         System.assertEquals(0, errors.size(), 'No error should be created: ' + errors);
     }
-     
+
     /**
      * @description Verifies Opps are processed when currency on RD is changed only
      */
@@ -670,7 +721,7 @@ private class RD2_OpportunityEvaluationService_TEST {
     }
 
     /**
-     * @description Verifies the calendar Current and Next Year Values 
+     * @description Verifies the calendar Current and Next Year Values
      * should be calculated when a Recurring Donation is created
      */
     @IsTest
@@ -726,7 +777,7 @@ private class RD2_OpportunityEvaluationService_TEST {
                     oppBuilder.withOpenStage().build()
                 );
             }
-        }    
+        }
         insert opps;
 
         Test.startTest();
@@ -774,7 +825,7 @@ private class RD2_OpportunityEvaluationService_TEST {
                     oppBuilder.withClosedLostStage().build()
                 );
             }
-        }        
+        }
         insert opps;
 
         Test.startTest();
@@ -827,12 +878,12 @@ private class RD2_OpportunityEvaluationService_TEST {
         for (Integer i = monthsToMigration; i < MONTHS_TO_YEAR_END + 2; i++) {//data migration applied in Oct
             opps.add(oppBuilder
                 .withName()
-                .withCloseDate(START_DATE.addMonths(i))   
-                .withClosedLostStage()             
+                .withCloseDate(START_DATE.addMonths(i))
+                .withClosedLostStage()
                 .withInstallmentNumberMigrationFlag()
                 .build()
             );
-        }        
+        }
         insert opps;
 
         Test.startTest();
@@ -905,7 +956,7 @@ private class RD2_OpportunityEvaluationService_TEST {
      * with their matching projected installments
      */
     @IsTest
-    private static void yearValuesShouldExcludeInstallmentWhenMatchingOppExists() {        
+    private static void yearValuesShouldExcludeInstallmentWhenMatchingOppExists() {
         //set current date override
         final Date nextCloseDate = START_DATE.addMonths(MONTHS_TO_DEC);
         final Date today = nextCloseDate.addDays(-1);
@@ -927,12 +978,12 @@ private class RD2_OpportunityEvaluationService_TEST {
                 opps.add(
                     oppBuilder.withClosedWonStage().build()
                 );
-            } else {                
+            } else {
                 opps.add(
                     oppBuilder.withOpenStage().build()
                 );
             }
-        }        
+        }
         insert opps;
 
         Test.startTest();
@@ -954,7 +1005,7 @@ private class RD2_OpportunityEvaluationService_TEST {
      * @description The Current and Next Year Value should exclude future Closed Lost Opps.
      */
     @IsTest
-    private static void yearValuesShouldExcludeFutureClosedLostOpp() {        
+    private static void yearValuesShouldExcludeFutureClosedLostOpp() {
         //set current date override
         final Date today = START_DATE.addMonths(1).addDays(1);
         RD2_ScheduleService.currentDate = today;
@@ -1139,7 +1190,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         rd = rdGateway.getRecord(rd.Id);
 
         System.assertEquals(RD_AMOUNT * 7 + 10 + RD_NEW_AMOUNT * 2, rd.CurrentYearValue__c,
-            'Current Year Value should include July 2019 - Jan 2020 past Opps, ' 
+            'Current Year Value should include July 2019 - Jan 2020 past Opps, '
             + 'a Feb 2020 open Opp with updated Amount and March 1st projected installment '
             + 'for the current fiscal year ending on March 31, 2020');
         System.assertEquals(RD_NEW_AMOUNT * 12, rd.NextYearValue__c,
@@ -1219,7 +1270,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         System.assertEquals(rd.npe03__Amount__c * 12, rd.NextYearValue__c,
             'Next Year Value should be calculated when RD is created');
     }
-    
+
     /**
      * @description Verifies the calendar year Current and Next Year Values
      * should be calculated when custom settings Use Fiscal Year is checked
@@ -1261,12 +1312,12 @@ private class RD2_OpportunityEvaluationService_TEST {
         //set current date override
         final Date startDate = Date.newInstance(2020, 1, 1);
         final Date today = Date.newInstance(2020, 4, 1);//the next fiscal year is starting today
-        RD2_ScheduleService.currentDate = today;        
+        RD2_ScheduleService.currentDate = today;
 
         setUpUseFiscalYear(true);
         UTIL_FiscalYearInfo.fiscalYearInfo = new UTIL_FiscalYearInfo(4, true);
 
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled(); 
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id)
             .withStartDate(startDate)
@@ -1292,7 +1343,7 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build()
         );
         insert opps;
-        
+
         new RD2_OpportunityEvaluationService()
             .withRds(new Set<Id>{ rd.Id })
             .evaluateOpportunities();
@@ -1305,7 +1356,7 @@ private class RD2_OpportunityEvaluationService_TEST {
     }
 
     /**
-     * @description Verifies field values from Recurring Donation 
+     * @description Verifies field values from Recurring Donation
      * are copied into mapped fields on Opportunity record when RD is created
      */
     @IsTest
@@ -1326,12 +1377,12 @@ private class RD2_OpportunityEvaluationService_TEST {
         List<Opportunity> opps = oppGateway.getRecords(rd);
 
         System.assertEquals(1, opps.size(), 'The number of returned Opps should match');
-        System.assertEquals(rd.Name, opps[0].Description, 
+        System.assertEquals(rd.Name, opps[0].Description,
             'The RD Name should be copied into the Opportunity record Description field');
     }
 
     /**
-     * @description Verifies field values from Recurring Donation 
+     * @description Verifies field values from Recurring Donation
      * are copied into mapped fields on Opportunity record when RD is updated
     */
     @IsTest
@@ -1341,7 +1392,7 @@ private class RD2_OpportunityEvaluationService_TEST {
 
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
         RD2_CustomFieldMapper_TEST.createCustomFieldMapping('Name', 'Description');
-        
+
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact()).build();
         insert rd;
 
@@ -1352,16 +1403,16 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
 
         List<Opportunity> opps = oppGateway.getRecords(rd);
-        System.assert(String.isBlank(opps[0].Description), 'Description should not be specified');        
-       
+        System.assert(String.isBlank(opps[0].Description), 'Description should not be specified');
+
         Test.startTest();
-        rd.npe03__Amount__c = 2000; 
+        rd.npe03__Amount__c = 2000;
         update rd;
         Test.stopTest();
 
         opps = oppGateway.getRecords(rd);
         System.assertEquals(1, opps.size(), 'The number of returned Opps should match');
-        System.assertEquals(rd.Name, opps[0].Description, 
+        System.assertEquals(rd.Name, opps[0].Description,
             'The RD Name should be copied into the Opportunity record Description field');
     }
 
@@ -1377,7 +1428,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         Date today = Date.newInstance(2020, 3, 2);
         RD2_ScheduleService.currentDate = today;
 
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled(); 
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id)
             .withStartDate(startDate)
@@ -1398,16 +1449,16 @@ private class RD2_OpportunityEvaluationService_TEST {
         }
         insert opps;
 
-        Test.startTest();        
+        Test.startTest();
         new RD2_OpportunityEvaluationService()
             .withRds(new Set<Id>{ rd.Id })
             .evaluateOpportunities();
         Test.stopTest();
 
         rd = rdGateway.getRecord(rd.Id);
-        System.assertEquals(RD_AMOUNT * 12, rd.CurrentYearValue__c, 
+        System.assertEquals(RD_AMOUNT * 12, rd.CurrentYearValue__c,
             'Current Year Value should include actual and planned installment amounts');
-        System.assertEquals(RD_AMOUNT * 7, rd.NextYearValue__c, 
+        System.assertEquals(RD_AMOUNT * 7, rd.NextYearValue__c,
             'Next Year Value should match the expected planned installment amount');
     }
 
@@ -1423,7 +1474,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         Date today = Date.newInstance(2020, 3, 2);
         RD2_ScheduleService.currentDate = today;
 
-        RD2_EnablementService_TEST.setRecurringDonations2Enabled(); 
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id)
             .withStartDate(startDate)
@@ -1462,12 +1513,12 @@ private class RD2_OpportunityEvaluationService_TEST {
         Test.stopTest();
 
         rd = rdGateway.getRecord(rd.Id);
-        System.assertEquals(paidInstallments, rd.npe03__Total_Paid_Installments__c, 
+        System.assertEquals(paidInstallments, rd.npe03__Total_Paid_Installments__c,
             'Number of paid installments should match the RD field');
 
-        System.assertEquals(RD_AMOUNT * 12, rd.CurrentYearValue__c, 
+        System.assertEquals(RD_AMOUNT * 12, rd.CurrentYearValue__c,
             'Current Year Value should include actual and planned installment amounts');
-        System.assertEquals(RD_AMOUNT * 6 + extraOppAmount, rd.NextYearValue__c, 
+        System.assertEquals(RD_AMOUNT * 6 + extraOppAmount, rd.NextYearValue__c,
             'Next Year Value should match the expected planned installment and the future open Opp amounts');
     }
 
@@ -1541,5 +1592,30 @@ private class RD2_OpportunityEvaluationService_TEST {
         RD2_Settings_TEST.setUpConfiguration(
             new Map<String, Object>{ 'UseFiscalYearForRecurringDonationValue__c' => isEnabled }
         );
+    }
+
+    /****
+    * @description Sets up test data for elevate Recurring donations
+    * @param configStub Elevate Integration Service stub
+    * @param Id is the Mock commitment Id for setting up elevate Recurring Donations
+    * @return List of opportunities
+    */
+    private static List<Opportunity> testDataForElevateRD(PS_IntegrationServiceConfig_TEST.Stub configStub, Id MOCK_COMMITMENT_ID) {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        RD2_RecurringDonation.config =  (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, configStub);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact())
+            .withDayOfMonth('20')
+            .withCalculateNextDonationDate()
+            .withCommitmentId(MOCK_COMMITMENT_ID)
+            .build();
+
+        Test.startTest();
+        insert rd;
+        Test.stopTest();
+
+        return  oppGateway.getRecords(rd);
+
     }
 }

--- a/src/classes/RD2_OpportunityEvaluation_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluation_TEST.cls
@@ -136,7 +136,7 @@ private class RD2_OpportunityEvaluation_TEST {
 
         PS_IntegrationServiceConfig_TEST.Stub configStub = new PS_IntegrationServiceConfig_TEST.Stub()
             .withIsIntegrationEnabled(true);
-        RD2_RecurringDonation.config = (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, configStub);
+        RD2_ElevateIntegrationService.config = (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, configStub);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
             .withCommitmentId(RD2_ElevateIntegrationService_TEST.COMMITMENT_ID)

--- a/src/classes/RD2_OpportunityEvaluation_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluation_TEST.cls
@@ -126,27 +126,24 @@ private class RD2_OpportunityEvaluation_TEST {
             'Next Year Value should be zero for a Closed RD');
     }
 
-    /**
-    * @description Verifies no opportunity is created on RD insert when elevate integration
-    * is enabled and RD have commitment Id.
+
+   /**
+    * @description Verifies no installment Opportunity is created by the RD batch when
+    * Elevate integration is enabled and Commitment Id is specified on the RD.
     */
     @IsTest
-    private static void shouldNotCreateFutureOppWhenRDIsFromElevateIntegration() {
+    private static void shouldNotCreateNextOppForElevateRDWhenIntegrationIsEnabled() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
         final Date today = START_DATE.addMonths(1);
         RD2_ScheduleService.currentDate = today;
 
-        Boolean isEnabled = true;
-        mockperms.withIsIntegrationEnabled(isEnabled);
+        PS_IntegrationServiceConfig_TEST.Stub configStub = new PS_IntegrationServiceConfig_TEST.Stub()
+            .withIsIntegrationEnabled(true);
+        RD2_RecurringDonation.config = (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, configStub);
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
-            .withDayOfMonth('20')
-            .withCalculateNextDonationDate()
-            .withCommitmentId(MOCK_COMMITMENT_ID)
+            .withCommitmentId(RD2_ElevateIntegrationService_TEST.COMMITMENT_ID)
             .build();
-
-        RD2_RecurringDonation.config =  (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, mockperms);
-
         insert rd;
 
         runBatch(new RD2_OpportunityEvaluation_BATCH(today));
@@ -154,10 +151,9 @@ private class RD2_OpportunityEvaluation_TEST {
         assertBatchJobIteration(1);
 
         List<Opportunity> opps = oppGateway.getRecords(rd);
-        System.assertEquals(0, opps.size(), 'No new Opp should be created: ' + opps);
-
+        System.assertEquals(0, opps.size(),
+            'No installment Opportunity should be created for the Elevate RD when integration is enabled: ' + opps);
     }
-
 
     /**
      * @description Verifies an Opp with Close Date today is not created if it already exists

--- a/src/classes/RD2_OpportunityEvaluation_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluation_TEST.cls
@@ -126,6 +126,10 @@ private class RD2_OpportunityEvaluation_TEST {
             'Next Year Value should be zero for a Closed RD');
     }
 
+    /**
+    * @description Verifies no opportunity is created on RD insert when elevate integration
+    * is enabled and RD have commitment Id.
+    */
     @IsTest
     private static void shouldNotCreateFutureOppWhenRDIsFromElevateIntegration() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();

--- a/src/classes/RD2_OpportunityEvaluation_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluation_TEST.cls
@@ -44,6 +44,9 @@ private class RD2_OpportunityEvaluation_TEST {
 
     private static final Date START_DATE = Date.newInstance(2019, 9, 15);
     private static final Integer MONTHS_TO_YEAR_END = START_DATE.monthsBetween(Date.newInstance(2020, 1, 1));
+    private static final Id MOCK_COMMITMENT_ID = '707f100007HyXHJAA3';
+
+    private static PS_IntegrationServiceConfig_TEST.Stub mockperms = new PS_IntegrationServiceConfig_TEST.Stub();
 
     /****
     * @description Creates data required for unit tests
@@ -122,6 +125,35 @@ private class RD2_OpportunityEvaluation_TEST {
         System.assertEquals(0, rd.NextYearValue__c,
             'Next Year Value should be zero for a Closed RD');
     }
+
+    @IsTest
+    private static void shouldNotCreateFutureOppWhenRDIsFromElevateIntegration() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        final Date today = START_DATE.addMonths(1);
+        RD2_ScheduleService.currentDate = today;
+
+        Boolean isEnabled = true;
+        mockperms.withIsIntegrationEnabled(isEnabled);
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
+            .withDayOfMonth('20')
+            .withCalculateNextDonationDate()
+            .withCommitmentId(MOCK_COMMITMENT_ID)
+            .build();
+
+        RD2_RecurringDonation.config =  (PS_IntegrationServiceConfig) Test.createStub(PS_IntegrationServiceConfig.class, mockperms);
+
+        insert rd;
+
+        runBatch(new RD2_OpportunityEvaluation_BATCH(today));
+
+        assertBatchJobIteration(1);
+
+        List<Opportunity> opps = oppGateway.getRecords(rd);
+        System.assertEquals(0, opps.size(), 'No new Opp should be created: ' + opps);
+
+    }
+
 
     /**
      * @description Verifies an Opp with Close Date today is not created if it already exists
@@ -228,9 +260,9 @@ private class RD2_OpportunityEvaluation_TEST {
         assertRecordsFailed(batch, 0);
 
         Map<Id, Opportunity> oppById = new Map<Id, Opportunity>(oppGateway.getRecords(rd));
-        System.assertEquals(opps.size(), oppById.size(), 
+        System.assertEquals(opps.size(), oppById.size(),
             'No new Opp should be created: ' + oppById.values());
-        System.assertEquals(nextCloseDate, oppById.get(opps[2].Id).CloseDate, 
+        System.assertEquals(nextCloseDate, oppById.get(opps[2].Id).CloseDate,
             'Close Date should be unchanged for the future Opp');
     }
 
@@ -601,17 +633,17 @@ private class RD2_OpportunityEvaluation_TEST {
         runBatch(new RD2_OpportunityEvaluation_BATCH(today));
 
         Map<Id, Opportunity> oppById = new Map<Id, Opportunity>(oppGateway.getRecords(rd));
-        System.assertEquals(2, oppById.size(), 
+        System.assertEquals(2, oppById.size(),
             'New Opp should be created for the Next Donation Date offset by the closed Opp: ' + oppById.values());
-        
+
         Opportunity actualOpp = oppById.remove(opp.Id);
         System.assertEquals(true, actualOpp.IsClosed && !actualOpp.IsWon, 'Existing Closed Lost Opp should stay closed');
 
         //verify the Next Donation Date is advanced and a new Opp is created
         actualOpp = oppById.values()[0];
-        
+
         System.assertEquals(false, actualOpp.IsClosed, 'New Opp should be open: ' + actualOpp);
-        System.assertEquals(nextCloseDate.addMonths(1), actualOpp.CloseDate, 
+        System.assertEquals(nextCloseDate.addMonths(1), actualOpp.CloseDate,
             'New Opp Close Date should be the Next Donation Date after the closed Opp Close Date: ' + actualOpp);
     }
 
@@ -821,7 +853,7 @@ private class RD2_OpportunityEvaluation_TEST {
     }
 
     /**
-    * Verifies that no future installment will be created for a fixed length RD 
+    * Verifies that no future installment will be created for a fixed length RD
     * when number of open Opps plus closed won Opps equals number of planned installments
     */
     @isTest
@@ -865,19 +897,19 @@ private class RD2_OpportunityEvaluation_TEST {
 
         List<Opportunity> actualOpps = oppGateway.getRecords(rd);
 
-        System.assertEquals(plannedInstallments, actualOpps.size(), 
+        System.assertEquals(plannedInstallments, actualOpps.size(),
             'No new installment Opp should be created when: open Opps + paid Opps = planned installments. ' + actualOpps);
     }
 
     /**
     * @description Verifies that the next installment Opp should be created for a fixed length RD
-    * when number of open Opps plus closed won Opps is less than number of planned installments  
+    * when number of open Opps plus closed won Opps is less than number of planned installments
     */
     @isTest
     private static void shouldCreateNextOppWhenFixedLengthRDHasNotReachedPlannedInstallmentCount() {
         final Integer plannedInstallments = 3;
         final Integer paidInstallments = 2;
-        
+
         final Date startDate = Date.newInstance(2020, 1, 1);
         Date today = Date.newInstance(2020, 3, 1);
         RD2_ScheduleService.currentDate = today;
@@ -892,7 +924,7 @@ private class RD2_OpportunityEvaluation_TEST {
             .withPaidInstallments(paidInstallments)
             .build();
         insert rd;
-        
+
         List<Opportunity> opps = new List<Opportunity>();
         TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
         for (Integer month = 0; month < paidInstallments; month++){
@@ -913,13 +945,13 @@ private class RD2_OpportunityEvaluation_TEST {
         assertBatchJobIteration(1);
 
         List<Opportunity> actualOpps = oppGateway.getRecords(rd);
-        System.assertEquals(plannedInstallments + 1, actualOpps.size(), 
+        System.assertEquals(plannedInstallments + 1, actualOpps.size(),
             'The next installment Opp should be created since one Opp is Closed Lost: ' + opps);
 
         Opportunity nextDonationDateOpp = actualOpps[actualOpps.size() - 1];
-        System.assertEquals(false, nextDonationDateOpp.IsClosed, 
+        System.assertEquals(false, nextDonationDateOpp.IsClosed,
             'The newly created Opp should be open: ' + nextDonationDateOpp);
-        System.assertEquals(today.addMonths(1), nextDonationDateOpp.CloseDate, 
+        System.assertEquals(today.addMonths(1), nextDonationDateOpp.CloseDate,
             'The Next Donation Date should advance and the newly created Opp should match it');
     }
 

--- a/src/classes/RD2_OpportunityEvaluation_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluation_TEST.cls
@@ -44,9 +44,6 @@ private class RD2_OpportunityEvaluation_TEST {
 
     private static final Date START_DATE = Date.newInstance(2019, 9, 15);
     private static final Integer MONTHS_TO_YEAR_END = START_DATE.monthsBetween(Date.newInstance(2020, 1, 1));
-    private static final Id MOCK_COMMITMENT_ID = '707f100007HyXHJAA3';
-
-    private static PS_IntegrationServiceConfig_TEST.Stub mockperms = new PS_IntegrationServiceConfig_TEST.Stub();
 
     /****
     * @description Creates data required for unit tests

--- a/src/classes/RD2_RecurringDonation.cls
+++ b/src/classes/RD2_RecurringDonation.cls
@@ -81,17 +81,6 @@ public inherited sharing class RD2_RecurringDonation {
         return reviseNextDonationDate(scheduleService, rd.RecurringDonationSchedules__r);
     }
 
-    @TestVisible
-    private static PS_IntegrationServiceConfig config {
-        get {
-            if (config == null) {
-                config = new PS_IntegrationServiceConfig();
-            }
-            return config;
-        }
-        set;
-    }
-
     /**
     * @description Revises and modifies the Recurring Donation Next Donation Date.
     * Whenever the Next Donation Date is being revised, review the status and the Next Donation Date
@@ -365,9 +354,10 @@ public inherited sharing class RD2_RecurringDonation {
     }
 
     /***
-    * @description Contains attribute confirming if Elevate Integration is not enabled
+    * @description Checks if the Recurring Donation is originated in Elevate
     */
-    public Boolean isElevateIntegrationDisabled() {
-       return String.isBlank(rd.CommitmentId__c) || !config.isIntegrationEnabled();
+    public Boolean isElevateRecord() {
+       return String.isNotBlank(rd.CommitmentId__c);
     }
+
 }

--- a/src/classes/RD2_RecurringDonation.cls
+++ b/src/classes/RD2_RecurringDonation.cls
@@ -37,7 +37,7 @@
 public inherited sharing class RD2_RecurringDonation {
 
     /**
-    * @description Recurring Donation record containing 
+    * @description Recurring Donation record containing
     * related Opportunities and Schedules in subqueries
     */
     npe03__Recurring_Donation__c rd;
@@ -77,20 +77,31 @@ public inherited sharing class RD2_RecurringDonation {
     * @param scheduleService RD Schedule Service
     * @return RD2_RecurringDonation This record instance
     */
-    public RD2_RecurringDonation reviseNextDonationDate(RD2_ScheduleService scheduleService) {  
+    public RD2_RecurringDonation reviseNextDonationDate(RD2_ScheduleService scheduleService) {
         return reviseNextDonationDate(scheduleService, rd.RecurringDonationSchedules__r);
+    }
+
+    @TestVisible
+    private static PS_IntegrationServiceConfig config {
+        get {
+            if (config == null) {
+                config = new PS_IntegrationServiceConfig();
+            }
+            return config;
+        }
+        set;
     }
 
     /**
     * @description Revises and modifies the Recurring Donation Next Donation Date.
-    * Whenever the Next Donation Date is being revised, review the status and the Next Donation Date 
-    * for a fixed-length RD in the case it should be closed. 
+    * Whenever the Next Donation Date is being revised, review the status and the Next Donation Date
+    * for a fixed-length RD in the case it should be closed.
     * If so, the next installment Opp should not be created when the last open Opp on the fixed-length RD is closed.
     * @param scheduleService RD Schedule Service
     * @param rdSchedules Existing Schedules on the Recurring Donation
     * @return RD2_RecurringDonation This record instance
     */
-    public RD2_RecurringDonation reviseNextDonationDate(RD2_ScheduleService scheduleService, List<RecurringDonationSchedule__c> rdSchedules) { 
+    public RD2_RecurringDonation reviseNextDonationDate(RD2_ScheduleService scheduleService, List<RecurringDonationSchedule__c> rdSchedules) {
         return setNextDonationDate(
             scheduleService.getNextDonationDate(rd, rdSchedules)
         );
@@ -154,7 +165,7 @@ public inherited sharing class RD2_RecurringDonation {
     }
 
     /**
-    * @description Sets the Number of Planned Installments to null when RecurringType is Open 
+    * @description Sets the Number of Planned Installments to null when RecurringType is Open
     * and Number of Planned Installments = 1 (default)
     * @return RD2_RecurringDonation This record instance
     */
@@ -210,7 +221,7 @@ public inherited sharing class RD2_RecurringDonation {
 
     /**
     * @description Return the Recurring Donation record
-    * @return npe03__Recurring_Donation__c 
+    * @return npe03__Recurring_Donation__c
     */
     public npe03__Recurring_Donation__c getSObject() {
         return rd;
@@ -255,7 +266,7 @@ public inherited sharing class RD2_RecurringDonation {
     public Boolean isFixedLengthComplete() {
         return rd.npe03__Total_Paid_Installments__c >= rd.npe03__Installments__c;
     }
-    
+
     /**
     * @description Return number of planned installments on the Recurring Donation, default to 0 when null
     * @return Integer
@@ -351,5 +362,12 @@ public inherited sharing class RD2_RecurringDonation {
             }
         }
         return false;
+    }
+
+    /***
+    * @description Contains attribute confirming if Elevate Integration is not enabled
+    */
+    public Boolean isElevateIntegrationDisabled() {
+       return String.isBlank(rd.CommitmentId__c) || !config.isIntegrationEnabled();
     }
 }

--- a/src/classes/TEST_RecurringDonationBuilder.cls
+++ b/src/classes/TEST_RecurringDonationBuilder.cls
@@ -475,18 +475,6 @@ public without sharing class TEST_RecurringDonationBuilder {
     }
 
     /***
-    * @description Sets CommitmentId field
-    * @param commitmentId  value
-    * @return TEST_RecurringDonationBuilder Builder instance
-    */
-    public TEST_RecurringDonationBuilder withCommitmentId(String commitmentId) {
-        validateMode(Mode.Enhanced);
-
-        valuesByFieldName.put('CommitmentId__c', commitmentId);
-        return this;
-    }
-
-    /***
     * @description Sets Next Donation Date. It's the same field as NextPaymentDate, but in RD2 this field is generally
     * calculated automatically during insert.
     * @param dt Date

--- a/src/classes/TEST_RecurringDonationBuilder.cls
+++ b/src/classes/TEST_RecurringDonationBuilder.cls
@@ -475,6 +475,18 @@ public without sharing class TEST_RecurringDonationBuilder {
     }
 
     /***
+    * @description Sets CommitmentId field
+    * @param commitmentId  value
+    * @return TEST_RecurringDonationBuilder Builder instance
+    */
+    public TEST_RecurringDonationBuilder withCommitmentId(String commitmentId) {
+        validateMode(Mode.Enhanced);
+
+        valuesByFieldName.put('CommitmentId__c', commitmentId);
+        return this;
+    }
+
+    /***
     * @description Sets Next Donation Date. It's the same field as NextPaymentDate, but in RD2 this field is generally
     * calculated automatically during insert.
     * @param dt Date

--- a/src/package.xml
+++ b/src/package.xml
@@ -364,6 +364,8 @@
         <members>PSC_PartialSoftCredit_TDTM</members>
         <members>PSC_PartialSoftCredit_TEST</members>
         <members>PS_IntegrationService</members>
+        <members>PS_IntegrationServiceConfig</members>
+        <members>PS_IntegrationServiceConfig_TEST</members>
         <members>PS_IntegrationService_TEST</members>
         <members>RD2_Constants</members>
         <members>RD2_CustomFieldMapper</members>


### PR DESCRIPTION
As an Admin of a Payment Services enabled Org, I want to prevent Enhanced Recurring Donations from automatically creating any Installment Opportunities for Elevate-Originating Recurring Donations.
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
