### PR TITLE
Updated "Tell me more" help link

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -4943,7 +4943,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Text to be display before the &#39;See Duplicate Contact&#39; button</shortDescription>
-        <value>See all duplicate Contacts found using matching rules. &lt;a href=&quot;https://powerofus.force.com/s/article/IP-About-Duplicate-Detection&quot;&gt;&lt;b&gt; Tell Me More &lt;/b&gt;&lt;/a&gt;</value>
+        <value>See all duplicate Contacts found using matching rules. &lt;a href=&quot; https://powerofus.force.com/s/article/NPSP-Merging-Contacts&quot;&gt;&lt;b&gt; Tell Me More &lt;/b&gt;&lt;/a&gt;</value>
     </labels>
     <labels>
         <fullName>conMergeSeeDupConDRS</fullName>


### PR DESCRIPTION
Changed line 4946 in src/lables/customLables.labes

from:

<shortDescription>Text to be display before the 'See Duplicate Contact' button</shortDescription>
<value>See all duplicate Contacts found using matching rules. <a href="https://powerofus.force.com/s/article/IP-About-Duplicate-Detection&quot;&gt;&lt;b&gt; Tell Me More </b></a></value>
to:
<shortDescription>Text to be display before the 'See Duplicate Contact' button</shortDescription>
<value>See all duplicate Contacts found using matching rules. <a href="https://powerofus.force.com/s/article/NPSP-Merging-Contacts&quot;&gt;&lt;b&gt; Tell Me More </b></a></value>

# Critical Changes

# Changes
In the See all Duplicates section, changed "Tell me more" URL on Contact Merge page.  It now resolves to https://powerofus.force.com/s/article/NPSP-Merging-Contacts
# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
