### PR TITLE
Automatic naming should never use Contact name for non-HH accounts

### DIFF
--- a/src/classes/RD2_Donor.cls
+++ b/src/classes/RD2_Donor.cls
@@ -49,6 +49,7 @@ public with sharing class RD2_Donor {
     public class Record {
         public Id recordId { get; private set; }
         public String name { get; private set; }
+        public String recordTypeId { get; private set; }
 
         /***
         * @description Constructor
@@ -58,6 +59,18 @@ public with sharing class RD2_Donor {
         public Record(Id recordId, String name) {
             this.recordId = recordId;
             this.name = name;
+        }
+
+        /***
+        * @description Constructor
+        * @param recordId Account/Contact SObject Id
+        * @param name Account/Contact name
+        * @param recordTypeId Account recordTypeId
+        */
+        public Record(Id recordId, String name, String recordTypeId) {
+            this.recordId = recordId;
+            this.name = name;
+            this.recordTypeId = recordTypeId;
         }
     }
 
@@ -84,11 +97,11 @@ public with sharing class RD2_Donor {
             contactIds.remove(null);
 
             for (Account acc : [
-                SELECT Name
+                SELECT Name, RecordTypeId
                 FROM Account
                 WHERE Id IN :accountIds
             ]) {
-                donorById.put(acc.Id, new Record(acc.Id, acc.Name));
+                donorById.put(acc.Id, new Record(acc.Id, acc.Name, acc.RecordTypeId));
             }
 
             for (Contact c : [

--- a/src/classes/RD2_Donor.cls
+++ b/src/classes/RD2_Donor.cls
@@ -49,7 +49,7 @@ public with sharing class RD2_Donor {
     public class Record {
         public Id recordId { get; private set; }
         public String name { get; private set; }
-        public String recordTypeId { get; private set; }
+        public Id recordTypeId { get; private set; }
 
         /***
         * @description Constructor

--- a/src/classes/RD2_Donor_TEST.cls
+++ b/src/classes/RD2_Donor_TEST.cls
@@ -38,18 +38,20 @@
 public with sharing class RD2_Donor_TEST {
 
     /***
-    * @description Verifies Donor Name is set correctly based on the Account data
+    * @description Verifies Donor fields are set correctly based on the Account data
     */
     @isTest
     private static void shouldSetDonorWhenAccountDataIsProvided() {
         Account acc = new Account(
             Id = UTIL_UnitTestData_TEST.mockId(Account.SObjectType),
-            Name = CAO_Constants.OCR_DONOR_ROLE
+            Name = CAO_Constants.OCR_DONOR_ROLE,
+            RecordTypeId = RD2_NamingService.hhRecordTypeId
         );
-        RD2_Donor.Record donor = new RD2_Donor.Record(acc.Id, acc.Name);
+        RD2_Donor.Record donor = new RD2_Donor.Record(acc.Id, acc.Name, acc.RecordTypeId);
 
         System.assertEquals(acc.Id, donor.recordId, 'Donor Id should match');
         System.assertEquals(acc.Name, donor.Name, 'Donor Name should match');
+        System.assertEquals(acc.RecordTypeId, donor.recordTypeId, 'Donor Record Type Id should match');
     }
 
     /***
@@ -117,7 +119,7 @@ public with sharing class RD2_Donor_TEST {
         */
         public GatewayMock withDonors(List<Account> accounts) {
             for (Account acc : accounts) {
-                donorById.put(acc.Id, new RD2_Donor.Record(acc.Id, acc.Name));
+                donorById.put(acc.Id, new RD2_Donor.Record(acc.Id, acc.Name, acc.RecordTypeId));
             }
             return this;
         }

--- a/src/classes/RD2_NamingService.cls
+++ b/src/classes/RD2_NamingService.cls
@@ -197,11 +197,12 @@ public with sharing class RD2_NamingService {
     * @return String New name for the Recurring Donation record
     */
     private String constructName(npe03__Recurring_Donation__c rd,  Map<Id, RD2_Donor.Record> donorById) {
-        System.debug('hhRecordTypeId - ' + hhRecordTypeId);
-        System.debug('rd.npe03__Organization__c - ' + rd.npe03__Organization__c);
-        System.debug('donorById.get(rd.npe03__Organization__c) - ' + donorById.get(rd.npe03__Organization__c));
-        RD2_Donor.Record donor = rd.npe03__Contact__c != null
-                && donorById.get(rd.npe03__Organization__c).recordTypeId == hhRecordTypeId
+        Boolean useContact = rd.npe03__Organization__c == null;
+        if (!useContact) {
+            useContact = donorById.get(rd.npe03__Organization__c).recordTypeId == hhRecordTypeId;
+        }
+
+        RD2_Donor.Record donor = useContact
             ? donorById.get(rd.npe03__Contact__c)
             : donorById.get(rd.npe03__Organization__c);
 

--- a/src/classes/RD2_NamingService.cls
+++ b/src/classes/RD2_NamingService.cls
@@ -54,6 +54,20 @@ public with sharing class RD2_NamingService {
     }
 
     /***
+    * @description Retrieves the record type id for the household account record type
+    */
+    @TestVisible
+    public static String hhRecordTypeId {
+        get {
+            if (hhRecordTypeId == null) {
+                hhRecordTypeId = UTIL_CustomSettingsFacade.getContactsSettings().npe01__HH_Account_RecordTypeID__c;
+            }
+            return hhRecordTypeId;
+        }
+        private set;
+    }
+
+    /***
     * @description Returns Donor (Account/Contact) records
     */
     @TestVisible
@@ -183,7 +197,11 @@ public with sharing class RD2_NamingService {
     * @return String New name for the Recurring Donation record
     */
     private String constructName(npe03__Recurring_Donation__c rd,  Map<Id, RD2_Donor.Record> donorById) {
+        System.debug('hhRecordTypeId - ' + hhRecordTypeId);
+        System.debug('rd.npe03__Organization__c - ' + rd.npe03__Organization__c);
+        System.debug('donorById.get(rd.npe03__Organization__c) - ' + donorById.get(rd.npe03__Organization__c));
         RD2_Donor.Record donor = rd.npe03__Contact__c != null
+                && donorById.get(rd.npe03__Organization__c).recordTypeId == hhRecordTypeId
             ? donorById.get(rd.npe03__Contact__c)
             : donorById.get(rd.npe03__Organization__c);
 

--- a/src/classes/RD2_NamingService_TEST.cls
+++ b/src/classes/RD2_NamingService_TEST.cls
@@ -40,7 +40,8 @@ public with sharing class RD2_NamingService_TEST {
     private static final String CURRENCY_USD = 'USD';
 
     private static final Boolean isMultiCurrencyEnabled = UserInfo.isMultiCurrencyOrganization();
-    private static Account acc = getAccountMock();
+    private static Account accOrg = getOrgAccountMock();
+    private static Account accHH = getHHAccountMock();
 
     /***
     * @description Verifies Recurring Donation Name is not generated when automatic naming is not enabled
@@ -85,19 +86,47 @@ public with sharing class RD2_NamingService_TEST {
     private static void shouldAutogenerateNameUsingProvidedAccountAndAmount() {
         String currencyCode = UserInfo.getDefaultCurrency();
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.25)
             .withCurrencyIsoCode(currencyCode)
             .build();
         
-        RD2_NamingService service = buildAutomaticNamingService(acc);
+        RD2_NamingService service = buildAutomaticNamingService(accOrg);
         service.autogenerateNames(new List<npe03__Recurring_Donation__c>{ rd });
 
-        System.assertEquals(getExpectedName(acc, '100.25', currencyCode), rd.Name, 'The name should match.');
+        System.assertEquals(getExpectedName(accOrg, '100.25', currencyCode), rd.Name, 'The name should match.');
     }
 
     /***
     * @description Verifies generated Recurring Donation Name is constructed using 
+    * Account Name, Amount and the suffix.
+    */
+    @isTest
+    private static void shouldAutogenerateNameUsingAccountAndAmountWhenNotHouseholdAccount() {
+        String currencyCode = UserInfo.getDefaultCurrency();
+        Contact contact = getContactMock();
+
+        npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
+            .withAccount(accOrg.Id)
+            .withContact(contact.Id)
+            .withAmount(100.25)
+            .withCurrencyIsoCode(currencyCode)
+            .build();
+
+        RD2_NamingService service = buildAutomaticNamingService(
+            new List<Account>{
+                accOrg
+            },
+            new List<Contact>{ contact }
+        );
+
+        service.autogenerateNames(new List<npe03__Recurring_Donation__c>{ rd });
+
+        System.assertEquals(getExpectedName(accOrg, '100.25', currencyCode), rd.Name, 'The name should match.');
+    }
+
+    /***
+    * @description Verifies generated Recurring Donation Name is constructed using
     * Contact Name, Amount and the suffix.
     */
     @isTest
@@ -106,14 +135,16 @@ public with sharing class RD2_NamingService_TEST {
         Contact contact = getContactMock();
 
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accHH.Id)
             .withContact(contact.Id)
             .withAmount(100.25)
             .withCurrencyIsoCode(currencyCode)
             .build();
-        
+
         RD2_NamingService service = buildAutomaticNamingService(
-            new List<Account>{ acc },
+            new List<Account>{
+                accHH
+            },
             new List<Contact>{ contact }
         );
 
@@ -132,15 +163,15 @@ public with sharing class RD2_NamingService_TEST {
         }
 
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.25)
             .withCurrencyIsoCode(CURRENCY_CAD)
             .build();
         
-        RD2_NamingService service = buildAutomaticNamingService(acc);        
+        RD2_NamingService service = buildAutomaticNamingService(accOrg);
         service.autogenerateNames(new List<npe03__Recurring_Donation__c>{ rd });
 
-        String expectedName = acc.Name + ' $100.25 - ' + System.Label.RecurringDonationNameSuffix;
+        String expectedName = accOrg.Name + ' $100.25 - ' + System.Label.RecurringDonationNameSuffix;
         System.assertEquals(expectedName, rd.Name, 'The amount format should match.');
     }
 
@@ -151,15 +182,15 @@ public with sharing class RD2_NamingService_TEST {
     private static void shouldReturnAmountWithoutTrailingZeros() {
         String currencyCode = UserInfo.getDefaultCurrency();
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.00)
             .withCurrencyIsoCode(currencyCode)
             .build();
         
-        RD2_NamingService service = buildAutomaticNamingService(acc);        
+        RD2_NamingService service = buildAutomaticNamingService(accOrg);
         service.autogenerateNames(new List<npe03__Recurring_Donation__c>{ rd });
 
-        System.assertEquals(getExpectedName(acc, '100', currencyCode), rd.Name, 'The amount format should match.');
+        System.assertEquals(getExpectedName(accOrg, '100', currencyCode), rd.Name, 'The amount format should match.');
     }
 
     /***
@@ -172,20 +203,20 @@ public with sharing class RD2_NamingService_TEST {
         final Integer accountNameLength = 210;
         String padding = 'Company';
 
-        acc.Name = String.valueOf(acc.Name).rightPad(accountNameLength, padding).left(accountNameLength);
-        System.assertEquals(accountNameLength, acc.Name.length(), 'Account Name should be of max length');
+        accOrg.Name = String.valueOf(accOrg.Name).rightPad(accountNameLength, padding).left(accountNameLength);
+        System.assertEquals(accountNameLength, accOrg.Name.length(), 'Account Name should be of max length');
 
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.00)
             .withCurrencyIsoCode(currencyCode)
             .build();
         
-        RD2_NamingService service = buildAutomaticNamingService(acc);        
+        RD2_NamingService service = buildAutomaticNamingService(accOrg);
         service.autogenerateNames(new List<npe03__Recurring_Donation__c>{ rd });
 
         String expectedSuffix = '... ' + getCurrencySymbol(currencyCode) + '100 - ' + System.Label.RecurringDonationNameSuffix;
-        String expectedName = acc.Name.left(RD2_NamingService.MAX_NAME_LENGTH - expectedSuffix.length()) + expectedSuffix;
+        String expectedName = accOrg.Name.left(RD2_NamingService.MAX_NAME_LENGTH - expectedSuffix.length()) + expectedSuffix;
 
         System.assertEquals(expectedName, rd.Name, 'Recurring Donations Name should match.');
         System.assertEquals(RD2_NamingService.MAX_NAME_LENGTH, rd.Name.length(), 'Recurring Donation Name should be of max length');
@@ -242,11 +273,11 @@ public with sharing class RD2_NamingService_TEST {
     @isTest
     private static void shouldReturnTrueWhenAmountHasChanged() {
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.00)
             .build();
         npe03__Recurring_Donation__c oldRd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.25)
             .build();
 
@@ -264,12 +295,12 @@ public with sharing class RD2_NamingService_TEST {
         }
 
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.00)
             .withCurrencyIsoCode(CURRENCY_USD)
             .build();
         npe03__Recurring_Donation__c oldRd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.00)
             .withCurrencyIsoCode(CURRENCY_CAD)
             .build();
@@ -285,11 +316,11 @@ public with sharing class RD2_NamingService_TEST {
     private static void shouldReturnTrueWhenNameIsTheReplaceKeyword() {
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
             .withName(System.Label.npo02.NameReplacementText)
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.00)
             .build();
         npe03__Recurring_Donation__c oldRd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.00)
             .build();
 
@@ -304,11 +335,11 @@ public with sharing class RD2_NamingService_TEST {
     @isTest
     private static void shouldReturnFalseWhenNameConstructKeyFieldsAreUnchanged() {
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.00)
             .build();
         npe03__Recurring_Donation__c oldRd = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withAmount(100.00)
             .build();
 
@@ -324,7 +355,7 @@ public with sharing class RD2_NamingService_TEST {
     private static void shouldAutogenerateNameWhenNameConstructKeyFieldsAreChanged() {
         String currencyCode = UserInfo.getDefaultCurrency();
         TEST_RecurringDonationBuilder rdBuilder = new TEST_RecurringDonationBuilder()
-            .withAccount(acc.Id)
+            .withAccount(accOrg.Id)
             .withCurrencyIsoCode(currencyCode);
         List<npe03__Recurring_Donation__c> rds = new List<npe03__Recurring_Donation__c>{
             rdBuilder.withAmount(100).build(),
@@ -342,13 +373,13 @@ public with sharing class RD2_NamingService_TEST {
         oldRds[1].Id = rds[1].Id;
         oldRds[1].npe03__Amount__c = 180;
         
-        RD2_NamingService service = buildAutomaticNamingService(acc);
+        RD2_NamingService service = buildAutomaticNamingService(accOrg);
         service.autogenerateNamesOnChange(rds, oldRds);
 
         System.assertEquals(unchangedName, rds[0].Name, 
             'RD Name should not change when construct key fields are unchanged');
 
-        System.assertEquals(getExpectedName(acc, '200', currencyCode), rds[1].Name, 
+        System.assertEquals(getExpectedName(accOrg, '200', currencyCode), rds[1].Name,
             'RD Name should change when construct key fields are changed');
     }
 
@@ -357,21 +388,29 @@ public with sharing class RD2_NamingService_TEST {
     */
     @isTest
     private static void shouldQueryForDonorInformation() {
-        insert acc = new Account(Name = 'RD2 Query Account');
+        insert accOrg = new Account(Name = 'RD2 Query Account');
 
         Contact contact = UTIL_UnitTestData_TEST.getContact();
         insert contact;
+        contact = [SELECT FirstName, LastName, AccountId FROM Contact WHERE Id = :contact.Id];
 
         String currencyCode = UserInfo.getDefaultCurrency();
         List<npe03__Recurring_Donation__c> rds = new List<npe03__Recurring_Donation__c>{
             new TEST_RecurringDonationBuilder()
-                .withAccount(acc.Id)
+                .withAccount(accOrg.Id)
                 .withAmount(100)
                 .withCurrencyIsoCode(currencyCode)
                 .build(),
             new TEST_RecurringDonationBuilder()
                 .withContact(contact.Id)
+                .withAccount(contact.AccountId)
                 .withAmount(200)
+                .withCurrencyIsoCode(currencyCode)
+                .build(),
+            new TEST_RecurringDonationBuilder()
+                .withAccount(accOrg.Id)
+                .withContact(contact.Id)
+                .withAmount(300)
                 .withCurrencyIsoCode(currencyCode)
                 .build()
         };
@@ -379,10 +418,12 @@ public with sharing class RD2_NamingService_TEST {
         RD2_NamingService service = buildAutomaticNamingService();
         service.autogenerateNames(rds);
 
-        System.assertEquals(getExpectedName(acc, '100', currencyCode), rds[0].Name, 
+        System.assertEquals(getExpectedName(accOrg, '100', currencyCode), rds[0].Name,
             'The Account name should be queried and incorporated into the name');
-        System.assertEquals(getExpectedName(contact, '200', currencyCode), rds[1].Name, 
+        System.assertEquals(getExpectedName(contact, '200', currencyCode), rds[1].Name,
             'The Contact name should be queried and incorporated into the name');
+        System.assertEquals(getExpectedName(accOrg, '300', currencyCode), rds[2].Name,
+            'The Account name should be queried and incorporated into the name');
     }
 
 
@@ -500,13 +541,25 @@ public with sharing class RD2_NamingService_TEST {
     }
 
     /***
-    * @description Builds an Account and sets mock Id as the Id
+    * @description Builds an Organizational Account and sets mock Id as the Id
     * @return Account Mock Account record
     */
-    private static Account getAccountMock() {
+    private static Account getOrgAccountMock() {
         return new Account(
             Name = 'Donor Company',
             Id = UTIL_UnitTestData_TEST.mockId(Account.SObjectType)
+        );
+    }
+
+    /***
+    * @description Builds an Organizational Account and sets mock Id as the Id
+    * @return Account Mock Account record
+    */
+    private static Account getHHAccountMock() {
+        return new Account(
+            Name = 'Donor Company',
+            Id = UTIL_UnitTestData_TEST.mockId(Account.SObjectType),
+            RecordTypeId = RD2_NamingService.hhRecordTypeId
         );
     }
 

--- a/src/classes/RD2_RecurringDonations_TEST.cls
+++ b/src/classes/RD2_RecurringDonations_TEST.cls
@@ -51,7 +51,6 @@ private with sharing class RD2_RecurringDonations_TEST {
         insert acc;
 
         Contact contact = UTIL_UnitTestData_TEST.getContact();
-        contact.AccountId = acc.Id;
         insert contact;
     }
 
@@ -64,6 +63,7 @@ private with sharing class RD2_RecurringDonations_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         Contact contact = getContact();
+        Account account = getAccount();
 
         List<npe03__Recurring_Donation__c> rds = new List<npe03__Recurring_Donation__c>{
             new TEST_RecurringDonationBuilder()
@@ -72,7 +72,7 @@ private with sharing class RD2_RecurringDonations_TEST {
                 .withDefaultValues()
                 .build(),
             new TEST_RecurringDonationBuilder()
-                .withAccount(contact.AccountId)
+                .withAccount(account.Id)
                 .withAmount(200)
                 .withDefaultValues()
                 .build()
@@ -94,7 +94,7 @@ private with sharing class RD2_RecurringDonations_TEST {
         System.assert(rdName.endsWith('100 - ' + System.Label.RecurringDonationNameSuffix), 'Name should contain amount value');
 
         rdName = actualRdById.get(rds[1].id).Name;
-        System.assert(rdName.startsWith(contact.Account.Name), 'Name should start with Account name');
+        System.assert(rdName.startsWith(account.Name), 'Name should start with Account name');
         System.assert(rdName.endsWith('200 - ' + System.Label.RecurringDonationNameSuffix), 'Name should contain amount value');
     }
 
@@ -106,10 +106,10 @@ private with sharing class RD2_RecurringDonations_TEST {
     private static void shouldAutogenerateNameOnUpdateWhenAutoNamingIsEnabled() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
-        Contact contact = getContact();
+        Account account = getAccount();
 
         npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
-            .withAccount(contact.AccountId)
+            .withAccount(account.Id)
             .withAmount(100)
             .withDefaultValues()
             .build();
@@ -127,7 +127,7 @@ private with sharing class RD2_RecurringDonations_TEST {
         Test.stopTest();
 
         rd = rdGateway.getRecord(rd.Id);
-        System.assert(rd.Name.startsWith(contact.Account.Name), 'Name should start with Account name');
+        System.assert(rd.Name.startsWith(account.Name), 'Name should start with Account name');
         System.assert(rd.Name.endsWith('200 - ' + System.Label.RecurringDonationNameSuffix), 'Name should contain amount value');
     }
 
@@ -168,6 +168,7 @@ private with sharing class RD2_RecurringDonations_TEST {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         Contact contact = getContact();
+        Account account = getAccount();
 
         List<npe03__Recurring_Donation__c> rds = new List<npe03__Recurring_Donation__c>{
             new TEST_RecurringDonationBuilder()
@@ -178,7 +179,7 @@ private with sharing class RD2_RecurringDonations_TEST {
                 .withName(null)
                 .build(),
             new TEST_RecurringDonationBuilder()
-                .withAccount(contact.AccountId)
+                .withAccount(account.Id)
                 .withAmount(200)
                 .withDefaultValues()
                 .build()
@@ -962,6 +963,18 @@ private with sharing class RD2_RecurringDonations_TEST {
         return [
             SELECT FirstName, LastName, AccountId, Account.Name
             FROM Contact
+            LIMIT 1
+        ];
+    }
+
+    /****
+    * @description Returns account record
+    * @return Account
+    */
+    private static Account getAccount() {
+        return [
+            SELECT Name
+            FROM Account
             LIMIT 1
         ];
     }


### PR DESCRIPTION
# Critical Changes

# Changes
- We fixed an issue in Enhanced Recurring Donations automatic naming that caused Recurring Donations with both a Contact and an Account specified to use Contact name instead of Account name in the naming formula when the Account is a non-Household Account.

# Issues Closed
- Issue #5514

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
