### PR TITLE
[Robot]GE:Review Donations Modal test case

### DIFF
--- a/robot/Cumulus/doc/Keywords.html
+++ b/robot/Cumulus/doc/Keywords.html
@@ -634,7 +634,7 @@ pre {
                   <i>title</i>
                   
                 </td>
-                <td class="kwdoc"><p>This keyword is similar to click button but uses set focus to button and javascript In the cases where javascript is being triggered on moving away from field, click button doesn't seem to work in headless mode</p></td>
+                <td class="kwdoc"><p>This keyword is similar to click button but uses set focus to button and javascript In the cases where javascript is being triggered on moving away from field, click button doesn't seem to work in headless mode, hence using actionchains moving focus out of field and clicking on screen before performing actual click for next element</p></td>
               </tr>
               
               <tr class="kwrow" id="NPSP.py.Click Special Object Button">
@@ -1950,6 +1950,16 @@ pre {
             <tbody>
               <tr><th>Keyword</th><th>Arguments</th><th>Documentation</th></tr>
               
+              <tr class="kwrow" id="NPSP.robot.API Check And Enable Gift Entry">
+                <td class="kwname">
+                  API Check And Enable Gift Entry
+                </td>
+                <td class="kwargs">
+                  
+                </td>
+                <td class="kwdoc"><p>Checks through API if Advanced Mapping and Gift Entry are already enabled. If yes then does nothing. If either of them are not enabled then calls the Enable Gift Entry keyword to enable them</p></td>
+              </tr>
+              
               <tr class="kwrow" id="NPSP.robot.API Create Campaign">
                 <td class="kwname">
                   API Create Campaign
@@ -2350,6 +2360,20 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                 <td class="kwdoc"></td>
               </tr>
               
+              <tr class="kwrow" id="NPSP.robot.API Query Record">
+                <td class="kwname">
+                  API Query Record
+                </td>
+                <td class="kwargs">
+                  
+                  <i>object_name</i>, 
+                  
+                  <i>**fields</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Queries the given object table by using key,value pair passed and returns the entire record</p></td>
+              </tr>
+              
               <tr class="kwrow" id="NPSP.robot.Capture Screenshot and Delete Records and Close Browser">
                 <td class="kwname">
                   Capture Screenshot and Delete Records and Close Browser
@@ -2509,13 +2533,13 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                   Run Recurring Donations Batch
                 </td>
                 <td class="kwargs">
-
+                  
                   <i>type</i>
-
+                  
                 </td>
                 <td class="kwdoc"><p>Triggers Recurring Donations Batch Job And Waits For the Batch Job To Complete Depending On the Type</p></td>
               </tr>
-
+              
               <tr class="kwrow" id="NPSP.robot.Scroll Page To Location">
                 <td class="kwname">
                   Scroll Page To Location
@@ -4027,6 +4051,20 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                 <td class="kwdoc"><p>Verify that the no. of gifts on the page match with count</p></td>
               </tr>
               
+              <tr class="kwrow" id="GiftEntryPageObject.py.Verify Table Field Values">
+                <td class="kwname">
+                  Verify Table Field Values
+                </td>
+                <td class="kwargs">
+                  
+                  <i>table</i>, 
+                  
+                  <i>**kwargs</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Verifies that table has given field name with value. Arguments are: table=table name, fieldname=fieldvalue Eg: |Verify Table Field Values  |  Batch Gifts  |  Opportunity Amount=$150.00  |</p></td>
+              </tr>
+              
             </tbody>
           </table>
         </div> 
@@ -5436,13 +5474,13 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                   Click Rd2 Modal Button
                 </td>
                 <td class="kwargs">
-
+                  
                   <i>name</i>
-
+                  
                 </td>
                 <td class="kwdoc"><p>Based on the button name (Cancel)  or (Save) on the modal footer, selects and clicks on the respective button</p></td>
               </tr>
-
+              
               <tr class="kwrow" id="RecurringDonationsPageObject.py.Log Current Page Object">
                 <td class="kwname">
                   Log Current Page Object
@@ -5459,27 +5497,27 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                   Populate Rd2 Modal Form
                 </td>
                 <td class="kwargs">
-
+                  
                   <i>**kwargs</i>
-
+                  
                 </td>
-                <td class="kwdoc"><p>Populate the RD2 modal form fields with the respective fields and values</p></td>
+                <td class="kwdoc"><p>Populates the RD2 modal form fields with the respective fields and values</p></td>
               </tr>
-
+              
               <tr class="kwrow" id="RecurringDonationsPageObject.py.Select Value From Rd2 Modal Dropdown">
                 <td class="kwname">
                   Select Value From Rd2 Modal Dropdown
                 </td>
                 <td class="kwargs">
-
-                  <i>dropdown</i>,
-
+                  
+                  <i>dropdown</i>, 
+                  
                   <i>value</i>
-
+                  
                 </td>
                 <td class="kwdoc"><p>Selects given value from the dropdown field on the rd2 modal</p></td>
               </tr>
-
+              
             </tbody>
           </table>
         </div> 
@@ -5653,7 +5691,7 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
       
     </div>
     <div class="footer">
-      Generated on Tuesday July 28, 11:41 AM - cumulusci v3.15.0
+      Generated on Thursday August 06, 11:23 AM - cumulusci v3.15.0
     </div>
   </body>
 </html>

--- a/robot/Cumulus/resources/NPSP.py
+++ b/robot/Cumulus/resources/NPSP.py
@@ -1588,6 +1588,8 @@ class NPSP(BaseNPSPPage,SalesforceRobotLibraryBase):
         """This keyword is similar to click button but uses set focus to button and javascript
         In the cases where javascript is being triggered on moving away from field, 
         click button doesn't seem to work in headless mode"""
+        actions = ActionChains(self.selenium.driver)
+        actions.move_by_offset(0, 20).click().perform()
         locator=npsp_lex_locators['button-with-text'].format(title)
         element = self.selenium.driver.find_element_by_xpath(locator)
         self.selenium.scroll_element_into_view(locator)

--- a/robot/Cumulus/resources/NPSP.py
+++ b/robot/Cumulus/resources/NPSP.py
@@ -1587,7 +1587,8 @@ class NPSP(BaseNPSPPage,SalesforceRobotLibraryBase):
     def click_special_button(self,title):
         """This keyword is similar to click button but uses set focus to button and javascript
         In the cases where javascript is being triggered on moving away from field, 
-        click button doesn't seem to work in headless mode"""
+        click button doesn't seem to work in headless mode, hence using actionchains moving focus out of field 
+        and clicking on screen before performing actual click for next element"""
         actions = ActionChains(self.selenium.driver)
         actions.move_by_offset(0, 20).click().perform()
         locator=npsp_lex_locators['button-with-text'].format(title)

--- a/robot/Cumulus/resources/NPSP.robot
+++ b/robot/Cumulus/resources/NPSP.robot
@@ -462,8 +462,9 @@ Enable Gift Entry
     Enable Gift Entry If Not Enabled    
 
 API Query Record
+    [Documentation]    Queries the given object table by using key,value pair passed and returns the entire record
     [Arguments]        ${object_name}             &{fields}
-    @{object} =        Salesforce Query           ${object_name}
+    @{records} =       Salesforce Query           ${object_name}
     ...                select=Id
     ...                &{fields}
     &{Id} =            Get From List  ${records}  0

--- a/robot/Cumulus/resources/NPSP.robot
+++ b/robot/Cumulus/resources/NPSP.robot
@@ -470,3 +470,16 @@ API Query Record
     &{Id} =            Get From List  ${records}  0
     &{myrecord} =      Salesforce Get  ${object_name}  ${Id}[Id]
     [return]           &{myrecord}
+
+API Check And Enable Gift Entry
+    [Documentation]    Checks through API if Advanced Mapping and Gift Entry are already enabled. If yes then does nothing.
+    ...                If either of them are not enabled then calls the Enable Gift Entry keyword to enable them
+    @{records} =       Salesforce Query           Data_Import_Settings__c
+    ...                select=Field_Mapping_Method__c    
+    &{am} =            Get From List  ${records}  0
+    @{records} =       Salesforce Query           Gift_Entry_Settings__c
+    ...                select=Enable_Gift_Entry__c   
+    &{ge} =            Get From List  ${records}  0
+    Run Keyword if     '${am}[Field_Mapping_Method__c]'!='Data Import Field Mapping' or '${ge}[Enable_Gift_Entry__c]'!='True'
+    ...                Enable Gift Entry
+

--- a/robot/Cumulus/resources/NPSP.robot
+++ b/robot/Cumulus/resources/NPSP.robot
@@ -460,3 +460,12 @@ Enable Gift Entry
     Open Main Menu                          System Tools
     Click Link With Text                    Advanced Mapping for Data Import & Gift Entry
     Enable Gift Entry If Not Enabled    
+
+API Query Record
+    [Arguments]        ${object_name}             &{fields}
+    @{object} =        Salesforce Query           ${object_name}
+    ...                select=Id
+    ...                &{fields}
+    &{Id} =            Get From List  ${records}  0
+    &{myrecord} =      Salesforce Get  ${object_name}  ${Id}[Id]
+    [return]           &{myrecord}

--- a/robot/Cumulus/resources/NPSP.robot
+++ b/robot/Cumulus/resources/NPSP.robot
@@ -474,12 +474,13 @@ API Query Record
 API Check And Enable Gift Entry
     [Documentation]    Checks through API if Advanced Mapping and Gift Entry are already enabled. If yes then does nothing.
     ...                If either of them are not enabled then calls the Enable Gift Entry keyword to enable them
-    @{records} =       Salesforce Query           Data_Import_Settings__c
-    ...                select=Field_Mapping_Method__c    
+    ${ns} =             Get NPSP Namespace Prefix
+    @{records} =       Salesforce Query           ${ns}Data_Import_Settings__c
+    ...                select=${ns}Field_Mapping_Method__c    
     &{am} =            Get From List  ${records}  0
-    @{records} =       Salesforce Query           Gift_Entry_Settings__c
-    ...                select=Enable_Gift_Entry__c   
+    @{records} =       Salesforce Query           ${ns}Gift_Entry_Settings__c
+    ...                select=${ns}Enable_Gift_Entry__c   
     &{ge} =            Get From List  ${records}  0
-    Run Keyword if     '${am}[Field_Mapping_Method__c]'!='Data Import Field Mapping' or '${ge}[Enable_Gift_Entry__c]'!='True'
+    Run Keyword if     '${am}[${ns}Field_Mapping_Method__c]'!='Data Import Field Mapping' or '${ge}[${ns}Enable_Gift_Entry__c]'!='True'
     ...                Enable Gift Entry
 

--- a/robot/Cumulus/tests/browser/gift_entry/change_labels_tmpbldr.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/change_labels_tmpbldr.robot
@@ -5,7 +5,7 @@ Library         cumulusci.robotframework.PageObjects
 Suite Setup     Run keywords
 ...             Open Test Browser
 ...             Setup Test Data
-...             Enable Gift Entry
+...             API Check And Enable Gift Entry
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
 *** Variables ***

--- a/robot/Cumulus/tests/browser/gift_entry/review_donations_create_opp_sge.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/review_donations_create_opp_sge.robot
@@ -8,7 +8,7 @@ Library         cumulusci.robotframework.PageObjects
 ...             robot/Cumulus/resources/AccountPageObject.py
 Suite Setup     Run keywords
 ...             Open Test Browser
-...             Enable Gift Entry
+...             API Check And Enable Gift Entry
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 

--- a/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
@@ -24,6 +24,8 @@ Setup Test Data
     ...                  CloseDate=${DATE}    
     ...                  npe01__Do_Not_Automatically_Create_Payment__c=false    
     ...                  Name=${ACCOUNT}[Name] Donation
+    ${ui_date} =    Get Current Date                   result_format=%b %-d, %Y
+    Set suite variable    ${UI_DATE}
 
 *** Test Cases ***
 Review Donation And Update Payment For BGE
@@ -36,6 +38,7 @@ Review Donation And Update Payment For BGE
     Click Gift Entry Button              New Batch
     Wait Until Modal Is Open
     Select Template                      Default Gift Entry Template
+    Load Page Object                     Form                          Gift Entry
     Fill Gift Entry Form
     ...                                  Batch Name=${ACCOUNT}[Name]Automation Batch
     ...                                  Batch Description=This is a test batch created via automation script
@@ -47,9 +50,17 @@ Review Donation And Update Payment For BGE
     ...                                  Existing Donor Organization=${ACCOUNT}[Name]
     Click Button                         Review Donations
     Wait Until Modal Is Open
-    Click Button                         Update This Payment
+    Click Button                         Update this Payment
     Wait Until Modal Is Closed 
-    Fill Gift Entry Formy
-    ...                                  Donation Amount=499.50
-    Click Button                         Save
+    Fill Gift Entry Form                 Donation Amount=499.50
+    Click Button                         Save & Enter New Gift
+    Verify Gift Count                    1
+    Verify Table Field Values               Batch Gifts
+    ...                                     Donor Name=&{ACCOUNT}[Name]
+    ...                                     Opportunity: Amount=$499.50
+    ...                                     ${DATE}[Field Label]=${UI_DATE}
+    Click Gift Entry Button                 Process Batch
+    Click Data Import Button                NPSP Data Import                button       Begin Data Import Process
+    Wait For Batch To Process               BDI_DataImport_BATCH            Completed
+    Click Button With Value                 Close
     

--- a/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
@@ -8,12 +8,14 @@ Library         cumulusci.robotframework.PageObjects
 ...             robot/Cumulus/resources/AccountPageObject.py
 Suite Setup     Run keywords
 ...             Open Test Browser
-...             Enable Gift Entry
+...             API Check And Enable Gift Entry
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
 *** Keywords ***
 Setup Test Data
+    [Documentation]      Creates the organiation account,opportunity and queries the payment record required for the test
+    ...                  along with getting dates and namespace required for test.
     &{account} =         API Create Organization Account    Name=${faker.company()}
     Set suite variable   &{ACCOUNT}
     ${fut_date} =            Get Current Date         result_format=%Y-%m-%d    increment=2 days
@@ -80,7 +82,7 @@ Review Donation And Update Payment For Batch Gift
     #verify same payment record is updated and paid but opportunity values did not change
     Verify Expected Values               nonns                          Opportunity    ${OPPORTUNITY}[Id]
     ...                                  Amount=500.0
-    # check if this date should be updated or not, noticing update when tested
+    #*** As per PM this date should not be updated, raised W-7921235 for this issue ***
     ...                                  CloseDate=${CUR_DATE}
     ...                                  StageName=Prospecting
     ...                                  npe01__Amount_Outstanding__c=0.5

--- a/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
@@ -83,6 +83,7 @@ Review Donation And Update Payment For Batch Gift
     # check if this date should be updated or not, noticing update when tested
     ...                                  CloseDate=${CUR_DATE}
     ...                                  StageName=Prospecting
+    ...                                  npe01__Amount_Outstanding__c=0.5
     Verify Expected Values               nonns                          npe01__OppPayment__c    ${PAYMENT}[Id]
     ...                                  npe01__Payment_Amount__c=499.5
     ...                                  npe01__Payment_Date__c=${CUR_DATE}

--- a/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
@@ -72,6 +72,7 @@ Review Donation And Update Payment For Batch Gift
     ...                                  Donation Amount=$499.50
     ...                                  Donation Name=${PAYMENT}[Name]
     ...                                  Donation Date=${UI_DATE}
+    Scroll Page To Location              0      0
     Click Gift Entry Button              Process Batch
     Click Data Import Button             NPSP Data Import                button       Begin Data Import Process
     Wait For Batch To Process            BDI_DataImport_BATCH            Completed

--- a/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
@@ -16,24 +16,24 @@ Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 Setup Test Data
     [Documentation]      Creates the organiation account,opportunity and queries the payment record required for the test
     ...                  along with getting dates and namespace required for test.
-    &{account} =         API Create Organization Account    Name=${faker.company()}
+    &{ACCOUNT} =         API Create Organization Account    Name=${faker.company()}
     Set suite variable   &{ACCOUNT}
-    ${fut_date} =            Get Current Date         result_format=%Y-%m-%d    increment=2 days
+    ${FUT_DATE} =            Get Current Date         result_format=%Y-%m-%d    increment=2 days
     Set suite variable   ${FUT_DATE}
-    ${cur_date} =            Get Current Date         result_format=%Y-%m-%d    
+    ${CUR_DATE} =            Get Current Date         result_format=%Y-%m-%d    
     Set suite variable   ${CUR_DATE}
-    &{opportunity} =     API Create Opportunity   ${ACCOUNT}[Id]              Donation  
+    &{OPPORTUNITY} =     API Create Opportunity   ${ACCOUNT}[Id]              Donation  
     ...                  StageName=Prospecting    
     ...                  Amount=500    
     ...                  CloseDate=${FUT_DATE}    
     ...                  npe01__Do_Not_Automatically_Create_Payment__c=false    
     ...                  Name=${ACCOUNT}[Name] Donation
     Set suite variable   &{OPPORTUNITY}
-    ${ui_date} =         Get Current Date                   result_format=%b %-d, %Y
+    ${UI_DATE} =         Get Current Date                   result_format=%b %-d, %Y
     Set suite variable   ${UI_DATE}
-    &{payment} =         API Query Record         npe01__OppPayment__c      npe01__Opportunity__c=${OPPORTUNITY}[Id]
+    &{PAYMENT} =         API Query Record         npe01__OppPayment__c      npe01__Opportunity__c=${OPPORTUNITY}[Id]
     Set suite variable   &{PAYMENT}
-    ${ns} =              Get NPSP Namespace Prefix
+    ${NS} =              Get NPSP Namespace Prefix
     Set suite variable   ${NS}
 
 *** Test Cases ***

--- a/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
@@ -16,22 +16,30 @@ Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 Setup Test Data
     &{account} =         API Create Organization Account    Name=${faker.company()}
     Set suite variable   &{ACCOUNT}
-    ${date} =            Get Current Date         result_format=%Y-%m-%d
-    Set suite variable   ${DATE}
+    ${fut_date} =            Get Current Date         result_format=%Y-%m-%d    increment=2 days
+    Set suite variable   ${FUT_DATE}
+    ${cur_date} =            Get Current Date         result_format=%Y-%m-%d    
+    Set suite variable   ${CUR_DATE}
     &{opportunity} =     API Create Opportunity   ${ACCOUNT}[Id]              Donation  
     ...                  StageName=Prospecting    
     ...                  Amount=500    
-    ...                  CloseDate=${DATE}    
+    ...                  CloseDate=${FUT_DATE}    
     ...                  npe01__Do_Not_Automatically_Create_Payment__c=false    
     ...                  Name=${ACCOUNT}[Name] Donation
-    ${ui_date} =    Get Current Date                   result_format=%b %-d, %Y
-    Set suite variable    ${UI_DATE}
+    Set suite variable   &{OPPORTUNITY}
+    ${ui_date} =         Get Current Date                   result_format=%b %-d, %Y
+    Set suite variable   ${UI_DATE}
+    &{payment} =         API Query Record         npe01__OppPayment__c      npe01__Opportunity__c=${OPPORTUNITY}[Id]
+    Set suite variable   &{PAYMENT}
+    ${ns} =              Get NPSP Namespace Prefix
+    Set suite variable   ${NS}
 
 *** Test Cases ***
-Review Donation And Update Payment For BGE
-    # [Documentation]                      Create an organization account with open opportunity (with payment record) via API. Go to SGE form
-    # ...                                  select the donor as account and the account created. Verify review donations modal but select to create alternative opportunity.
-    # ...                                  Enter details and save. Verify that new opportunity and payment are created with right info 
+Review Donation And Update Payment For Batch Gift
+    [Documentation]                      Create an organization account with open opportunity (with payment record) via API. Go to SGE form
+    ...                                  select the donor as account and the account created. Verify review donations modal and select to update payment.
+    ...                                  Change date to today and payment amount to be less than opp amount. Verify that same payment record got updated
+    ...                                  with new amount and date but opportunity is still prospecting and amount is not updated.
     [tags]                               unstable      feature:GE                    W-042803   
     #verify Review Donations link is available and update a payment                           
     Go To Page                           Landing                       GE_Gift_Entry         
@@ -45,6 +53,7 @@ Review Donation And Update Payment For BGE
     Click Gift Entry Button              Next
     Click Gift Entry Button              Save
     Current Page Should Be               Form                          Gift Entry
+    ${batch_id} =                        Save Current Record ID For Deletion     ${NS}DataImportBatch__c
     Fill Gift Entry Form
     ...                                  Donor Type=Account1
     ...                                  Existing Donor Organization=${ACCOUNT}[Name]
@@ -52,15 +61,29 @@ Review Donation And Update Payment For BGE
     Wait Until Modal Is Open
     Click Button                         Update this Payment
     Wait Until Modal Is Closed 
-    Fill Gift Entry Form                 Donation Amount=499.50
+    Fill Gift Entry Form                 
+    ...                                  Donation Amount=499.50
+    ...                                  Donation Date=Today
     Click Button                         Save & Enter New Gift
+    #verify donation date and amount values changed on table
     Verify Gift Count                    1
-    Verify Table Field Values               Batch Gifts
-    ...                                     Donor Name=&{ACCOUNT}[Name]
-    ...                                     Opportunity: Amount=$499.50
-    ...                                     ${DATE}[Field Label]=${UI_DATE}
-    Click Gift Entry Button                 Process Batch
-    Click Data Import Button                NPSP Data Import                button       Begin Data Import Process
-    Wait For Batch To Process               BDI_DataImport_BATCH            Completed
-    Click Button With Value                 Close
+    Verify Table Field Values            Batch Gifts
+    ...                                  Donor Name=${ACCOUNT}[Name]
+    ...                                  Donation Amount=$499.50
+    ...                                  Donation Name=${PAYMENT}[Name]
+    ...                                  Donation Date=${UI_DATE}
+    Click Gift Entry Button              Process Batch
+    Click Data Import Button             NPSP Data Import                button       Begin Data Import Process
+    Wait For Batch To Process            BDI_DataImport_BATCH            Completed
+    Click Button With Value              Close
+    #verify same payment record is updated and paid but opportunity values did not change
+    Verify Expected Values               nonns                          Opportunity    ${OPPORTUNITY}[Id]
+    ...                                  Amount=500.0
+    # check if this date should be updated or not, noticing update when tested
+    ...                                  CloseDate=${CUR_DATE}
+    ...                                  StageName=Prospecting
+    Verify Expected Values               nonns                          npe01__OppPayment__c    ${PAYMENT}[Id]
+    ...                                  npe01__Payment_Amount__c=499.5
+    ...                                  npe01__Payment_Date__c=${CUR_DATE}
+    ...                                  npe01__Paid__c=True
     

--- a/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/review_donations_update_pmt_bge.robot
@@ -1,0 +1,55 @@
+*** Settings ***
+
+Resource        robot/Cumulus/resources/NPSP.robot
+Library         cumulusci.robotframework.PageObjects
+...             robot/Cumulus/resources/GiftEntryPageObject.py
+...             robot/Cumulus/resources/OpportunityPageObject.py
+...             robot/Cumulus/resources/PaymentPageObject.py
+...             robot/Cumulus/resources/AccountPageObject.py
+Suite Setup     Run keywords
+...             Open Test Browser
+...             Enable Gift Entry
+...             Setup Test Data
+Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Keywords ***
+Setup Test Data
+    &{account} =         API Create Organization Account    Name=${faker.company()}
+    Set suite variable   &{ACCOUNT}
+    ${date} =            Get Current Date         result_format=%Y-%m-%d
+    Set suite variable   ${DATE}
+    &{opportunity} =     API Create Opportunity   ${ACCOUNT}[Id]              Donation  
+    ...                  StageName=Prospecting    
+    ...                  Amount=500    
+    ...                  CloseDate=${DATE}    
+    ...                  npe01__Do_Not_Automatically_Create_Payment__c=false    
+    ...                  Name=${ACCOUNT}[Name] Donation
+
+*** Test Cases ***
+Review Donation And Update Payment For BGE
+    # [Documentation]                      Create an organization account with open opportunity (with payment record) via API. Go to SGE form
+    # ...                                  select the donor as account and the account created. Verify review donations modal but select to create alternative opportunity.
+    # ...                                  Enter details and save. Verify that new opportunity and payment are created with right info 
+    [tags]                               unstable      feature:GE                    W-042803   
+    #verify Review Donations link is available and update a payment                           
+    Go To Page                           Landing                       GE_Gift_Entry         
+    Click Gift Entry Button              New Batch
+    Wait Until Modal Is Open
+    Select Template                      Default Gift Entry Template
+    Fill Gift Entry Form
+    ...                                  Batch Name=${ACCOUNT}[Name]Automation Batch
+    ...                                  Batch Description=This is a test batch created via automation script
+    Click Gift Entry Button              Next
+    Click Gift Entry Button              Save
+    Current Page Should Be               Form                          Gift Entry
+    Fill Gift Entry Form
+    ...                                  Donor Type=Account1
+    ...                                  Existing Donor Organization=${ACCOUNT}[Name]
+    Click Button                         Review Donations
+    Wait Until Modal Is Open
+    Click Button                         Update This Payment
+    Wait Until Modal Is Closed 
+    Fill Gift Entry Formy
+    ...                                  Donation Amount=499.50
+    Click Button                         Save
+    

--- a/robot/Cumulus/tests/browser/gift_entry/template_builder.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/template_builder.robot
@@ -3,7 +3,9 @@
 Resource        robot/Cumulus/resources/NPSP.robot
 Library         cumulusci.robotframework.PageObjects
 ...             robot/Cumulus/resources/GiftEntryPageObject.py
-Suite Setup     Open Test Browser
+Suite Setup     Run keywords
+...             Open Test Browser
+...             API Check And Enable Gift Entry
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
 *** Variables ***

--- a/robot/Cumulus/tests/browser/gift_entry/verify_mapped_fields_tmpbldr.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/verify_mapped_fields_tmpbldr.robot
@@ -9,7 +9,7 @@ Library         cumulusci.robotframework.PageObjects
 Suite Setup     Run keywords
 ...             Open Test Browser
 ...             Setup Test Data
-...             Enable Gift Entry
+...             API Check And Enable Gift Entry
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
 *** Variables ***

--- a/robot/Cumulus/tests/browser/gift_entry/verify_mapped_fields_tmpbldr.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/verify_mapped_fields_tmpbldr.robot
@@ -9,7 +9,7 @@ Library         cumulusci.robotframework.PageObjects
 Suite Setup     Run keywords
 ...             Open Test Browser
 ...             Setup Test Data
-...             API Check And Enable Gift Entry
+...             Enable Gift Entry
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
 *** Variables ***

--- a/robot/Cumulus/tests/browser/gift_entry/zedit_template.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/zedit_template.robot
@@ -8,7 +8,7 @@ Library         cumulusci.robotframework.PageObjects
 ...             robot/Cumulus/resources/PaymentPageObject.py
 Suite Setup     Run keywords
 ...             Open Test Browser
-...             Enable Gift Entry
+...             API Check And Enable Gift Entry
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 


### PR DESCRIPTION
Added a new test that Creates an organization account with open opportunity (with payment record) via API. Go to SGE form select the donor as account and the account created. Verify review donations modal and select to update payment. Change date to today and payment amount to be less than the opp amount. Verify that the same payment record got updated with a new amount and date but the opportunity is still prospecting and the amount is not updated.
Also created a new API keyword that checks if GE is enabled via API first and if not enabled then enables via UI
AA WI-042803
File Created: review_donations_update_pmt_bge.robot
FIles Updated:
NPSP.py
NPSP.robot
change_labels_tmpbldr.robot
review_donations_create_opp_sge.robot
template_builder.robot
verify_mapped_fields_tmpbldr.robot
zedit_template.robot
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
