### PR TITLE
GE PMT: Clear out Payment Status and Token in 'Do Not Charge Card' Mode

### DIFF
--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -162,7 +162,7 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     connectedCallback() {
         registerListener('widgetData', this.handleWidgetData, this);
         registerListener('paymentError', this.handleAsyncWidgetError, this);
-        registerListener('doNotChargeState', this.setCreditCardWidgetState, this);
+        registerListener('doNotChargeState', this.handleDoNotChargeCardState, this);
 
         if (this.batchId) {
             // When the form is being used for Batch Gift Entry, the Form Template JSON
@@ -907,10 +907,10 @@ export default class GeFormRenderer extends NavigationMixin(LightningElement) {
     }
 
     /**
-     * Informs the Form renderer when the credit card widget is in a 'do not charge' state
+     * @description Informs the form renderer when the credit card widget is in a 'do not charge' state
      * @param event
      */
-    setCreditCardWidgetState (event) {
+    handleDoNotChargeCardState (event) {
         this._isCreditCardWidgetInDoNotChargeState = true;
     }
 

--- a/src/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
+++ b/src/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
@@ -49,12 +49,9 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     handleUserDisabledWidget() {
         this.toggleWidget(true);
         this.hasUserDisabledWidget = true;
-        fireEvent(
-            null,
-            'doNotChargeState',
-            {
-                isWidgetDisabled : this.hasUserDisabledWidget
-            });
+        this.dispatchApplicationEvent('doNotChargeState', {
+            isWidgetDisabled : this.hasUserDisabledWidget
+        });
     }
 
     /*******************************************************************************
@@ -64,12 +61,9 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
         this.isLoading = true;
         this.toggleWidget(false);
         this.hasUserDisabledWidget = false;
-        fireEvent(
-            null,
-            'doNotChargeState',
-            {
-                isWidgetDisabled : this.hasUserDisabledWidget
-            });
+        this.dispatchApplicationEvent('doNotChargeState', {
+            isWidgetDisabled : this.hasUserDisabledWidget
+        });
     }
 
     /*******************************************************************************
@@ -241,5 +235,9 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     @api
     setNameOnCard(cardHolderName) {
         this.cardHolderName = cardHolderName;
+    }
+
+    dispatchApplicationEvent (eventName, payload) {
+        fireEvent(null, eventName, payload);
     }
 }

--- a/src/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
+++ b/src/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
@@ -4,7 +4,7 @@ import TemplateBuilderService from 'c/geTemplateBuilderService';
 import getOrgDomain from '@salesforce/apex/GE_GiftEntryController.getOrgDomain';
 import { format } from 'c/utilCommon';
 import { isFunction } from 'c/utilCommon';
-import { registerListener, unregisterListener } from 'c/pubsubNoPageRef';
+import { fireEvent, registerListener, unregisterListener } from 'c/pubsubNoPageRef';
 import DATA_IMPORT_PAYMENT_AUTHORIZATION_TOKEN_FIELD from '@salesforce/schema/DataImport__c.Payment_Authorization_Token__c';
 import { WIDGET_TYPE_DI_FIELD_VALUE, LABEL_NEW_LINE, DISABLE_TOKENIZE_WIDGET_EVENT_NAME } from 'c/geConstants';
 
@@ -49,7 +49,12 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     handleUserDisabledWidget() {
         this.toggleWidget(true);
         this.hasUserDisabledWidget = true;
-        // TODO: dispatch an event to form renderer to clear the token from the data import record
+        fireEvent(
+            null,
+            'doNotChargeState',
+            {
+                isWidgetDisabled : this.hasUserDisabledWidget
+            });
     }
 
     /*******************************************************************************
@@ -59,6 +64,12 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
         this.isLoading = true;
         this.toggleWidget(false);
         this.hasUserDisabledWidget = false;
+        fireEvent(
+            null,
+            'doNotChargeState',
+            {
+                isWidgetDisabled : this.hasUserDisabledWidget
+            });
     }
 
     /*******************************************************************************

--- a/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.js
+++ b/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.js
@@ -197,7 +197,7 @@ export default class GeGiftEntryFormApp extends NavigationMixin(LightningElement
         inMemoryDataImport[PAYMENT_STATUS__C] =
             this._isCreditCardWidgetInDoNotChargeState ? '' : this.dataImportRecord[PAYMENT_STATUS__C];
         inMemoryDataImport[PAYMENT_DECLINED_REASON__C] =
-            this.dataImportRecord[PAYMENT_DECLINED_REASON__C];
+            this._isCreditCardWidgetInDoNotChargeState ? '' : this.dataImportRecord[PAYMENT_DECLINED_REASON__C];
         inMemoryDataImport[PAYMENT_AUTHORIZE_TOKEN__C] =
             this._isCreditCardWidgetInDoNotChargeState ? '' : this.dataImportRecord[PAYMENT_AUTHORIZE_TOKEN__C];
         return inMemoryDataImport;

--- a/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.js
+++ b/src/lwc/geGiftEntryFormApp/geGiftEntryFormApp.js
@@ -76,6 +76,7 @@ export default class GeGiftEntryFormApp extends NavigationMixin(LightningElement
     dataImportRecord = {};
     errorCallback;
     isFailedPurchase = false;
+    _isCreditCardWidgetInDoNotChargeState = false;
 
     get isBatchMode() {
         return this.sObjectName &&
@@ -141,16 +142,16 @@ export default class GeGiftEntryFormApp extends NavigationMixin(LightningElement
     singleGiftSubmit = async (event) => {
         let { inMemoryDataImport } = event.detail;
         this.hasUserSelectedDonation = event.detail.hasUserSelectedDonation;
-
+        this._isCreditCardWidgetInDoNotChargeState = event.detail.isWidgetInDoNotChargeState;
         try {
             await this.saveDataImport(inMemoryDataImport);
 
             const hasPaymentToProcess = this.dataImportRecord[PAYMENT_AUTHORIZE_TOKEN__C];
-            if (hasPaymentToProcess) {
+            if (isNotEmpty(hasPaymentToProcess)) {
                 await this.processPayment();
             }
 
-            if (!this.isFailedPurchase) {
+            if (!this.isFailedPurchase || this._isCreditCardWidgetInDoNotChargeState) {
                 await this.processDataImport();
             }
         } catch (error) {
@@ -193,10 +194,12 @@ export default class GeGiftEntryFormApp extends NavigationMixin(LightningElement
     prepareInMemoryDataImportForUpdate(inMemoryDataImport) {
         inMemoryDataImport.Id = this.dataImportRecord.Id;
         inMemoryDataImport[PAYMENT_METHOD__C] = this.dataImportRecord[PAYMENT_METHOD__C];
-        inMemoryDataImport[PAYMENT_STATUS__C] = this.dataImportRecord[PAYMENT_STATUS__C];
+        inMemoryDataImport[PAYMENT_STATUS__C] =
+            this._isCreditCardWidgetInDoNotChargeState ? '' : this.dataImportRecord[PAYMENT_STATUS__C];
         inMemoryDataImport[PAYMENT_DECLINED_REASON__C] =
             this.dataImportRecord[PAYMENT_DECLINED_REASON__C];
-
+        inMemoryDataImport[PAYMENT_AUTHORIZE_TOKEN__C] =
+            this._isCreditCardWidgetInDoNotChargeState ? '' : this.dataImportRecord[PAYMENT_AUTHORIZE_TOKEN__C];
         return inMemoryDataImport;
     }
 


### PR DESCRIPTION
# Critical Changes

# Changes
- The payment status and payment authorization token will now be cleared out from Data Import records if the 'Do Not Charge Card' button is pressed while a single gift is entered.

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
