### PR TITLE
GE: fix template builder widget definition bug

### DIFF
--- a/src/lwc/geTemplateBuilder/geTemplateBuilder.js
+++ b/src/lwc/geTemplateBuilder/geTemplateBuilder.js
@@ -663,8 +663,8 @@ export default class geTemplateBuilder extends NavigationMixin(LightningElement)
             required: false,
             sectionId: sectionId,
             elementType: widget.Element_Type,
-            dataImportObjectMappingDevName: widget.Widget_Object_Mapping_Developer_Name,
-            dataImportFieldMappingDevNames: widget.Widget_Field_Mapping_Developer_Names,
+            dataImportObjectMappingDevName: widget.objectMappingDeveloperName,
+            dataImportFieldMappingDevNames: widget.fieldMappingDeveloperNames,
         }
     }
 


### PR DESCRIPTION
# Critical Changes

# Changes
- Fixes a bug that causes the GAU Allocation widget to throw a de-reference error on new form templates.
# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
