### PR TITLE
CRLP: UI Error When Einstein Opportunity Insights is Enabled

### DIFF
--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -958,10 +958,11 @@ public with sharing class CRLP_RollupUI_SVC {
     */
     private static Boolean excludeSystemAndEinsteinInsightsFields(Schema.DescribeFieldResult dfr) {
         if (dfr.name.toLowerCase().contains('__system')
-                || dfr.name.toLowerCase().contains('topinsightid')
-                || dfr.name.toLowerCase().contains('activitymetric')
-                || dfr.name.toLowerCase().contains('opportunityscore')
-                || dfr.name.toLowerCase().contains('activitymetricrollup')) {
+            || dfr.name.toLowerCase().contains('topinsightid')
+            || dfr.name.toLowerCase().contains('activitymetric')
+            || dfr.name.toLowerCase().contains('opportunityscore')
+            || dfr.name.toLowerCase().contains('activitymetricrollup')
+        ) {
             return false;
 
         }

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -318,7 +318,7 @@ public with sharing class CRLP_RollupUI_SVC {
                 };
                 List<Map<String, String>> pscList = getSpecificFieldsWithType(obj, pscFieldsToReturn, false);
                 objNameToFieldTypeMap.put(obj, pscList);
-                
+
             } else {
                 List<Map<String, String>> detailNameToFieldTypeObj = getFilterRuleFieldsExcludingTypes(obj, excludedTypes);
                 objNameToFieldTypeMap.put(obj, detailNameToFieldTypeObj);
@@ -455,7 +455,7 @@ public with sharing class CRLP_RollupUI_SVC {
         String objectLabel = UTIL_Describe.getObjectLabel(objectName);
 
         for (Schema.DescribeFieldResult dfr : objectFields.values()) {
-            if (!dfr.name.toLowerCase().contains('__system')) {
+            if (excludeSystemAndEinsteinInsightsFields(dfr)) {
                 Map<String, String> fieldObject = new Map<String, String>();
                 fieldObject.put('name', objectName+' '+dfr.name);
                 fieldObject.put('label', objectLabel+': '+dfr.label);
@@ -692,7 +692,7 @@ public with sharing class CRLP_RollupUI_SVC {
             // For new records, the RecordName property will be null by default. The process of deploying the
             // CMT data will generate a unique RecordName to use for the new record.
             CRLP_RollupCMT.Rollup cmtRollup = (CRLP_RollupCMT.Rollup) JSON.deserialize(jsonRollup, CRLP_RollupCMT.Rollup.class);
-            
+
             if (cmtRollup.isDuplicate()) {
                 throw new RollupException(Label.CRLP_DuplicateTargetField);
             }
@@ -741,7 +741,7 @@ public with sharing class CRLP_RollupUI_SVC {
 
             CRLP_ConfigBuilder_SVC.queueRollupConfigForDeploy(filterGroups);
             String jobId = CRLP_ConfigBuilder_SVC.deployedQueuedMetadataTypes(changeHandler, changeHandler.params);
-            
+
             // Return the unique record DeveloperName value of the FilterGroup__mdt record
             return jobId + '-' + cmtFilterGroup.recordName;
         } catch (Exception ex) {
@@ -951,7 +951,23 @@ public with sharing class CRLP_RollupUI_SVC {
 
     }
 
-    
+    /***
+    * @description Checks if the given field name is not system and einstein insights fields
+    * @param dfr the DescribeFieldResult of the field
+    * @return Boolean
+    */
+    private static Boolean excludeSystemAndEinsteinInsightsFields(Schema.DescribeFieldResult dfr) {
+        if (dfr.name.toLowerCase().contains('__system')
+                || dfr.name.toLowerCase().contains('topinsightid')
+                || dfr.name.toLowerCase().contains('activitymetric')
+                || dfr.name.toLowerCase().contains('opportunityscore')
+                || dfr.name.toLowerCase().contains('activitymetricrollup')) {
+            return false;
+
+        }
+        return true;
+    }
+
 
     public class RollupException extends Exception {}
 

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -39,6 +39,22 @@ public with sharing class CRLP_RollupUI_SVC {
 
     private static final String SUCCESS_RESPONSE = 'SUCCESS';
 
+    @TestVisible
+    private static final Set<String> fieldsToExclude = new Set<String> {
+        'topinsightid',
+        'activitymetricid',
+        'activitymetric',
+        'opportunityscoreid',
+        'activitymetricrollupid',
+        'activitymetricrollup',
+        'npo02__system_custom_naming__c',
+        'npe01__system_accounttype__c',
+        'npe01__systemisindividual__c',
+        'npe01__systemaccountprocessor__c',
+        'npo02__systemhouseholdprocessor__c',
+        'npo02__systemhouseholdcontactroleprocessor__c'
+    };
+
     /*******************************************************************************************************
     * @description a class to hold only the required information from the rollup__mdt records for the rollup UI.
     */
@@ -455,7 +471,7 @@ public with sharing class CRLP_RollupUI_SVC {
         String objectLabel = UTIL_Describe.getObjectLabel(objectName);
 
         for (Schema.DescribeFieldResult dfr : objectFields.values()) {
-            if (excludeSystemAndEinsteinInsightsFields(dfr)) {
+            if (!excludeField(dfr)) {
                 Map<String, String> fieldObject = new Map<String, String>();
                 fieldObject.put('name', objectName+' '+dfr.name);
                 fieldObject.put('label', objectLabel+': '+dfr.label);
@@ -956,17 +972,12 @@ public with sharing class CRLP_RollupUI_SVC {
     * @param dfr the DescribeFieldResult of the field
     * @return Boolean
     */
-    private static Boolean excludeSystemAndEinsteinInsightsFields(Schema.DescribeFieldResult dfr) {
-        if (dfr.name.toLowerCase().contains('__system')
-            || dfr.name.toLowerCase().contains('topinsightid')
-            || dfr.name.toLowerCase().contains('activitymetric')
-            || dfr.name.toLowerCase().contains('opportunityscore')
-            || dfr.name.toLowerCase().contains('activitymetricrollup')
-        ) {
-            return false;
+    private static Boolean excludeField(Schema.DescribeFieldResult dfr) {
 
+        if (fieldsToExclude.contains(dfr.name.toLowerCase())) {
+            return true;
         }
-        return true;
+        return false;
     }
 
 

--- a/src/classes/CRLP_RollupUI_SVC.cls
+++ b/src/classes/CRLP_RollupUI_SVC.cls
@@ -42,9 +42,11 @@ public with sharing class CRLP_RollupUI_SVC {
     @TestVisible
     private static final Set<String> fieldsToExclude = new Set<String> {
         'topinsightid',
+        'topinsight',
         'activitymetricid',
         'activitymetric',
         'opportunityscoreid',
+        'opportunityscore',
         'activitymetricrollupid',
         'activitymetricrollup',
         'npo02__system_custom_naming__c',
@@ -462,6 +464,7 @@ public with sharing class CRLP_RollupUI_SVC {
     * @param objectName the name of the object to look up
     * @return List<Map<String, String>> an object with field api names, labels and data type.
     */
+    @TestVisible
     private static List<Map<String, String>> getDetailFieldsWithType(String objectName) {
 
         List<Map<String, String>> fieldObjectList = new List<Map<String, String>>();
@@ -471,20 +474,21 @@ public with sharing class CRLP_RollupUI_SVC {
         String objectLabel = UTIL_Describe.getObjectLabel(objectName);
 
         for (Schema.DescribeFieldResult dfr : objectFields.values()) {
-            if (!excludeField(dfr)) {
-                Map<String, String> fieldObject = new Map<String, String>();
-                fieldObject.put('name', objectName+' '+dfr.name);
-                fieldObject.put('label', objectLabel+': '+dfr.label);
-                String fieldType = UTIL_Describe.getFieldType(objectName, dfr.name.toLowerCase());
-                fieldObject.put('type', fieldType);
-
-                if (fieldType == 'REFERENCE') {
-                    fieldObject.put('referenceTo', dfr.referenceTo[0].getDescribe().name);
-                } else if (fieldType == 'ID') {
-                    fieldObject.put('referenceTo', objectName);
-                }
-                fieldObjectList.add(fieldObject);
+            if (excludeField(dfr)) {
+                continue;
             }
+            Map<String, String> fieldObject = new Map<String, String>();
+            fieldObject.put('name', objectName+' '+dfr.name);
+            fieldObject.put('label', objectLabel+': '+dfr.label);
+            String fieldType = UTIL_Describe.getFieldType(objectName, dfr.name.toLowerCase());
+            fieldObject.put('type', fieldType);
+
+            if (fieldType == 'REFERENCE') {
+                fieldObject.put('referenceTo', dfr.referenceTo[0].getDescribe().name);
+            } else if (fieldType == 'ID') {
+                fieldObject.put('referenceTo', objectName);
+            }
+            fieldObjectList.add(fieldObject);
         }
 
         return fieldObjectList;
@@ -973,13 +977,8 @@ public with sharing class CRLP_RollupUI_SVC {
     * @return Boolean
     */
     private static Boolean excludeField(Schema.DescribeFieldResult dfr) {
-
-        if (fieldsToExclude.contains(dfr.name.toLowerCase())) {
-            return true;
-        }
-        return false;
+        return fieldsToExclude.contains(dfr.name.toLowerCase());
     }
-
 
     public class RollupException extends Exception {}
 

--- a/src/classes/CRLP_RollupUI_TEST.cls
+++ b/src/classes/CRLP_RollupUI_TEST.cls
@@ -105,6 +105,34 @@ public class CRLP_RollupUI_TEST {
         System.assertNotEquals(null, jsonModel, 'JSON string of entire model should be returned.');
     }
 
+    /***
+    * @description Verifies if there are no exception thrown in setting up the Rollups when Einstein
+    * insights platform is enabled in the org
+    */
+    @isTest
+    private static void shouldNotThrowExceptionInCRLPSetupWhenEinsteinIsEnabled() {
+        String errMessage = '';
+        String scriptError = 'Script-thrown exception';
+
+        mockRollupCMTValues();
+        Rollup__mdt rollup = CRLP_Rollup_SEL.cachedRollups[0];
+
+        List<String> targetObjectNames = new List<String>{'Account','Contact'};
+        List<String> detailObjectNames = new List<String>{'Opportunity'};
+
+        if (!UTIL_Namespace.isEinsteinEnabled()) {
+            return;
+        }
+
+        try {
+            String jsonModel = CRLP_RollupUI_SVC.setupRollupDetail(rollup.Id, targetObjectNames, detailObjectNames);
+        } catch (Exception e) {
+            errMessage = e.getMessage();
+        }
+        System.assert(!errMessage.contains(scriptError));
+        System.assertEquals('', errMessage, 'No exception is returned when Einstein is enabled');
+    }
+
     /*********************************************************************************************************
     * @description Tests Saving a new Rollup With Summaries Disabled returns a job id for the deployment
     */
@@ -112,7 +140,7 @@ public class CRLP_RollupUI_TEST {
     private static void saveRollupReturnsDeploymentJob() {
         CRLP_RollupCMT.Rollup rollup = CRLP_RollupCMT_Test.generateRollup('test');
         String rollupString = JSON.serialize(rollup);
-       
+
         Test.startTest();
         String saveResult = CRLP_RollupUI_SVC.saveRollup(rollupString);
         Test.stopTest();

--- a/src/classes/CRLP_RollupUI_TEST.cls
+++ b/src/classes/CRLP_RollupUI_TEST.cls
@@ -139,8 +139,6 @@ public class CRLP_RollupUI_TEST {
     */
     @isTest
     private static void shouldNotHaveSystemFieldsInResponseFromGetDetailsType() {
-        List<String> fieldNames = new List<String>();
-
         mockRollupCMTValues();
         Rollup__mdt rollup = CRLP_Rollup_SEL.cachedRollups[0];
 
@@ -149,9 +147,10 @@ public class CRLP_RollupUI_TEST {
         List<Map<String, String>> detailNameToFieldTypeObj = CRLP_RollupUI_SVC.getDetailFieldsWithType(detailObj);
 
         for(Map<String,String> apiFieldNames: detailNameToFieldTypeObj) {
-            fieldNames.add(apiFieldNames.get('name'));
+            System.assert(!apiFieldNames.get('name').containsIgnoreCase('npe01__SYSTEM_AccountType__c'),
+                'The returned collection of Field API Names should not include the "npe01__SYSTEM_AccountType__c" field');
         }
-        System.assertEquals(false, fieldNames.contains('npe01__SYSTEM_AccountType__c'), 'Validate that the names does not include the system field');
+
     }
 
     /*********************************************************************************************************

--- a/src/classes/CRLP_RollupUI_TEST.cls
+++ b/src/classes/CRLP_RollupUI_TEST.cls
@@ -120,7 +120,7 @@ public class CRLP_RollupUI_TEST {
         List<String> targetObjectNames = new List<String>{'Account','Contact'};
         List<String> detailObjectNames = new List<String>{'Opportunity'};
 
-        if (!UTIL_Namespace.isEinsteinEnabled()) {
+        if (!UTIL_Namespace.isEinsteinInsightsInstalled()) {
             return;
         }
 

--- a/src/classes/CRLP_RollupUI_TEST.cls
+++ b/src/classes/CRLP_RollupUI_TEST.cls
@@ -133,6 +133,27 @@ public class CRLP_RollupUI_TEST {
         System.assertEquals('', errMessage, 'No exception is returned when Einstein is enabled');
     }
 
+    /***
+    * @description Validate that the response from getdetailsfieldswithtype does not include the
+    * System field for account object
+    */
+    @isTest
+    private static void shouldNotHaveSystemFieldsInResponseFromGetDetailsType() {
+        List<String> fieldNames = new List<String>();
+
+        mockRollupCMTValues();
+        Rollup__mdt rollup = CRLP_Rollup_SEL.cachedRollups[0];
+
+        String detailObj = 'Account';
+
+        List<Map<String, String>> detailNameToFieldTypeObj = CRLP_RollupUI_SVC.getDetailFieldsWithType(detailObj);
+
+        for(Map<String,String> apiFieldNames: detailNameToFieldTypeObj) {
+            fieldNames.add(apiFieldNames.get('name'));
+        }
+        System.assertEquals(false, fieldNames.contains('npe01__SYSTEM_AccountType__c'), 'Validate that the names does not include the system field');
+    }
+
     /*********************************************************************************************************
     * @description Tests Saving a new Rollup With Summaries Disabled returns a job id for the deployment
     */

--- a/src/classes/UTIL_Namespace.cls
+++ b/src/classes/UTIL_Namespace.cls
@@ -49,6 +49,12 @@ public class UTIL_Namespace {
     *******************************************************************************************************/
     public static final String HARDCODED_NPSP_NAMESPACE = 'npsp';
 
+    /***
+    * @description Constant value for the Einstein enabled namespace, for checking if the org has
+    * einstein insights platform has been installed or not.
+    */
+    public static final String EINSTEIN_ENABLED = 'OIQ';
+
     /*******************************************************************************************************
     * @description Finds the namespace for the current context.
     * @return string The current namespace as a string, or a blank string if we're not in a namespaced context.
@@ -249,6 +255,16 @@ public class UTIL_Namespace {
     public static Boolean isCustomerOrg() {
         try {
             return UserInfo.isCurrentUserLicensed(HARDCODED_NPSP_NAMESPACE);
+        } catch (Exception ex) {}
+        return false;
+    }
+
+    /***
+    * @description Returns true if the Einstein insights is currently installed in an org as a managed package
+    */
+    public static Boolean isEinsteinEnabled() {
+        try {
+            return UserInfo.isCurrentUserLicensed(EINSTEIN_ENABLED);
         } catch (Exception ex) {}
         return false;
     }

--- a/src/classes/UTIL_Namespace.cls
+++ b/src/classes/UTIL_Namespace.cls
@@ -53,7 +53,7 @@ public class UTIL_Namespace {
     * @description Constant value for the Einstein enabled namespace, for checking if the org has
     * einstein insights platform has been installed or not.
     */
-    public static final String EINSTEIN_ENABLED = 'OIQ';
+    private static final String EINSTEIN_INSIGHTS_NAMESPACE = 'OIQ';
 
     /*******************************************************************************************************
     * @description Finds the namespace for the current context.
@@ -262,9 +262,9 @@ public class UTIL_Namespace {
     /***
     * @description Returns true if the Einstein insights is currently installed in an org as a managed package
     */
-    public static Boolean isEinsteinEnabled() {
+    public static Boolean isEinsteinInsightsInstalled() {
         try {
-            return UserInfo.isCurrentUserLicensed(EINSTEIN_ENABLED);
+            return UserInfo.isCurrentUserLicensed(EINSTEIN_INSIGHTS_NAMESPACE);
         } catch (Exception ex) {}
         return false;
     }


### PR DESCRIPTION
When Einstein Opportunity Insights is enabled, the Customizable Rollups UI should not return error when attempting to load an existing rollup or create a new one.
# Critical Changes

# Changes

# Issues Closed
- Fixes #4022

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
