### PR TITLE
Feature/remove pmm installers

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -645,21 +645,21 @@ flows:
                 task: deploy_trial_config
                 ui_options:
                     name: "NPSP Trial Experience"
-            2:
-                task: update_dependencies
-                options:
-                    dependencies:
-                        - github: "https://github.com/SalesforceFoundation/pmm"
-            3:
-                task: deploy_pmm_trial_config
-                ui_options:
-                    name: "Configure Program Management Module"
-            4:
-                task: pmm:deploy_customer_profiles
-                options:
-                    unmanaged: False
-                ui_options:
-                    name: "Install Program Management Module Profile"
+            #2:
+            #    task: update_dependencies
+            #    options:
+            #        dependencies:
+            #            - github: "https://github.com/SalesforceFoundation/pmm"
+            #3:
+            #    task: deploy_pmm_trial_config
+            #    ui_options:
+            #        name: "Configure Program Management Module"
+            #4:
+            #    task: pmm:deploy_customer_profiles
+            #    options:
+            #        unmanaged: False
+            #    ui_options:
+            #        name: "Install Program Management Module Profile"
 
     deploy_rollup_testing:
         description: 'Deploys custom fields and rollup definitions for testing Customizable Rollups using the Apex Anon testing script. >>> NOTE: Customizable Rollups needs to be successfully enabled before deploy_rollup_testing can be run <<<'
@@ -726,8 +726,8 @@ flows:
                 options:
                     deploy_trial_config:
                         unmanaged: False
-                    deploy_pmm_trial_config:
-                        unmanaged: False
+                    #deploy_pmm_trial_config:
+                    #    unmanaged: False
 
             4:
                 task: update_admin_profile
@@ -947,11 +947,11 @@ plans:
                 ui_options:
                     first:
                         name: NPSP Config for Salesforce Mobile App
-            6:
-                task: update_dependencies
-                options:
-                    dependencies:
-                        - github: "https://github.com/SalesforceFoundation/pmm"
+            #6:
+            #    task: update_dependencies
+            #    options:
+            #        dependencies:
+            #            - github: "https://github.com/SalesforceFoundation/pmm"
     new_org:
         slug: trailhead
         title: Install NPSP for Trailhead Playgrounds


### PR DESCRIPTION
This PR suppresses PMM elements of the NPSP installer. PMM delivery will be reconsidered over the coming sprints in light of TSO-related challenges.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
