### PR TITLE
Feature/payments add missing translations for config sobj

### DIFF
--- a/src/objectTranslations/Payment_Services_Configuration__c-de.objectTranslation
+++ b/src/objectTranslations/Payment_Services_Configuration__c-de.objectTranslation
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <caseType>Nominative</caseType>
+        <plural>false</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <caseType>Nominative</caseType>
+        <plural>true</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <caseType>Accusative</caseType>
+        <plural>false</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <caseType>Accusative</caseType>
+        <plural>true</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <caseType>Genitive</caseType>
+        <plural>false</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <caseType>Genitive</caseType>
+        <plural>true</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <caseType>Dative</caseType>
+        <plural>false</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <caseType>Dative</caseType>
+        <plural>true</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <fields>
+        <label><!-- Is Secret --></label>
+        <name>Is_Secret__c</name>
+    </fields>
+    <fields>
+        <label><!-- Key --></label>
+        <name>Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service Key --></label>
+        <name>Service_Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service --></label>
+        <name>Service__c</name>
+    </fields>
+    <fields>
+        <label><!-- Value --></label>
+        <name>Value__c</name>
+    </fields>
+    <gender><!-- Neuter --></gender>
+    <layouts>
+        <layout>Payment Cofiguration Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Payment Services Configuration Name --></nameFieldLabel>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Payment_Services_Configuration__c-en_US.objectTranslation
+++ b/src/objectTranslations/Payment_Services_Configuration__c-en_US.objectTranslation
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Payment Services Configuration</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Payment Services Configuration</value>
+    </caseValues>
+    <fields>
+        <label><!-- Is Secret --></label>
+        <name>Is_Secret__c</name>
+    </fields>
+    <fields>
+        <label><!-- Key --></label>
+        <name>Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service Key --></label>
+        <name>Service_Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service --></label>
+        <name>Service__c</name>
+    </fields>
+    <fields>
+        <label><!-- Value --></label>
+        <name>Value__c</name>
+    </fields>
+    <layouts>
+        <layout>Payment Cofiguration Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Payment_Services_Configuration__c-es.objectTranslation
+++ b/src/objectTranslations/Payment_Services_Configuration__c-es.objectTranslation
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <fields>
+        <label><!-- Is Secret --></label>
+        <name>Is_Secret__c</name>
+    </fields>
+    <fields>
+        <label><!-- Key --></label>
+        <name>Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service Key --></label>
+        <name>Service_Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service --></label>
+        <name>Service__c</name>
+    </fields>
+    <fields>
+        <label><!-- Value --></label>
+        <name>Value__c</name>
+    </fields>
+    <gender><!-- Feminine --></gender>
+    <layouts>
+        <layout>Payment Cofiguration Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Payment Services Configuration Name --></nameFieldLabel>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Payment_Services_Configuration__c-fr.objectTranslation
+++ b/src/objectTranslations/Payment_Services_Configuration__c-fr.objectTranslation
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <fields>
+        <label><!-- Is Secret --></label>
+        <name>Is_Secret__c</name>
+    </fields>
+    <fields>
+        <label><!-- Key --></label>
+        <name>Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service Key --></label>
+        <name>Service_Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service --></label>
+        <name>Service__c</name>
+    </fields>
+    <fields>
+        <label><!-- Value --></label>
+        <name>Value__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>Payment Cofiguration Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Payment Services Configuration Name --></nameFieldLabel>
+    <startsWith><!-- Consonant --></startsWith>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Payment_Services_Configuration__c-iw.objectTranslation
+++ b/src/objectTranslations/Payment_Services_Configuration__c-iw.objectTranslation
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <article>None</article>
+        <plural>false</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <article>Definite</article>
+        <plural>false</plural>
+        <value><!-- הPayment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <article>None</article>
+        <plural>true</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <article>Definite</article>
+        <plural>true</plural>
+        <value><!-- הPayment Services Configuration --></value>
+    </caseValues>
+    <fields>
+        <label><!-- Is Secret --></label>
+        <name>Is_Secret__c</name>
+    </fields>
+    <fields>
+        <label><!-- Key --></label>
+        <name>Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service Key --></label>
+        <name>Service_Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service --></label>
+        <name>Service__c</name>
+    </fields>
+    <fields>
+        <label><!-- Value --></label>
+        <name>Value__c</name>
+    </fields>
+    <gender><!-- Masculine --></gender>
+    <layouts>
+        <layout>Payment Cofiguration Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Payment Services Configuration Name --></nameFieldLabel>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Payment_Services_Configuration__c-ja.objectTranslation
+++ b/src/objectTranslations/Payment_Services_Configuration__c-ja.objectTranslation
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <fields>
+        <label><!-- Is Secret --></label>
+        <name>Is_Secret__c</name>
+    </fields>
+    <fields>
+        <label><!-- Key --></label>
+        <name>Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service Key --></label>
+        <name>Service_Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service --></label>
+        <name>Service__c</name>
+    </fields>
+    <fields>
+        <label><!-- Value --></label>
+        <name>Value__c</name>
+    </fields>
+    <layouts>
+        <layout>Payment Cofiguration Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Payment Services Configuration Name --></nameFieldLabel>
+</CustomObjectTranslation>

--- a/src/objectTranslations/Payment_Services_Configuration__c-nl_NL.objectTranslation
+++ b/src/objectTranslations/Payment_Services_Configuration__c-nl_NL.objectTranslation
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value><!-- Payment Services Configuration --></value>
+    </caseValues>
+    <fields>
+        <label><!-- Is Secret --></label>
+        <name>Is_Secret__c</name>
+    </fields>
+    <fields>
+        <label><!-- Key --></label>
+        <name>Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service Key --></label>
+        <name>Service_Key__c</name>
+    </fields>
+    <fields>
+        <label><!-- Service --></label>
+        <name>Service__c</name>
+    </fields>
+    <fields>
+        <label><!-- Value --></label>
+        <name>Value__c</name>
+    </fields>
+    <gender><!-- Neuter --></gender>
+    <layouts>
+        <layout>Payment Cofiguration Layout</layout>
+        <sections>
+            <label><!-- Custom Links --></label>
+            <section>Custom Links</section>
+        </sections>
+    </layouts>
+    <nameFieldLabel><!-- Payment Services Configuration Name --></nameFieldLabel>
+</CustomObjectTranslation>

--- a/src/package.xml
+++ b/src/package.xml
@@ -3290,6 +3290,13 @@
         <members>Partial_Soft_Credit__c-iw</members>
         <members>Partial_Soft_Credit__c-ja</members>
         <members>Partial_Soft_Credit__c-nl_NL</members>
+        <members>Payment_Services_Configuration__c-de</members>
+        <members>Payment_Services_Configuration__c-en_US</members>
+        <members>Payment_Services_Configuration__c-es</members>
+        <members>Payment_Services_Configuration__c-fr</members>
+        <members>Payment_Services_Configuration__c-iw</members>
+        <members>Payment_Services_Configuration__c-ja</members>
+        <members>Payment_Services_Configuration__c-nl_NL</members>
         <members>RecurringDonationSchedule__c-de</members>
         <members>RecurringDonationSchedule__c-en_US</members>
         <members>RecurringDonationSchedule__c-es</members>


### PR DESCRIPTION
# Critical Changes

# Changes

Include translation files for the new payment services config object

# Issues Closed

# Community Ideas Delivered

# New Metadata

ObjectTranslations:
	- Payment_Services_Configuration__c-de.objectTranslation
	- Payment_Services_Configuration__c-en_US.objectTranslation
	- Payment_Services_Configuration__c-es.objectTranslation
	- Payment_Services_Configuration__c-fr.objectTranslation
	- Payment_Services_Configuration__c-iw.objectTranslation
	- Payment_Services_Configuration__c-ja.objectTranslation
	- Payment_Services_Configuration__c-nl_NL.objectTranslation

# Deleted Metadata
