### PR TITLE
Bugfix: Prevent debug-mode component error in GE_GiftEntryForm

### DIFF
--- a/src/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.html
+++ b/src/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.html
@@ -48,9 +48,7 @@
                             onrowaction={handleRowActions}
                             enable-infinite-loading
                             onloadmore={loadMoreData}
-                            data-qa-locator="datatable Batch Gifts"
-                            count={count}
-                            total={total}>
+                            data-qa-locator="datatable Batch Gifts">
                     </lightning-datatable>
                 </div>
             </div>


### PR DESCRIPTION
As an artifact of the implementation of the progress section in
Gift Entry batch mode, two non-existent public properties are
being set on the instance of lightning-datatable, which throws
an "Unknown public property" error when Debug Mode is enabled 
for Lightning Components.  The error is only thrown when debug
mode is enabled.  This PR fixes the issue.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
