### PR TITLE
Run update_admin_profile on CI profile in packaging

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -661,6 +661,13 @@ flows:
             #    ui_options:
             #        name: "Install Program Management Module Profile"
 
+    config_packaging:
+        steps:
+            1:
+                task: update_admin_profile
+                options:
+                    package_xml: lib/admin_profile_packaging.xml
+
     deploy_rollup_testing:
         description: 'Deploys custom fields and rollup definitions for testing Customizable Rollups using the Apex Anon testing script. >>> NOTE: Customizable Rollups needs to be successfully enabled before deploy_rollup_testing can be run <<<'
         group: NPSP

--- a/lib/admin_profile_packaging.xml
+++ b/lib/admin_profile_packaging.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <members>Account</members>
+        <members>Campaign</members>
+        <members>Contact</members>
+        <members>Lead</members>
+        <members>Opportunity</members>
+        <members>npe01__OppPayment__c</members>
+        <members>npo02__Household__c</members>
+        <members>npo02__Opportunity_Rollup_Error__c</members>
+        <members>npe03__Custom_Field_Mapping__c</members>
+        <members>npe03__Recurring_Donation__c</members>
+        <members>npe4__Relationship__c</members>
+        <members>npe4__Relationship_Auto_Create__c</members>
+        <members>npe4__Relationship_Error__c</members>
+        <members>npe4__Relationship_Lookup__c</members>
+        <members>npe5__Affiliation__c</members>
+        <name>CustomObject</name>
+    </types>
+    <types>
+        <members>Continuous Integration</members>
+        <members>Admin</members>
+        <name>Profile</name>
+    </types>
+    <version>43.0</version>
+</Package>


### PR DESCRIPTION
This PR is intended to fix the root cause of [this build failure](https://sfdo-metaci.herokuapp.com/builds/235474/flows) by selectively targeting the Continuous Integration profile for FLS updates upon deployment into the packaging org.

Pending: test against a mock packaging org.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
