### PR TITLE
RD2: Validate RD status to state mapping

### DIFF
--- a/src/classes/RD2_StatusMapper.cls
+++ b/src/classes/RD2_StatusMapper.cls
@@ -40,7 +40,7 @@ public with sharing class RD2_StatusMapper {
     * @param status Recurring Donation status
     * @return String 
     */
-    public String getStatusType(String status) {
+    public String getState(String status) {
         if (status == RD2_Constants.STATUS_ACTIVE) {
             return RD2_Constants.STATUS_ACTIVE;
 

--- a/src/classes/RD2_StatusMapper.cls
+++ b/src/classes/RD2_StatusMapper.cls
@@ -1,0 +1,56 @@
+/*
+    Copyright (c) 2020 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Recurring Donations
+* @description Recurring Donation status mapping wrapper
+*
+*/
+public with sharing class RD2_StatusMapper {
+
+    /**
+    * @description Get the mapped State from the Status
+    * @param status Recurring Donation status
+    * @return String 
+    */
+    public String getStatusType(String status) {
+        if (status == RD2_Constants.STATUS_ACTIVE) {
+            return RD2_Constants.STATUS_ACTIVE;
+
+        } else if (status == RD2_Constants.STATUS_LAPSED) {
+            return RD2_Constants.STATUS_LAPSED;
+
+        } else if (status == RD2_Constants.STATUS_CLOSED) {
+            return RD2_Constants.STATUS_CLOSED;
+        }
+        
+        return null;
+    }
+}

--- a/src/classes/RD2_StatusMapper.cls
+++ b/src/classes/RD2_StatusMapper.cls
@@ -30,14 +30,14 @@
 * @author Salesforce.org
 * @date 2020
 * @group Recurring Donations
-* @description Recurring Donation status mapping wrapper
+* @description Enhanced Recurring Donation Status Mapping Setting
 *
 */
 public with sharing class RD2_StatusMapper {
 
     /**
     * @description Get the mapped State from the Status
-    * @param status Recurring Donation status
+    * @param status Recurring Donation Status
     * @return String 
     */
     public String getState(String status) {

--- a/src/classes/RD2_StatusMapper.cls-meta.xml
+++ b/src/classes/RD2_StatusMapper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/RD2_StatusMapper_TEST.cls
+++ b/src/classes/RD2_StatusMapper_TEST.cls
@@ -41,17 +41,21 @@ public with sharing class RD2_StatusMapper_TEST {
     public class Stub implements System.StubProvider {
 
         /***
-        * @description Mock RD Status Mapping Settings 
+        * @description Mock RD Status Mapping Settings
         */
-        private Map<String, String> statusToStateMap = new Map<String, String>();
+        private Map<String, String> statusToStateMap = new Map<String, String> {
+            RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE,
+            RD2_Constants.STATUS_LAPSED => RD2_Constants.STATUS_LAPSED,
+            RD2_Constants.STATUS_CLOSED => RD2_Constants.STATUS_CLOSED
+        };
 
         /**
-        * @description Hard coded validate status
-        * @param status Status to mapped from
-        * @param state State to mapped to
+        * @description Override default Status to State Mapping
+        * @param statusToStateMap new Status to State map;
         */
-        public String mapStatusToState(String status, String state) {
-            statusToStateMap.put(status, state);
+        public Stub mapStatusToState(Map<String, String> statusToStateMap) {
+            this.statusToStateMap = statusToStateMap;
+            return this;
         }
 
         public Object handleMethodCall(

--- a/src/classes/RD2_StatusMapper_TEST.cls
+++ b/src/classes/RD2_StatusMapper_TEST.cls
@@ -1,0 +1,39 @@
+/*
+    Copyright (c) 2020 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2020
+* @group Recurring Donations
+* @description Unit tests for the Enhanced RD Settings
+*
+*/
+@IsTest(IsParallel=true)
+public with sharing class RD2_StatusMapper_TEST {
+
+}

--- a/src/classes/RD2_StatusMapper_TEST.cls
+++ b/src/classes/RD2_StatusMapper_TEST.cls
@@ -40,20 +40,18 @@ public with sharing class RD2_StatusMapper_TEST {
     */
     public class Stub implements System.StubProvider {
 
+        /***
+        * @description Mock RD Status Mapping Settings 
+        */
+        private Map<String, String> statusToStateMap = new Map<String, String>();
+
         /**
         * @description Hard coded validate status
-        * @param status status to check
-        * @return Convert to mapped status, return null when status is not Active or Closed 
+        * @param status Status to mapped from
+        * @param state State to mapped to
         */
-        private String convertStatusType(String status) {
-            if (status == RD2_Constants.STATUS_ACTIVE) {
-                return RD2_Constants.STATUS_ACTIVE;
-    
-            } else if (status == RD2_Constants.STATUS_CLOSED) {
-                return RD2_Constants.STATUS_CLOSED;
-            } else {
-                return null;
-            }
+        public String mapStatusToState(String status, String state) {
+            statusToStateMap.put(status, state);
         }
 
         public Object handleMethodCall(
@@ -65,8 +63,8 @@ public with sharing class RD2_StatusMapper_TEST {
             List<Object> args
         ) {
             switch on methodName {
-                when 'getStatusType' {
-                    return convertStatusType((String) args[0]);
+                when 'getState' {
+                    return statusToStateMap.get((String) args[0]);
                 } when else {
                     return null;
                 }

--- a/src/classes/RD2_StatusMapper_TEST.cls
+++ b/src/classes/RD2_StatusMapper_TEST.cls
@@ -50,10 +50,10 @@ public with sharing class RD2_StatusMapper_TEST {
         };
 
         /**
-        * @description Override default Status to State Mapping
-        * @param statusToStateMap new Status to State map;
+        * @description Override default Status Mapping Settings
+        * @param statusToStateMap new Status Mapping Settings;
         */
-        public Stub mapStatusToState(Map<String, String> statusToStateMap) {
+        public Stub overrideDefaultMapping(Map<String, String> statusToStateMap) {
             this.statusToStateMap = statusToStateMap;
             return this;
         }

--- a/src/classes/RD2_StatusMapper_TEST.cls
+++ b/src/classes/RD2_StatusMapper_TEST.cls
@@ -35,5 +35,42 @@
 */
 @IsTest(IsParallel=true)
 public with sharing class RD2_StatusMapper_TEST {
+    /***
+    * @description RD2_StatusMapper Stub
+    */
+    public class Stub implements System.StubProvider {
 
+        /**
+        * @description Hard coded validate status
+        * @param status status to check
+        * @return Convert to mapped status, return null when status is not Active or Closed 
+        */
+        private String convertStatusType(String status) {
+            if (status == RD2_Constants.STATUS_ACTIVE) {
+                return RD2_Constants.STATUS_ACTIVE;
+    
+            } else if (status == RD2_Constants.STATUS_CLOSED) {
+                return RD2_Constants.STATUS_CLOSED;
+            } else {
+                return null;
+            }
+        }
+
+        public Object handleMethodCall(
+            Object stubbedObject,
+            String methodName,
+            Type returnType,
+            List<Type> paramTypes,
+            List<String> paramNames,
+            List<Object> args
+        ) {
+            switch on methodName {
+                when 'getStatusType' {
+                    return convertStatusType((String) args[0]);
+                } when else {
+                    return null;
+                }
+            }
+        }
+    }
 }

--- a/src/classes/RD2_StatusMapper_TEST.cls
+++ b/src/classes/RD2_StatusMapper_TEST.cls
@@ -43,18 +43,31 @@ public with sharing class RD2_StatusMapper_TEST {
         /***
         * @description Mock RD Status Mapping Settings
         */
-        private Map<String, String> statusToStateMap = new Map<String, String> {
-            RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE,
-            RD2_Constants.STATUS_LAPSED => RD2_Constants.STATUS_LAPSED,
-            RD2_Constants.STATUS_CLOSED => RD2_Constants.STATUS_CLOSED
-        };
+        private Map<String, String> stateByStatus = new Map<String, String>();
 
         /**
-        * @description Override default Status Mapping Settings
-        * @param statusToStateMap new Status Mapping Settings;
+        * @description Load Status Mapping Settings mock with default values
+        * @return Stub
         */
-        public Stub overrideDefaultMapping(Map<String, String> statusToStateMap) {
-            this.statusToStateMap = statusToStateMap;
+        public Stub withDefaultMapping() {
+            stateByStatus.putAll(new Map<String, String> {
+                RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE,
+                RD2_Constants.STATUS_LAPSED => RD2_Constants.STATUS_LAPSED,
+                RD2_Constants.STATUS_CLOSED => RD2_Constants.STATUS_CLOSED
+            });
+
+            return this;
+        }
+
+        /**
+        * @description Add Status to State to the Statue Mapping Settings
+        * @param status The status to mapped from
+        * @param state The state to mapped to
+        * @return Stub
+        */
+        public Stub withStatusMapping(String status, String state) {
+            stateByStatus.put(status, state);
+
             return this;
         }
 
@@ -68,7 +81,7 @@ public with sharing class RD2_StatusMapper_TEST {
         ) {
             switch on methodName {
                 when 'getState' {
-                    return statusToStateMap.get((String) args[0]);
+                    return stateByStatus.get((String) args[0]);
                 } when else {
                     return null;
                 }

--- a/src/classes/RD2_StatusMapper_TEST.cls
+++ b/src/classes/RD2_StatusMapper_TEST.cls
@@ -30,7 +30,7 @@
 * @author Salesforce.org
 * @date 2020
 * @group Recurring Donations
-* @description Unit tests for the Enhanced RD Settings
+* @description Unit tests for Enhanced Recurring Donation Status Mapping Setting
 *
 */
 @IsTest(IsParallel=true)

--- a/src/classes/RD2_StatusMapper_TEST.cls-meta.xml
+++ b/src/classes/RD2_StatusMapper_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -289,9 +289,15 @@ public with sharing class RD2_ValidationService {
     @TestVisible
     private void validateStatus(npe03__Recurring_Donation__c rd) {
         if (String.isBlank(statusMapper.getState(rd.Status__c))) {
+            String errorMessage = String.join(
+                new List<String>{
+                    System.Label.RD2_StatusMustBeMapped,
+                    System.Label.RD2_StatusMustBeMappedSolution},
+                ' ');
+
             rd.addError(
                 String.format(
-                    System.Label.RD2_StatusMustBeMapped,
+                    errorMessage,
                     new String[]{rd.Status__c})
             );
         }

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -282,12 +282,13 @@ public with sharing class RD2_ValidationService {
     }
 
     /**
-    * @description Validate the RD Status has the mapped State configure
+    * @description Validate the RD Status is configured in the Status Mapping Settings
     * @param rd The Recurring Donation to validate
-    * @return void 
+    * @return void
     */
+    @TestVisible
     private void validateStatusIsMapped(npe03__Recurring_Donation__c rd) {
-        if (String.isBlank(statusMapper.getStatusType(rd.Status__c))) {
+        if (String.isBlank(statusMapper.getState(rd.Status__c))) {
             rd.addError(
                 String.format(
                     System.Label.RD2_StatusMustBeMapped,

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -107,7 +107,7 @@ public with sharing class RD2_ValidationService {
     /**
     * @description Status to State Mapper 
     */
-    private static RD2_StatusMapper statusMapper {
+    public static RD2_StatusMapper statusMapper {
         get {
             if (statusMapper == null) {
                 statusMapper = new RD2_StatusMapper();
@@ -145,7 +145,7 @@ public with sharing class RD2_ValidationService {
             validateActiveRecurringDonation(rd);
             validateInstallmentFrequency(rd);
             validateDonor(rd, accountById.get(rd.npe03__Organization__c));
-            validateStatusMapping(rd);
+            validateStatusIsMapped(rd);
         }
     }
 
@@ -166,7 +166,7 @@ public with sharing class RD2_ValidationService {
             validateActiveRecurringDonation(rd);
             validateInstallmentFrequency(rd);
             validateCurrencyChange(rd, oldRd);
-            validateStatusMapping(rd);
+            validateStatusIsMapped(rd);
 
             Boolean isValid = validateDonorChange(rd, oldRd);
             if (isValid) {
@@ -286,9 +286,13 @@ public with sharing class RD2_ValidationService {
     * @param rd The Recurring Donation to validate
     * @return void 
     */
-    private void validateStatusMapping(npe03__Recurring_Donation__c rd) {
+    private void validateStatusIsMapped(npe03__Recurring_Donation__c rd) {
         if (String.isBlank(statusMapper.getStatusType(rd.Status__c))) {
-            rd.addError('error');
+            rd.addError(
+                String.format(
+                    System.Label.RD2_StatusMustBeMapped,
+                    new String[]{rd.Status__c})
+            );
         }
     }
 

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -105,7 +105,7 @@ public with sharing class RD2_ValidationService {
     }
 
     /**
-    * @description Status to State Mapper 
+    * @description Contains the current Status to State map configuration
     */
     public static RD2_StatusMapper statusMapper {
         get {

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -289,15 +289,9 @@ public with sharing class RD2_ValidationService {
     @TestVisible
     private void validateStatus(npe03__Recurring_Donation__c rd) {
         if (String.isBlank(statusMapper.getState(rd.Status__c))) {
-            String errorMessage = String.join(
-                new List<String>{
-                    System.Label.RD2_StatusMustBeMapped,
-                    System.Label.RD2_StatusMustBeMappedSolution},
-                ' ');
-
             rd.addError(
                 String.format(
-                    errorMessage,
+                    System.Label.RD2_StatusMustBeMapped + ' ' + System.Label.RD2_StatusMustBeMappedSolution,
                     new String[]{rd.Status__c})
             );
         }

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -104,6 +104,19 @@ public with sharing class RD2_ValidationService {
         set;
     }
 
+    /**
+    * @description Status to State Mapper 
+    */
+    private static RD2_StatusMapper statusMapper {
+        get {
+            if (statusMapper == null) {
+                statusMapper = new RD2_StatusMapper();
+            }
+            return statusMapper;
+        }
+        set;
+    }
+
 
     /**
     * @description Constructor for the RD2_ValidationService class
@@ -132,6 +145,7 @@ public with sharing class RD2_ValidationService {
             validateActiveRecurringDonation(rd);
             validateInstallmentFrequency(rd);
             validateDonor(rd, accountById.get(rd.npe03__Organization__c));
+            validateStatusMapping(rd);
         }
     }
 
@@ -152,6 +166,7 @@ public with sharing class RD2_ValidationService {
             validateActiveRecurringDonation(rd);
             validateInstallmentFrequency(rd);
             validateCurrencyChange(rd, oldRd);
+            validateStatusMapping(rd);
 
             Boolean isValid = validateDonorChange(rd, oldRd);
             if (isValid) {
@@ -263,6 +278,17 @@ public with sharing class RD2_ValidationService {
             && !noClosedOppRDIds.contains(rd.Id)
         ) {
             rd.addError(System.Label.RD2_CurrencyChangeIsRestrictedOnRD);
+        }
+    }
+
+    /**
+    * @description Validate the RD Status has the mapped State configure
+    * @param rd The Recurring Donation to validate
+    * @return void 
+    */
+    private void validateStatusMapping(npe03__Recurring_Donation__c rd) {
+        if (String.isBlank(statusMapper.getStatusType(rd.Status__c))) {
+            rd.addError('error');
         }
     }
 

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -145,7 +145,7 @@ public with sharing class RD2_ValidationService {
             validateActiveRecurringDonation(rd);
             validateInstallmentFrequency(rd);
             validateDonor(rd, accountById.get(rd.npe03__Organization__c));
-            validateStatusIsMapped(rd);
+            validateStatus(rd);
         }
     }
 
@@ -166,7 +166,7 @@ public with sharing class RD2_ValidationService {
             validateActiveRecurringDonation(rd);
             validateInstallmentFrequency(rd);
             validateCurrencyChange(rd, oldRd);
-            validateStatusIsMapped(rd);
+            validateStatus(rd);
 
             Boolean isValid = validateDonorChange(rd, oldRd);
             if (isValid) {
@@ -282,12 +282,12 @@ public with sharing class RD2_ValidationService {
     }
 
     /**
-    * @description Validate the RD Status is configured in the Status Mapping Settings
+    * @description Validates RD status is mapped to a valid state
     * @param rd The Recurring Donation to validate
     * @return void
     */
     @TestVisible
-    private void validateStatusIsMapped(npe03__Recurring_Donation__c rd) {
+    private void validateStatus(npe03__Recurring_Donation__c rd) {
         if (String.isBlank(statusMapper.getState(rd.Status__c))) {
             rd.addError(
                 String.format(

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -834,12 +834,9 @@ private with sharing class RD2_ValidationService_TEST {
         } catch (Exception e) {
             errMessage = e.getMessage();
         }
-        
-        String expectedMessage =  String.format(
-            System.Label.RD2_StatusMustBeMapped,
-            new String[]{rd.Status__c});
 
-        System.assert(errMessage.contains(expectedMessage),
+        System.assert(
+            errMessage.contains(formatStatusMappingError(rd.Status__c)),
             'RD should fail to inserted when the status is not mapped:' + errMessage
         );
     }
@@ -911,15 +908,8 @@ private with sharing class RD2_ValidationService_TEST {
             errMessage = e.getMessage();
         }
 
-        String expectedMessage =  String.format(
-            String.join(
-                new List<String>{
-                    System.Label.RD2_StatusMustBeMapped,
-                    System.Label.RD2_StatusMustBeMappedSolution},
-                ' '),
-            new String[]{rd.Status__c});
-
-        System.assert(errMessage.contains(expectedMessage),
+        System.assert(
+            errMessage.contains(formatStatusMappingError(rd.Status__c)),
             'RD update should fail when Status is not mapped: ' + errMessage
         );
     }
@@ -978,5 +968,16 @@ private with sharing class RD2_ValidationService_TEST {
             .withRecurringDonation(rd.Id)
             .withAmount(rd.npe03__Amount__c)
             .withInstallmentNumber(1);
+    }
+
+    /**
+    * @description Format the Status Mapping Validation Error
+    * @param status Status that will be included in the error message
+    */
+    private static String formatStatusMappingError(String status) {
+        return String.format(
+            System.Label.RD2_StatusMustBeMapped + ' ' + System.Label.RD2_StatusMustBeMappedSolution,
+            new List<String>{status}
+        );
     }
 }

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -778,14 +778,11 @@ private with sharing class RD2_ValidationService_TEST {
     * @description Verifies that RD is inserted successfully when Status is mapped
     */
     @isTest
-    private static void shouldSuccessfullyInsertRDWhenStatusIsMapped() {
+    private static void shouldCreateRDWhenStatusIsMapped() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
-            .overrideDefaultMapping(
-                new Map<String, String>{
-                    RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE}
-            );
+            .withDefaultMapping();
         RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
             RD2_StatusMapper.Class,
             mapperStub
@@ -818,10 +815,7 @@ private with sharing class RD2_ValidationService_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
-            .overrideDefaultMapping(
-                new Map<String, String>{
-                    RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE}
-            );
+            .withStatusMapping(RD2_Constants.STATUS_ACTIVE, RD2_Constants.STATUS_ACTIVE);
         RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
             RD2_StatusMapper.Class,
             mapperStub
@@ -854,15 +848,11 @@ private with sharing class RD2_ValidationService_TEST {
     * @description Verifies that RD is updated successfully when Status is mapped
     */
     @isTest
-    private static void shouldSuccessfullyUpdateRDWhenStatusIsMapped() {
+    private static void shouldUpdateRDWhenStatusIsMapped() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
-            .overrideDefaultMapping(
-                new Map<String, String>{
-                    RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE,
-                    RD2_Constants.STATUS_CLOSED => RD2_Constants.STATUS_CLOSED}
-            );
+            .withDefaultMapping();
         RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
             RD2_StatusMapper.Class,
             mapperStub
@@ -898,10 +888,7 @@ private with sharing class RD2_ValidationService_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
-            .overrideDefaultMapping(
-                new Map<String, String>{
-                    RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE}
-            );
+            .withStatusMapping(RD2_Constants.STATUS_ACTIVE, RD2_Constants.STATUS_ACTIVE);
         RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
             RD2_StatusMapper.Class,
             mapperStub

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -774,7 +774,133 @@ private with sharing class RD2_ValidationService_TEST {
         );
     }
 
+    /***
+    * @description Verifies that RD is inserted successfully when Status is mapped
+    */
+    @isTest
+    private static void shouldSuccessfullyInsertRDWhenStatusIsMapped() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
+            RD2_StatusMapper.Class,
+            new RD2_StatusMapper_TEST.Stub()
+        );
 
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
+            .withContact(getContact().Id)
+            .withStatusActive()
+            .build();
+        
+        Test.startTest();
+        insert rd;
+        Test.stopTest();
+
+        rd = rdGateway.getRecord(rd.Id);
+        System.assert(rd.Id != null, 'RD insert should succeed when Status is mapped');
+    }
+
+    /***
+    * @description Verifies that RD fail to inserted when Status is not mapped
+    */
+    @isTest
+    private static void shouldFailRDInsertWhenStatusIsNotMapped() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
+            RD2_StatusMapper.Class,
+            new RD2_StatusMapper_TEST.Stub()
+        );
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
+            .withContact(getContact().Id)
+            .withStatus(RD2_Constants.STATUS_LAPSED)
+            .build();
+    
+        String errMessage = '';
+        try {
+            Test.startTest();
+            insert rd;
+            Test.stopTest();
+        } catch (Exception e) {
+            errMessage = e.getMessage();
+        }
+        
+        String expectedMessage =  String.format(
+            System.Label.RD2_StatusMustBeMapped,
+            new String[]{rd.Status__c});
+
+        System.assert(errMessage.contains(expectedMessage),
+            'RD should fail to inserted when the status is not mapped:' + errMessage
+        );
+    }
+
+    /***
+    * @description Verifies that RD is updated successfully when Status is mapped
+    */
+    @isTest
+    private static void shouldSuccessfullyUpdateRDWhenStatusIsMapped() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
+            RD2_StatusMapper.Class,
+            new RD2_StatusMapper_TEST.Stub()
+        );
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
+            .withContact(getContact().Id)
+            .withStatusActive()
+            .build();
+        insert rd;
+        
+        
+        String errMessage = '';
+        try {
+            Test.startTest();
+            rd.Status__c = RD2_Constants.STATUS_CLOSED;
+            update rd;
+            Test.stopTest();
+        } catch (Exception e) {
+            errMessage = e.getMessage();
+        }
+
+        System.assert(String.isBlank(errMessage),
+            'RD update should succeed when Status is mapped: ' + errMessage
+        );
+    }
+
+    /***
+    * @description Verifies that RD fail to update when Status is not mapped
+    */
+    @isTest
+    private static void shouldFailRDUpdateWhenStatusIsNotMapped() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
+            RD2_StatusMapper.Class,
+            new RD2_StatusMapper_TEST.Stub()
+        );
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
+            .withContact(getContact().Id)
+            .withStatusActive()
+            .build();
+        insert rd;
+        
+        
+        String errMessage = '';
+        try {
+            Test.startTest();
+            rd.Status__c = RD2_Constants.STATUS_LAPSED;
+            update rd;
+            Test.stopTest();
+        } catch (Exception e) {
+            errMessage = e.getMessage();
+        }
+
+        String expectedMessage =  String.format(
+            System.Label.RD2_StatusMustBeMapped,
+            new String[]{rd.Status__c});
+
+        System.assert(errMessage.contains(expectedMessage),
+            'RD update should fail when Status is not mapped: ' + errMessage
+        );
+    }
 
     // Helper Methods
     /////////////////////

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -912,7 +912,11 @@ private with sharing class RD2_ValidationService_TEST {
         }
 
         String expectedMessage =  String.format(
-            System.Label.RD2_StatusMustBeMapped,
+            String.join(
+                new List<String>{
+                    System.Label.RD2_StatusMustBeMapped,
+                    System.Label.RD2_StatusMustBeMappedSolution},
+                ' '),
             new String[]{rd.Status__c});
 
         System.assert(errMessage.contains(expectedMessage),

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -780,9 +780,15 @@ private with sharing class RD2_ValidationService_TEST {
     @isTest
     private static void shouldSuccessfullyInsertRDWhenStatusIsMapped() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
+            .mapStatusToState(
+                new Map<String, String>{
+                    RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE}
+            );
         RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
             RD2_StatusMapper.Class,
-            new RD2_StatusMapper_TEST.Stub()
+            mapperStub
         );
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
@@ -790,12 +796,18 @@ private with sharing class RD2_ValidationService_TEST {
             .withStatusActive()
             .build();
         
-        Test.startTest();
-        insert rd;
-        Test.stopTest();
+        String errMessage = '';
+        try {
+            Test.startTest();
+            insert rd;
+            Test.stopTest();
+        } catch (Exception e) {
+            errMessage = e.getMessage();
+        }
 
-        rd = rdGateway.getRecord(rd.Id);
-        System.assert(rd.Id != null, 'RD insert should succeed when Status is mapped');
+        System.assert(String.isBlank(errMessage),
+            'RD insert should succeed when Status is mapped: ' + errMessage
+        );
     }
 
     /***
@@ -804,14 +816,20 @@ private with sharing class RD2_ValidationService_TEST {
     @isTest
     private static void shouldFailRDInsertWhenStatusIsNotMapped() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
+            .mapStatusToState(
+                new Map<String, String>{
+                    RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE}
+            );
         RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
             RD2_StatusMapper.Class,
-            new RD2_StatusMapper_TEST.Stub()
+            mapperStub
         );
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
             .withContact(getContact().Id)
-            .withStatus(RD2_Constants.STATUS_LAPSED)
+            .withStatusClosed()
             .build();
     
         String errMessage = '';
@@ -838,9 +856,16 @@ private with sharing class RD2_ValidationService_TEST {
     @isTest
     private static void shouldSuccessfullyUpdateRDWhenStatusIsMapped() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
+            .mapStatusToState(
+                new Map<String, String>{
+                    RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE,
+                    RD2_Constants.STATUS_CLOSED => RD2_Constants.STATUS_CLOSED}
+            );
         RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
             RD2_StatusMapper.Class,
-            new RD2_StatusMapper_TEST.Stub()
+            mapperStub
         );
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()
@@ -871,9 +896,15 @@ private with sharing class RD2_ValidationService_TEST {
     @isTest
     private static void shouldFailRDUpdateWhenStatusIsNotMapped() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
+            .mapStatusToState(
+                new Map<String, String>{
+                    RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE}
+            );
         RD2_ValidationService.statusMapper = (RD2_StatusMapper) Test.createStub(
             RD2_StatusMapper.Class,
-            new RD2_StatusMapper_TEST.Stub()
+            mapperStub
         );
 
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder()

--- a/src/classes/RD2_ValidationService_TEST.cls
+++ b/src/classes/RD2_ValidationService_TEST.cls
@@ -782,7 +782,7 @@ private with sharing class RD2_ValidationService_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
-            .mapStatusToState(
+            .overrideDefaultMapping(
                 new Map<String, String>{
                     RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE}
             );
@@ -818,7 +818,7 @@ private with sharing class RD2_ValidationService_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
-            .mapStatusToState(
+            .overrideDefaultMapping(
                 new Map<String, String>{
                     RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE}
             );
@@ -858,7 +858,7 @@ private with sharing class RD2_ValidationService_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
-            .mapStatusToState(
+            .overrideDefaultMapping(
                 new Map<String, String>{
                     RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE,
                     RD2_Constants.STATUS_CLOSED => RD2_Constants.STATUS_CLOSED}
@@ -898,7 +898,7 @@ private with sharing class RD2_ValidationService_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         RD2_StatusMapper_TEST.Stub mapperStub = new RD2_StatusMapper_TEST.Stub()
-            .mapStatusToState(
+            .overrideDefaultMapping(
                 new Map<String, String>{
                     RD2_Constants.STATUS_ACTIVE => RD2_Constants.STATUS_ACTIVE}
             );

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2108,6 +2108,14 @@ If you&apos;re not sure how to resolve these errors, post a message in the Nonpr
         <value>Upcoming Installments</value>
     </labels>
     <labels>
+        <fullName>RD2_StatusMustBeMapped</fullName>
+        <categories>Recurring-Donations, Error</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Message when Enhanced RD status is not mapped</shortDescription>
+        <value>The Status {0} hasn't been mapped to a State. Go to NPSP Settings | Recurring Donations | Status to State Mappings, or contact your administrator for help.</value>
+    </labels>
+    <labels>
         <fullName>RecurringDonationNameSuffix</fullName>
         <categories>Recurring Donations</categories>
         <language>en_US</language>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2109,11 +2109,19 @@ If you&apos;re not sure how to resolve these errors, post a message in the Nonpr
     </labels>
     <labels>
         <fullName>RD2_StatusMustBeMapped</fullName>
-        <categories>Recurring-Donations, Error</categories>
+        <categories>Recurring-Donations, Error, Health Check</categories>
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Message when Enhanced RD status is not mapped</shortDescription>
-        <value>The Status {0} hasn't been mapped to a State. Go to NPSP Settings | Recurring Donations | Status to State Mappings, or contact your administrator for help.</value>
+        <value>The Status &quot;{0}&quot; hasn&apos;&apos;t been mapped to a State.</value>
+    </labels>
+    <labels>
+        <fullName>RD2_StatusMustBeMappedSolution</fullName>
+        <categories>Recurring-Donations, Error, Health Check</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Solution when Enhanced RD status is not mapped</shortDescription>
+        <value>Go to NPSP Settings | Recurring Donations | Status to State Mappings, or contact your administrator for help.</value>
     </labels>
     <labels>
         <fullName>RecurringDonationNameSuffix</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1674,6 +1674,7 @@
         <members>RD2_ScheduleVisualizerMessageNoSchedule</members>
         <members>RD2_ScheduleVisualizerTitle</members>
         <members>RD2_StatusMustBeMapped</members>
+        <members>RD2_StatusMustBeMappedSolution</members>
         <members>RD_ContactMustBelongToAccount</members>
         <members>RD_DonorIsRequired</members>
         <members>RD_ErrorAddDonationHeaderText</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -405,6 +405,8 @@
         <members>RD2_ScheduleService_TEST</members>
         <members>RD2_Settings</members>
         <members>RD2_Settings_TEST</members>
+        <members>RD2_StatusMapper</members>
+        <members>RD2_StatusMapper_TEST</members>
         <members>RD2_ValidationService</members>
         <members>RD2_ValidationService_TEST</members>
         <members>RD2_VisualizeScheduleController</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1673,6 +1673,7 @@
         <members>RD2_ScheduleVisualizerMessageNoActiveSchedule</members>
         <members>RD2_ScheduleVisualizerMessageNoSchedule</members>
         <members>RD2_ScheduleVisualizerTitle</members>
+        <members>RD2_StatusMustBeMapped</members>
         <members>RD_ContactMustBelongToAccount</members>
         <members>RD_DonorIsRequired</members>
         <members>RD_ErrorAddDonationHeaderText</members>


### PR DESCRIPTION
As an admin I want to ensure that the Status my users enter on an RD is actually mapped to an RD state for processing so that they are handled correctly.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata
Apex Class:
- RD2_StatusMapper
- RD2_StatusMapper_TEST

Custom Labels:
- RD2_StatusMustBeMapped

# Deleted Metadata
