### PR TITLE
 W-7312506 Post Install Script for Custom Metadata Type Records

### DIFF
--- a/src/classes/BDI_MigrationMappingUtility.cls
+++ b/src/classes/BDI_MigrationMappingUtility.cls
@@ -34,7 +34,7 @@
 * @group-content ../../ApexDocContent/BatchDataImport.htm
 * @description Methods to handle converting data import help text mappings to custom metadata records
 */
-public class BDI_MigrationMappingUtility {
+public inherited sharing class BDI_MigrationMappingUtility {
     /*******************************************************************************************************
     * @description Metadata queued up for deployment
     */

--- a/src/classes/BDI_MigrationMappingUtility.cls
+++ b/src/classes/BDI_MigrationMappingUtility.cls
@@ -34,8 +34,7 @@
 * @group-content ../../ApexDocContent/BatchDataImport.htm
 * @description Methods to handle converting data import help text mappings to custom metadata records
 */
-public with sharing class BDI_MigrationMappingUtility {
-
+public class BDI_MigrationMappingUtility {
     /*******************************************************************************************************
     * @description Metadata queued up for deployment
     */


### PR DESCRIPTION
Update "without sharing" to "inherited sharing" BDI_MigrationMappingUtility due to Insufficient Privilege error on package upgrade.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
