### PR TITLE
Gift Entry: Fabricate Donor Name from Lookup

### DIFF
--- a/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
+++ b/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
@@ -60,7 +60,6 @@ import CONTACT_FIRST_NAME_INFO from '@salesforce/schema/Contact.FirstName';
 import CONTACT_LAST_NAME_INFO from '@salesforce/schema/Contact.LastName';
 import ACCOUNT_NAME_INFO from '@salesforce/schema/Account.Name';
 
-
 import commonError from '@salesforce/label/c.commonError';
 import commonUnknownError from '@salesforce/label/c.commonUnknownError';
 

--- a/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
+++ b/src/lwc/utilTemplateBuilder/utilTemplateBuilder.js
@@ -60,6 +60,7 @@ import CONTACT_FIRST_NAME_INFO from '@salesforce/schema/Contact.FirstName';
 import CONTACT_LAST_NAME_INFO from '@salesforce/schema/Contact.LastName';
 import ACCOUNT_NAME_INFO from '@salesforce/schema/Account.Name';
 
+
 import commonError from '@salesforce/label/c.commonError';
 import commonUnknownError from '@salesforce/label/c.commonUnknownError';
 


### PR DESCRIPTION
# Critical Changes

# Changes
- When the First/LastName or Account Name fields are missing from the Gift Entry form, use the values in the Donor Lookup field to populate cardholder name if Payment Widget is present.
# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
