### PR TITLE
Add My Domain check to installers

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -925,6 +925,10 @@ plans:
         slug: install
         title: Install NPSP
         tier: primary
+        checks:
+            - when: "'.my.' not in org_config.instance_url"
+              action: error
+              message: "Please enable My Domain in your org prior to installing."
         steps:
             1:
                 task: update_dependencies
@@ -957,6 +961,10 @@ plans:
         title: Install NPSP for Trailhead Playgrounds
         tier: additional
         is_listed: False
+        checks:
+            - when: "'.my.' not in org_config.instance_url"
+              action: error
+              message: "Please enable My Domain in your org prior to installing."
         steps:
             1:
                 task: update_dependencies


### PR DESCRIPTION
This PR modifies NPSP installers to require My Domain to be active in order to complete an installation. My Domain is required for PMM and for optional NPSP features such as Gift Entry.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
