### PR TITLE
Gift Entry: Batches Tab "View More" link, Sorting

### DIFF
--- a/src/classes/FORM_ServiceGiftEntry.cls
+++ b/src/classes/FORM_ServiceGiftEntry.cls
@@ -56,7 +56,7 @@ public with sharing class FORM_ServiceGiftEntry {
     /*******************************************************************************************************
     * @description Method retrieves records based on a query string.
     */
-    @AuraEnabled
+    @AuraEnabled(Cacheable=true)
     public static SObject[] retrieveRecords(String[] selectFields,
         String sObjectApiName, String[] whereClauses, String orderByClause, Integer limitClause) {
 

--- a/src/lwc/geListView/geListView.html
+++ b/src/lwc/geListView/geListView.html
@@ -79,7 +79,7 @@
 
     <template if:true={isShowStandardFooter}>
         <footer class="slds-card__footer slds-m-top_none">
-            <template if:true={hasRecords}>
+            <template if:true={showViewMore}>
                 <a class="slds-card__footer-action"
                    onclick={handleViewMore}
                    data-qa-locator={qaLocatorViewMore}>

--- a/src/lwc/geListView/geListView.html
+++ b/src/lwc/geListView/geListView.html
@@ -77,7 +77,7 @@
         </template>
     </template>
 
-    <template if:true={isShowStandardFooter}>
+    <template if:true={showStandardFooter}>
         <footer class="slds-card__footer slds-m-top_none">
             <template if:true={showViewMore}>
                 <a class="slds-card__footer-action"

--- a/src/lwc/geListView/geListView.js
+++ b/src/lwc/geListView/geListView.js
@@ -289,7 +289,6 @@ export default class geListView extends LightningElement {
                 if (columnEntry) {
                     if (checkNestedProperty(this.columnEntriesByName[this.sortedBy],
                         'typeAttributes', 'label', 'fieldName')) {
-                        debugger;
                         orderedByFieldApiName = columnEntry.typeAttributes.label.fieldName;
                     } else {
                         orderedByFieldApiName = columnEntry.fieldApiName;

--- a/src/lwc/geListView/geListView.js
+++ b/src/lwc/geListView/geListView.js
@@ -289,30 +289,32 @@ export default class geListView extends LightningElement {
                 if (columnEntry) {
                     if (checkNestedProperty(this.columnEntriesByName[this.sortedBy],
                         'typeAttributes', 'label', 'fieldName')) {
+                        debugger;
                         orderedByFieldApiName = columnEntry.typeAttributes.label.fieldName;
                     } else {
-                        orderedByFieldApiName = columnEntry.fieldName;
+                        orderedByFieldApiName = columnEntry.fieldApiName;
                     }
                     orderBy = `${orderedByFieldApiName} ${this.sortedDirection}`;
                 }
             }
-
-            const records = await retrieveRecords({
-                selectFields: fields,
-                sObjectApiName: this.objectApiName,
-                orderByClause: orderBy,
-                limitClause: this.limit + 1
-            })
-                .catch(error => {
-                    handleError(error);
+            try {
+                const records = await retrieveRecords({
+                    selectFields: fields,
+                    sObjectApiName: this.objectApiName,
+                    orderByClause: orderBy,
+                    limitClause: this.limit + 1
                 });
 
-            if(records.length > this.limit) {
-                this.hasAdditionalRows = true;
-                this.setDatatableRecordsForImperativeCall(records.slice(0,-1));
-            } else {
-                this.hasAdditionalRows = false;
-                this.setDatatableRecordsForImperativeCall(records);
+                if (records.length > this.limit) {
+                    this.hasAdditionalRows = true;
+                    this.setDatatableRecordsForImperativeCall(records.slice(0, -1));
+                } else {
+                    this.hasAdditionalRows = false;
+                    this.setDatatableRecordsForImperativeCall(records);
+                }
+
+            } catch (error) {
+                handleError(error);
             }
         }
     };
@@ -445,7 +447,7 @@ export default class geListView extends LightningElement {
                 fieldApiName: fieldDescribe.apiName,
                 label: fieldDescribe.label,
                 sortable: fieldDescribe.sortable
-            }
+            };
 
             columnEntry = this.handleReferenceTypeFields(fieldDescribe, columnEntry);
 
@@ -460,7 +462,7 @@ export default class geListView extends LightningElement {
                 'double': 'number',
                 'datetime': 'date',
                 'date': 'date-local'
-            }
+            };
             const convertedType = types[fieldDescribe.dataType.toLowerCase()];
 
             columnEntry.fieldName = fieldApiName;
@@ -570,7 +572,7 @@ export default class geListView extends LightningElement {
             .finally(() => {
                 this.isLoading = false;
             })
-    }
+    };
 
     /*******************************************************************************
     * @description Method prepares the provided column headers to be saved.

--- a/src/lwc/geListView/geListView.js
+++ b/src/lwc/geListView/geListView.js
@@ -150,12 +150,6 @@ export default class geListView extends LightningElement {
         return '';
     }
 
-    get isShowStandardFooter() {
-        return this.showStandardFooter === 'true' ||
-            this.showStandardFooter === true ||
-            this.showStandardFooter === 1;
-    }
-
     get hasRecords() {
         return this.recordsToDisplay && this.recordsToDisplay.length > 0;
     }

--- a/src/lwc/geTemplates/geTemplates.html
+++ b/src/lwc/geTemplates/geTemplates.html
@@ -56,6 +56,7 @@
                                                     custom-icon={batchesListViewIcon}
                                                     filtered-by={batchListFilteredBy}
                                                     onrowaction={handleBatchesTableRowAction}
+                                                    show-standard-footer
                                                     ontogglemodal={toggleModal}>
                                     </c-ge-list-view>
                                 </div>
@@ -89,7 +90,7 @@
                                                     actions={templatesTableActions}
                                                     onrowaction={handleTemplatesTableRowAction}
                                                     ontogglemodal={toggleModal}
-                                                    show-standard-footer='true'>
+                                                    show-standard-footer>
                                         <lightning-button label={CUSTOM_LABELS.geButtonTemplatesTabCreateTemplate}
                                                           class="slds-m-right_small"
                                                           onclick={handleNewFormTemplate}

--- a/src/package.xml
+++ b/src/package.xml
@@ -2041,7 +2041,6 @@
         <members>exceptionValidationRule</members>
         <members>flsError</members>
         <members>flsReadAccessError</members>
-        <members>gauAllocationErrorGeneral</members>
         <members>geAssistiveActiveSection</members>
         <members>geAssistiveBatchHeaderRemoveField</members>
         <members>geAssistiveFieldDown</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -2041,6 +2041,7 @@
         <members>exceptionValidationRule</members>
         <members>flsError</members>
         <members>flsReadAccessError</members>
+        <members>gauAllocationErrorGeneral</members>
         <members>geAssistiveActiveSection</members>
         <members>geAssistiveBatchHeaderRemoveField</members>
         <members>geAssistiveFieldDown</members>


### PR DESCRIPTION
# Critical Changes

# Changes
- We added a View More link to Gift Entry’s Batches tab. The link appears when Gift Entry has more than 10 batches. When you click View More, Gift Entry loads 10 more rows, and you can continue clicking the link until no further batches are available or the maximum of 2000 rows is reached.

# Issues Closed
- Closes #5292 
# Community Ideas Delivered

# New Metadata

# Deleted Metadata
