### PR TITLE
Accessibility: Add alt-text to lookup and date-picker icons

### DIFF
--- a/src/components/UTIL_InputField.component
+++ b/src/components/UTIL_InputField.component
@@ -41,7 +41,10 @@
                 var lkLink = lkSpan.querySelector("a");
                 lkLink.style.visibility = "";
                 lkLink.className = "";
-                lkLink.innerHTML = "<svg aria-hidden=\"true\" class=\"slds-icon slds-input__icon slds-icon_x-small slds-icon-text-default\" viewBox=\"0 0 24 24\"><path  d=\"M22.9 20.9l-6.2-6.1c1.3-1.8 1.9-4 1.6-6.4-.6-3.9-3.8-7.1-7.8-7.4C5 .4.4 5 1 10.5c.3 4 3.5 7.3 7.4 7.8 2.4.3 4.6-.3 6.4-1.5l6.1 6.1c.3.3.7.3 1 0l.9-1c.3-.3.3-.7.1-1zM3.7 9.6c0-3.2 2.7-5.9 5.9-5.9s6 2.7 6 5.9-2.7 6-6 6-5.9-2.6-5.9-6z\"></path></svg>";
+                lkLink.innerHTML = "<svg aria-label=\"{!$Label.UTIL_InputFormFormFieldAltLabelLookup} {!$ObjectType[sObjType].fields[field].label}\"" +
+                    " aria-hidden=\"true\" class=\"slds-icon slds-input__icon slds-icon_x-small slds-icon-text-default\"" + 
+                    " viewBox=\"0 0 24 24\">" + 
+                    " <path  d=\"M22.9 20.9l-6.2-6.1c1.3-1.8 1.9-4 1.6-6.4-.6-3.9-3.8-7.1-7.8-7.4C5 .4.4 5 1 10.5c.3 4 3.5 7.3 7.4 7.8 2.4.3 4.6-.3 6.4-1.5l6.1 6.1c.3.3.7.3 1 0l.9-1c.3-.3.3-.7.1-1zM3.7 9.6c0-3.2 2.7-5.9 5.9-5.9s6 2.7 6 5.9-2.7 6-6 6-5.9-2.6-5.9-6z\"></path></svg>";
             }
             // Swap out the date icon
             if (ftype === 'date' || ftype === 'datetime') {
@@ -51,7 +54,10 @@
                 lkLink.style.visibility = "";
                 lkLink.className = "";
                 lkLink.setAttribute("aria-label","{!$Label.lblToday}");
-                lkLink.innerHTML = "<svg aria-hidden=\"true\" class=\"slds-icon slds-input__icon slds-icon_x-small slds-icon-text-default\" width=\"52\" height=\"52\" viewBox=\"0 0 52 52\"><path  d=\"m46.5 20h-41c-0.8 0-1.5 0.7-1.5 1.5v24.5c0 2.2 1.8 4 4 4h36c2.2 0 4-1.8 4-4v-24.5c0-0.8-0.7-1.5-1.5-1.5z m-27.5 22c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m0-10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m10 10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m0-10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m10 10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m0-10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m5-25h-5v-2c0-1.6-1.3-3-3-3-1.6 0-3 1.3-3 3v2h-14v-2c0-1.6-1.3-3-3-3-1.6 0-3 1.3-3 3v2h-5c-2.2 0-4 1.8-4 4v2.5c0 0.8 0.7 1.5 1.5 1.5h41c0.8 0 1.5-0.7 1.5-1.5v-2.5c0-2.2-1.8-4-4-4z\"></path></svg>";
+                lkLink.innerHTML = "<svg aria-label=\"{!$Label.UTIL_InputFormFormFieldAltLabelDate} {!$ObjectType[sObjType].fields[field].label} \"" + 
+                    " aria-hidden=\"true\" class=\"slds-icon slds-input__icon slds-icon_x-small slds-icon-text-default\" " + 
+                    " width=\"52\" height=\"52\" viewBox=\"0 0 52 52\">" + 
+                    " <path  d=\"m46.5 20h-41c-0.8 0-1.5 0.7-1.5 1.5v24.5c0 2.2 1.8 4 4 4h36c2.2 0 4-1.8 4-4v-24.5c0-0.8-0.7-1.5-1.5-1.5z m-27.5 22c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m0-10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m10 10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m0-10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m10 10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m0-10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m5-25h-5v-2c0-1.6-1.3-3-3-3-1.6 0-3 1.3-3 3v2h-14v-2c0-1.6-1.3-3-3-3-1.6 0-3 1.3-3 3v2h-5c-2.2 0-4 1.8-4 4v2.5c0 0.8 0.7 1.5 1.5 1.5h41c0.8 0 1.5-0.7 1.5-1.5v-2.5c0-2.2-1.8-4-4-4z\"></path></svg>";
             }
         })();
 

--- a/src/components/UTIL_InputField.component
+++ b/src/components/UTIL_InputField.component
@@ -41,9 +41,10 @@
                 var lkLink = lkSpan.querySelector("a");
                 lkLink.style.visibility = "";
                 lkLink.className = "";
-                lkLink.innerHTML = "<svg aria-label=\"{!$Label.UTIL_InputFormFormFieldAltLabelLookup} {!$ObjectType[sObjType].fields[field].label}\"" +
-                    " aria-hidden=\"true\" class=\"slds-icon slds-input__icon slds-icon_x-small slds-icon-text-default\"" + 
-                    " viewBox=\"0 0 24 24\">" + 
+                lkLink.setAttribute("aria-label", "{!$Label.UTIL_InputFormFormFieldAltLabelLookup} {!$ObjectType[sObjType].fields[field].label}");
+                lkLink.innerHTML = "<svg " +
+                    " aria-hidden=\"true\" class=\"slds-icon slds-input__icon slds-icon_x-small slds-icon-text-default\"" +
+                    " viewBox=\"0 0 24 24\">" +
                     " <path  d=\"M22.9 20.9l-6.2-6.1c1.3-1.8 1.9-4 1.6-6.4-.6-3.9-3.8-7.1-7.8-7.4C5 .4.4 5 1 10.5c.3 4 3.5 7.3 7.4 7.8 2.4.3 4.6-.3 6.4-1.5l6.1 6.1c.3.3.7.3 1 0l.9-1c.3-.3.3-.7.1-1zM3.7 9.6c0-3.2 2.7-5.9 5.9-5.9s6 2.7 6 5.9-2.7 6-6 6-5.9-2.6-5.9-6z\"></path></svg>";
             }
             // Swap out the date icon
@@ -53,10 +54,10 @@
                 var lkLink = lkSpan.querySelector("a");
                 lkLink.style.visibility = "";
                 lkLink.className = "";
-                lkLink.setAttribute("aria-label","{!$Label.lblToday}");
-                lkLink.innerHTML = "<svg aria-label=\"{!$Label.UTIL_InputFormFormFieldAltLabelDate} {!$ObjectType[sObjType].fields[field].label} \"" + 
-                    " aria-hidden=\"true\" class=\"slds-icon slds-input__icon slds-icon_x-small slds-icon-text-default\" " + 
-                    " width=\"52\" height=\"52\" viewBox=\"0 0 52 52\">" + 
+                lkLink.setAttribute("aria-label","{!$Label.UTIL_InputFormFormFieldAltLabelDate} {!$ObjectType[sObjType].fields[field].label}");
+                lkLink.innerHTML = "<svg " +
+                    " aria-hidden=\"true\" class=\"slds-icon slds-input__icon slds-icon_x-small slds-icon-text-default\" " +
+                    " width=\"52\" height=\"52\" viewBox=\"0 0 52 52\">" +
                     " <path  d=\"m46.5 20h-41c-0.8 0-1.5 0.7-1.5 1.5v24.5c0 2.2 1.8 4 4 4h36c2.2 0 4-1.8 4-4v-24.5c0-0.8-0.7-1.5-1.5-1.5z m-27.5 22c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m0-10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m10 10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m0-10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m10 10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m0-10c0 0.6-0.4 1-1 1h-4c-0.6 0-1-0.4-1-1v-4c0-0.6 0.4-1 1-1h4c0.6 0 1 0.4 1 1v4z m5-25h-5v-2c0-1.6-1.3-3-3-3-1.6 0-3 1.3-3 3v2h-14v-2c0-1.6-1.3-3-3-3-1.6 0-3 1.3-3 3v2h-5c-2.2 0-4 1.8-4 4v2.5c0 0.8 0.7 1.5 1.5 1.5h41c0.8 0 1.5-0.7 1.5-1.5v-2.5c0-2.2-1.8-4-4-4z\"></path></svg>";
             }
         })();

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -2539,6 +2539,22 @@
         <value>Make sure you have entered both the Auth ID and Auth Token provided to you by SmartyStreets. You will find them in your SmartyStreets API Keys page.</value>
     </labels>
     <labels>
+        <fullName>UTIL_InputFormFormFieldAltLabelDate</fullName>
+        <categories>Alt Label</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Alt Text for the Date Picker icon</shortDescription>
+        <value>Date Picker</value>
+    </labels>
+    <labels>
+        <fullName>UTIL_InputFormFormFieldAltLabelLookup</fullName>
+        <categories>Alt Label</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Alt Text for the Lookup icon</shortDescription>
+        <value>Lookup</value>
+    </labels>
+    <labels>
         <fullName>Zip_Not_Found</fullName>
         <categories>address, verification</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1771,6 +1771,8 @@
         <members>Saved</members>
         <members>Settings_not_Saved</members>
         <members>SmartyStreets_Help_Text</members>
+        <members>UTIL_InputFormFormFieldAltLabelLookup</members>
+        <members>UTIL_InputFormFormFieldAltLabelDate</members>
         <members>Zip_Not_Found</members>
         <members>Zipcode_Verification_Limit</members>
         <members>adapterException</members>


### PR DESCRIPTION
- Add alt text labels to the inputfield lookup and inputfield date picker icons

# Critical Changes

# Changes
 - We added alt text labels to lookup and date picker icons in NPSP custom user interfaces.

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
