### PR TITLE
Gift Entry Payment Services: Hide Payment Services widget when not an Elevate customer

### DIFF
--- a/src/classes/GE_GiftEntryController.cls
+++ b/src/classes/GE_GiftEntryController.cls
@@ -258,5 +258,14 @@ public with sharing class GE_GiftEntryController {
         }
     }
 
+    @AuraEnabled
+    public static Boolean isElevateCustomer() {
+        try {
+            return GE_PaymentServices.isElevateCustomer;
+        } catch (Exception ex) {
+            throw new AuraHandledException(ex.getMessage());
+        }
+    }
+
     private class BDIException extends Exception {}
 }

--- a/src/classes/GE_PaymentServices.cls
+++ b/src/classes/GE_PaymentServices.cls
@@ -39,6 +39,10 @@ public with sharing class GE_PaymentServices {
 
     PurchaseCallBody purchaseCallBody;
 
+    // Names of Payment Service configuration sets
+    @TestVisible static final String PAYMENTS_SERVICE_NAME = 'payments';
+    @TestVisible static final String MAKANA_SERVICE_NAME = 'makana';
+
     // Properties used to configure headers in
     // HTTP Requests to Elevate payment services
     @TestVisible static final String API_KEY = 'apiKey';
@@ -50,9 +54,14 @@ public with sharing class GE_PaymentServices {
     @TestVisible static final String ELEVATE_SDK = 'elevateSDK';
     @TestVisible static final String PRODUCTID = 'productId';
 
-    // Names of Payment Service configuration sets
-    @TestVisible static final String PAYMENTS_SERVICE_NAME = 'payments';
-    @TestVisible static final String MAKANA_SERVICE_NAME = 'makana';
+    @TestVisible private static final List<String> REQUIRED_CONFIG_KEYS = new List<String>{
+            ELEVATE_SDK,
+            PRODUCTID,
+            BASE_URL,
+            API_KEY,
+            SFDO_MERCHANTIDS,
+            SFDO_GATEWAYIDS
+    };
 
     @TestVisible Map<String, String> config;
 
@@ -313,19 +322,12 @@ public with sharing class GE_PaymentServices {
      * @description Checks whether an org is a customer of Elevate Payment Services.
      *              After onboarding within Elevate, these configuration key-value
      *              pairs should exist in the org.  If this required set of keys is not
-     *              found, then NPSP cannot successfully make callouts to Elevate.
+     *              in the org, NPSP cannot load the Elevate SDK or successfully make
+     *              callouts to Elevate services.
     */
     @AuraEnabled
     public static Boolean isElevateCustomer() {
-        return new Configuration().keyValueMap.keySet().containsAll(
-                new List<String>{
-                        ELEVATE_SDK,
-                        PRODUCTID,
-                        BASE_URL,
-                        API_KEY,
-                        SFDO_MERCHANTIDS,
-                        SFDO_GATEWAYIDS
-                });
+        return new Configuration().keyValueMap.keySet().containsAll(REQUIRED_CONFIG_KEYS);
     }
 
 }

--- a/src/classes/GE_PaymentServices.cls
+++ b/src/classes/GE_PaymentServices.cls
@@ -325,9 +325,10 @@ public with sharing class GE_PaymentServices {
      *              in the org, NPSP cannot load the Elevate SDK or successfully make
      *              callouts to Elevate services.
     */
-    @AuraEnabled
-    public static Boolean isElevateCustomer() {
-        return new Configuration().keyValueMap.keySet().containsAll(REQUIRED_CONFIG_KEYS);
+    public static Boolean isElevateCustomer {
+        get {
+            return new Configuration().keyValueMap.keySet().containsAll(REQUIRED_CONFIG_KEYS);
+        }
     }
 
 }

--- a/src/classes/GE_PaymentServices.cls
+++ b/src/classes/GE_PaymentServices.cls
@@ -41,7 +41,7 @@ public with sharing class GE_PaymentServices {
 
     // Properties used to configure headers in
     // HTTP Requests to Elevate payment services
-    @TestVisible static final String API_Key = 'apiKey';
+    @TestVisible static final String API_KEY = 'apiKey';
     @TestVisible static final String BASE_URL = 'baseURL';
     @TestVisible static final String JWT_TOKEN = 'jwttoken';
     @TestVisible static final String SFDO_MERCHANTIDS = 'sfdo.merchantids';
@@ -282,7 +282,7 @@ public with sharing class GE_PaymentServices {
                             )) {
                         if (configRecord.Service__c == PAYMENTS_SERVICE_NAME) {
                             keyValueMap.put(configRecord.Key__c, configRecord.Value__c);
-                        } else if (configRecord.Key__c == API_Key &&
+                        } else if (configRecord.Key__c == API_KEY &&
                                 configRecord.Service__c == MAKANA_SERVICE_NAME) {
                             makanaKey = configRecord.Value__c;
                         }
@@ -290,8 +290,8 @@ public with sharing class GE_PaymentServices {
 
                     // If the payments service config does not have an Api key
                     // and makana does, use the makana Api key
-                    if (makanaKey != null && keyValueMap.get(API_Key) == null) {
-                        keyValueMap.put(API_Key, makanaKey);
+                    if (makanaKey != null && keyValueMap.get(API_KEY) == null) {
+                        keyValueMap.put(API_KEY, makanaKey);
                     }
                 }
                 return keyValueMap;

--- a/src/classes/GE_PaymentServices.cls
+++ b/src/classes/GE_PaymentServices.cls
@@ -48,7 +48,7 @@ public with sharing class GE_PaymentServices {
     @TestVisible static final String SFDO_GATEWAYIDS = 'sfdo.gatewayids';
     @TestVisible static final String SFDO_USERNAME = 'sfdo.username';
     @TestVisible static final String ELEVATE_SDK = 'elevateSDK';
-    @TestVisible protected final String PRODUCTID = 'productId';
+    @TestVisible static final String PRODUCTID = 'productId';
 
     // Names of Payment Service configuration sets
     @TestVisible static final String PAYMENTS_SERVICE_NAME = 'payments';
@@ -116,7 +116,7 @@ public with sharing class GE_PaymentServices {
     }
 
     public String getJwt() {
-        JWTPayload jwtPayload = new JWTPayload(this);
+        JWTPayload jwtPayload = new JWTPayload(config.get(PRODUCTID));
         String jwt = UTIL_Jwt.getSignedJWTFromString(
                 jwtPayload.getAsString(),
                 config.get(API_KEY)
@@ -139,8 +139,8 @@ public with sharing class GE_PaymentServices {
     public with sharing class JWTPayload {
         String sfdoId;
 
-        public JWTPayload(GE_PaymentServices serviceInstance) {
-            sfdoId = serviceInstance.config.get(serviceInstance.PRODUCTID);
+        public JWTPayload(String sfdoId) {
+            this.sfdoId = sfdoId;
         }
 
         private Long getEpochTimestamp(DateTime dt) {

--- a/src/classes/GE_PaymentServices.cls
+++ b/src/classes/GE_PaymentServices.cls
@@ -309,4 +309,23 @@ public with sharing class GE_PaymentServices {
         }
     }
 
+    /**
+     * @description Checks whether an org is a customer of Elevate Payment Services.
+     *              After onboarding within Elevate, these configuration key-value
+     *              pairs should exist in the org.  If this required set of keys is not
+     *              found, then NPSP cannot successfully make callouts to Elevate.
+    */
+    @AuraEnabled
+    public static Boolean isElevateCustomer() {
+        return new Configuration().keyValueMap.keySet().containsAll(
+                new List<String>{
+                        ELEVATE_SDK,
+                        PRODUCTID,
+                        BASE_URL,
+                        API_KEY,
+                        SFDO_MERCHANTIDS,
+                        SFDO_GATEWAYIDS
+                });
+    }
+
 }

--- a/src/classes/GE_PaymentServices_TEST.cls
+++ b/src/classes/GE_PaymentServices_TEST.cls
@@ -64,7 +64,7 @@ public class GE_PaymentServices_TEST {
                                             'value' => 'Payments.Purchase'
                                     },
                                     new Map<String, String>{
-                                            'key' => GE_PaymentServices.API_Key,
+                                            'key' => GE_PaymentServices.API_KEY,
                                             'value' => testApiKey
                                     }
                             }
@@ -142,7 +142,7 @@ public class GE_PaymentServices_TEST {
         // the same as those of the inserted config records
         System.assertEquals(testMerchantId,
                 service.config.get(GE_PaymentServices.SFDO_MERCHANTIDS));
-        System.assertEquals(testApiKey, service.config.get(GE_PaymentServices.API_Key));
+        System.assertEquals(testApiKey, service.config.get(GE_PaymentServices.API_KEY));
     }
 
     /**
@@ -160,14 +160,14 @@ public class GE_PaymentServices_TEST {
                         GE_PaymentServices.PAYMENTS_SERVICE_NAME =>
                                 new List<Map<String, String>>{
                                         new Map<String, String>{
-                                                'key' => GE_PaymentServices.API_Key,
+                                                'key' => GE_PaymentServices.API_KEY,
                                                 'value' => null
                                         }
                                 },
                         GE_PaymentServices.MAKANA_SERVICE_NAME =>
                                 new List<Map<String, String>>{
                                         new Map<String, String>{
-                                                'key' => GE_PaymentServices.API_Key,
+                                                'key' => GE_PaymentServices.API_KEY,
                                                 'value' => testMakanaApiKey
                                         }
                                 }
@@ -180,7 +180,7 @@ public class GE_PaymentServices_TEST {
 
         // Verify apiKey matches makana, while the rest match payments
         System.assertEquals(testMakanaApiKey,
-                service.config.get(GE_PaymentServices.API_Key));
+                service.config.get(GE_PaymentServices.API_KEY));
         System.assertEquals(testMerchantId,
                 service.config.get(GE_PaymentServices.SFDO_MERCHANTIDS));
     }

--- a/src/classes/GE_PaymentServices_TEST.cls
+++ b/src/classes/GE_PaymentServices_TEST.cls
@@ -204,7 +204,7 @@ public class GE_PaymentServices_TEST {
                         'all required configuration keys are present.');
 
         // Now delete a required configuration key and validate that
-        // GE_PaymentServices.isElevateCustomer returns false
+        // GE_PaymentServices.isElevateCustomer is false
         delete [SELECT Id FROM Payment_Services_Configuration__c LIMIT 1];
         System.assertEquals(false, GE_PaymentServices.isElevateCustomer,
                 'The org should not be considered an Elevate customer without ' +

--- a/src/classes/GE_PaymentServices_TEST.cls
+++ b/src/classes/GE_PaymentServices_TEST.cls
@@ -199,14 +199,14 @@ public class GE_PaymentServices_TEST {
         }
         insert requiredConfigs;
 
-        System.assertEquals(true, GE_PaymentServices.isElevateCustomer(),
+        System.assertEquals(true, GE_PaymentServices.isElevateCustomer,
                 'The org should be considered an Elevate customer when ' +
                         'all required configuration keys are present.');
 
         // Now delete a required configuration key and validate that
         // GE_PaymentServices.isElevateCustomer returns false
         delete [SELECT Id FROM Payment_Services_Configuration__c LIMIT 1];
-        System.assertEquals(false, GE_PaymentServices.isElevateCustomer(),
+        System.assertEquals(false, GE_PaymentServices.isElevateCustomer,
                 'The org should not be considered an Elevate customer without ' +
                         'all required configuration keys present.');
     }

--- a/src/classes/GE_PaymentServices_TEST.cls
+++ b/src/classes/GE_PaymentServices_TEST.cls
@@ -184,4 +184,31 @@ public class GE_PaymentServices_TEST {
         System.assertEquals(testMerchantId,
                 service.config.get(GE_PaymentServices.SFDO_MERCHANTIDS));
     }
+
+    @IsTest
+    private static void shouldRequireConfigurationKeysToBeAnElevateCustomer() {
+        List<Payment_Services_Configuration__c> requiredConfigs = new
+                List<Payment_Services_Configuration__c>();
+
+        for (Integer i = 0; i < GE_PaymentServices.REQUIRED_CONFIG_KEYS.size(); i++) {
+            requiredConfigs.add(new Payment_Services_Configuration__c(
+                    Service__c = GE_PaymentServices.PAYMENTS_SERVICE_NAME,
+                    Key__c = GE_PaymentServices.REQUIRED_CONFIG_KEYS.get(i),
+                    Value__c = String.valueOf(i)
+            ));
+        }
+        insert requiredConfigs;
+
+        System.assertEquals(true, GE_PaymentServices.isElevateCustomer(),
+                'The org should be considered an Elevate customer when ' +
+                        'all required configuration keys are present.');
+
+        // Now delete a required configuration key and validate that
+        // GE_PaymentServices.isElevateCustomer returns false
+        delete [SELECT Id FROM Payment_Services_Configuration__c LIMIT 1];
+        System.assertEquals(false, GE_PaymentServices.isElevateCustomer(),
+                'The org should not be considered an Elevate customer without ' +
+                        'all required configuration keys present.');
+    }
+
 }

--- a/src/lwc/geTemplateBuilderService/geTemplateBuilderService.js
+++ b/src/lwc/geTemplateBuilderService/geTemplateBuilderService.js
@@ -4,7 +4,7 @@ import { handleError } from 'c/utilTemplateBuilder';
 import { mutable } from 'c/utilCommon';
 import GeWidgetService from 'c/geWidgetService';
 import labelGeHeaderFieldBundles from '@salesforce/label/c.geHeaderFieldBundles';
-import isElevateCustomer from '@salesforce/apex/GE_PaymentServices.isElevateCustomer';
+import isElevateCustomer from '@salesforce/apex/GE_GiftEntryController.isElevateCustomer';
 
 class GeTemplateBuilderService {
     fieldMappingByDevName = null;

--- a/src/lwc/geTemplateBuilderService/geTemplateBuilderService.js
+++ b/src/lwc/geTemplateBuilderService/geTemplateBuilderService.js
@@ -110,22 +110,23 @@ class GeTemplateBuilderService {
     * @param {object} objectMappingByDevName: Map of object mappings.
     */
     addWidgetsPlaceholder = (fieldMappingByDevName, objectMappingByDevName, fieldMappingsByObjMappingDevName) => {
+        GeWidgetService.init(objectMappingByDevName, fieldMappingByDevName);
+
+        fieldMappingByDevName.geFormWidgetAllocation =
+            GeWidgetService.definitions.geFormWidgetAllocation;
+
+        objectMappingByDevName.Widgets = {
+            DeveloperName: 'Widgets',
+            MasterLabel: labelGeHeaderFieldBundles
+        };
+
+        fieldMappingsByObjMappingDevName.Widgets = [
+            fieldMappingByDevName.geFormWidgetAllocation
+        ];
+
+        // If the org is an Elevate customer, add the Salesforce.org Elevate widget
         isElevateCustomer()
             .then(isElevateCustomer => {
-                GeWidgetService.init(objectMappingByDevName, fieldMappingByDevName);
-
-                fieldMappingByDevName.geFormWidgetAllocation =
-                    GeWidgetService.definitions.geFormWidgetAllocation;
-
-                objectMappingByDevName.Widgets = {
-                    DeveloperName: 'Widgets',
-                    MasterLabel: labelGeHeaderFieldBundles
-                };
-
-                fieldMappingsByObjMappingDevName.Widgets = [
-                    fieldMappingByDevName.geFormWidgetAllocation
-                ];
-
                 if (isElevateCustomer) {
                     fieldMappingByDevName.geFormWidgetTokenizeCard =
                         GeWidgetService.definitions.geFormWidgetTokenizeCard;


### PR DESCRIPTION
This set of changes hides the payment services widget from the Template Builder sidebar if an org is not an Elevate customer.  It defines an Elevate customer by having the following configuration values set in the org:

elevateSDK, productId, baseURL, apiKey, sfdo.merchantids, sfdo.gatewayids

These configuration keys are required in order to load the Elevate SDK and to make callouts to Elevate services.

[W-040100](https://foundation.lightning.force.com/lightning/r/agf__ADM_Work__c/a2x1E000001HtRpQAK/view)

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
