### PR TITLE
[Robot] Changes to ensure RD2 tests work on regression org along with QA org

### DIFF
--- a/robot/Cumulus/doc/Keywords.html
+++ b/robot/Cumulus/doc/Keywords.html
@@ -2350,6 +2350,16 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                 <td class="kwdoc"></td>
               </tr>
               
+              <tr class="kwrow" id="NPSP.robot.API Query Recurrring Donation Settings For RD2 Enablement">
+                <td class="kwname">
+                  API Query Recurrring Donation Settings For RD2 Enablement
+                </td>
+                <td class="kwargs">
+                  
+                </td>
+                <td class="kwdoc"><p>Queries the Recurring Donation settings object for the RD2 Enabled status and returns the boolean status value</p></td>
+              </tr>
+              
               <tr class="kwrow" id="NPSP.robot.Capture Screenshot and Delete Records and Close Browser">
                 <td class="kwname">
                   Capture Screenshot and Delete Records and Close Browser
@@ -2509,13 +2519,13 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                   Run Recurring Donations Batch
                 </td>
                 <td class="kwargs">
-
+                  
                   <i>type</i>
-
+                  
                 </td>
                 <td class="kwdoc"><p>Triggers Recurring Donations Batch Job And Waits For the Batch Job To Complete Depending On the Type</p></td>
               </tr>
-
+              
               <tr class="kwrow" id="NPSP.robot.Scroll Page To Location">
                 <td class="kwname">
                   Scroll Page To Location
@@ -4027,6 +4037,20 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                 <td class="kwdoc"><p>Verify that the no. of gifts on the page match with count</p></td>
               </tr>
               
+              <tr class="kwrow" id="GiftEntryPageObject.py.Verify Table Field Values">
+                <td class="kwname">
+                  Verify Table Field Values
+                </td>
+                <td class="kwargs">
+                  
+                  <i>table</i>, 
+                  
+                  <i>**kwargs</i>
+                  
+                </td>
+                <td class="kwdoc"><p>Verifies that table has given field name with value. Arguments are: table=table name, fieldname=fieldvalue Eg: |Verify Table Field Values  |  Batch Gifts  |  Opportunity Amount=$150.00  |</p></td>
+              </tr>
+              
             </tbody>
           </table>
         </div> 
@@ -5436,13 +5460,13 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                   Click Rd2 Modal Button
                 </td>
                 <td class="kwargs">
-
+                  
                   <i>name</i>
-
+                  
                 </td>
                 <td class="kwdoc"><p>Based on the button name (Cancel)  or (Save) on the modal footer, selects and clicks on the respective button</p></td>
               </tr>
-
+              
               <tr class="kwrow" id="RecurringDonationsPageObject.py.Log Current Page Object">
                 <td class="kwname">
                   Log Current Page Object
@@ -5459,27 +5483,27 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
                   Populate Rd2 Modal Form
                 </td>
                 <td class="kwargs">
-
+                  
                   <i>**kwargs</i>
-
+                  
                 </td>
-                <td class="kwdoc"><p>Populate the RD2 modal form fields with the respective fields and values</p></td>
+                <td class="kwdoc"><p>Populates the RD2 modal form fields with the respective fields and values</p></td>
               </tr>
-
+              
               <tr class="kwrow" id="RecurringDonationsPageObject.py.Select Value From Rd2 Modal Dropdown">
                 <td class="kwname">
                   Select Value From Rd2 Modal Dropdown
                 </td>
                 <td class="kwargs">
-
-                  <i>dropdown</i>,
-
+                  
+                  <i>dropdown</i>, 
+                  
                   <i>value</i>
-
+                  
                 </td>
                 <td class="kwdoc"><p>Selects given value from the dropdown field on the rd2 modal</p></td>
               </tr>
-
+              
             </tbody>
           </table>
         </div> 
@@ -5653,7 +5677,7 @@ field_api_name=value | any field u want to populate with value on npe5__Affiliat
       
     </div>
     <div class="footer">
-      Generated on Tuesday July 28, 11:41 AM - cumulusci v3.15.0
+      Generated on Friday August 07, 12:07 AM - cumulusci v3.16.0.dev3
     </div>
   </body>
 </html>

--- a/robot/Cumulus/resources/NPSP.robot
+++ b/robot/Cumulus/resources/NPSP.robot
@@ -429,7 +429,6 @@ Enable RD2QA
     Run Task       execute_anon
     ...            apex= ${apex3}
 
-
 API Query Recurrring Donation Settings For RD2 Enablement
     [Documentation]    Queries the Recurring Donation settings object for the RD2 Enabled status and returns the boolean status value
     ${ns} =            Get Npsp Namespace Prefix

--- a/robot/Cumulus/resources/NPSP.robot
+++ b/robot/Cumulus/resources/NPSP.robot
@@ -429,10 +429,19 @@ Enable RD2QA
     Run Task       execute_anon
     ...            apex= ${apex3}
 
+
+API Query Recurrring Donation Settings For RD2 Enablement
+    [Documentation]    Queries the Recurring Donation settings object for the RD2 Enabled status and returns the boolean status value
+    ${ns} =            Get Npsp Namespace Prefix
+    @{record} =   Salesforce Query      npe03__Recurring_Donations_Settings__c
+    ...                select=${ns}IsRecurringDonations2Enabled__c
+    &{rd2_enabled} =                 Get From List  ${record}  0
+    [return]                ${rd2_enabled}[IsRecurringDonations2Enabled__c]
+
 Enable RD2
     [Documentation]           Checks if Rd2 settings are already enabled and then run the scripts to enable RD2
-    ${ns} =                   Get NPSP Namespace Prefix
-    Run Keyword if            "${ns}"!="npsp__"
+    ${is_rd2_enabled} =       API Query Recurrring Donation Settings For RD2 Enablement
+    Run Keyword if            "${is_rd2_enabled}"!="True"
     ...                       Enable RD2QA
 
 Run Recurring Donations Batch

--- a/robot/Cumulus/resources/NPSP.robot
+++ b/robot/Cumulus/resources/NPSP.robot
@@ -59,10 +59,11 @@ API Modify Recurring Donation
     ...              | Recurring Donation ID   |
 
     [Arguments]             ${rd_id}      &{fields}
+    ${ns} =                 Get NPSP Namespace Prefix
     Salesforce Update       npe03__Recurring_Donation__c     ${rd_id}
     ...                     &{fields}
     @{records} =  Salesforce Query      npe03__Recurring_Donation__c
-    ...              select=StartDate__c,npe03__Amount__c
+    ...              select=${ns}StartDate__c,npe03__Amount__c
     ...              Id=${rd_id}
     &{rd} =          Get From List  ${records}  0
     [return]         &{rd}
@@ -430,10 +431,8 @@ Enable RD2QA
 
 Enable RD2
     [Documentation]           Checks if Rd2 settings are already enabled and then run the scripts to enable RD2
-    Go To Page                Custom         NPSP_Settings
-    Open Main Menu            Recurring Donations
-    ${rd2_enabled} =          Check Rd2 Is Enabled
-    Run Keyword if            "${rd2_enabled}"!="True"
+    ${ns} =                   Get NPSP Namespace Prefix
+    Run Keyword if            "${ns}"!="npsp__"
     ...                       Enable RD2QA
 
 Run Recurring Donations Batch

--- a/robot/Cumulus/resources/RecurringDonationsPageObject.py
+++ b/robot/Cumulus/resources/RecurringDonationsPageObject.py
@@ -37,9 +37,17 @@ class RDListingPage(BaseNPSPPage, ListingPage):
     @capture_screenshot_on_error
     def populate_rd2_modal_form(self, **kwargs):
         """Populates the RD2 modal form fields with the respective fields and values"""
+        ns=self.npsp.get_npsp_namespace_prefix()
         for key, value in kwargs.items():
+            locator = npsp_lex_locators["erd"]["modal_input_field"].format(key)
+            # Recurring Donation Name field only appears on a regression org hence this check
+            if key == "Recurring Donation Name" and ns=="npsp__":
+                if self.npsp.check_if_element_exists(locator):
+                    self.selenium.set_focus_to_element(locator)
+                    self.salesforce._populate_field(locator, value)
+                else:
+                    self.builtin.log(f"Element {key} not found")
             if key in ("Amount", "Number of Planned Installments"):
-                locator = npsp_lex_locators["erd"]["modal_input_field"].format(key)
                 if self.npsp.check_if_element_exists(locator):
                     self.selenium.set_focus_to_element(locator)
                     self.salesforce._populate_field(locator, value)

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_fixed_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_fixed_erd_record.robot
@@ -52,6 +52,7 @@ Create Fixed Recurring Donation With Monthly Installment
     ...                                     Donor Type=Account
     ...                                     Account=${data}[account][Name]
     ...                                     Recurring Type=${type}
+    ...                                     Recurring Donation Name=Automation RD
     ...                                     Number of Planned Installments=${installments}
     ...                                     Amount=100
     ...                                     Payment Method=Credit Card

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_for_contact.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_for_contact.robot
@@ -43,6 +43,7 @@ ${METHOD}  Credit Card
     Populate Rd2 Modal Form
     ...                                    Contact=${data}[contact][LastName] Household
     ...                                    Amount=${AMOUNT}
+    ...                                    Recurring Donation Name=Automation RD
     ...                                    Payment Method=${METHOD}
     ...                                    Day of Month=${DAY_OF_MONTH}
     Click Rd2 Modal Button                 Save

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_record.robot
@@ -3,14 +3,14 @@ Resource        robot/Cumulus/resources/NPSP.robot
 Library         cumulusci.robotframework.PageObjects
 ...             robot/Cumulus/resources/NPSPSettingsPageObject.py
 ...             robot/Cumulus/resources/ContactPageObject.py
-...             robot/Cumulus/resources/RecurringDonationsPageObject.py
+...             robot/Cumulus/resources/RecurringDonationsPageObject.pyS
 ...             robot/Cumulus/resources/OpportunityPageObject.py
 ...             robot/Cumulus/resources/NPSP.py
 Suite Setup     Run keywords
 ...             Open Test Browser
 ...             Setup Test Data
-...             Enable RD2
-Suite Teardown  Delete Records and Close Browser
+#...             Enable RD2
+#Suite Teardown  Delete Records and Close Browser
 
 
 ***Keywords***
@@ -56,6 +56,7 @@ Create Open Recurring Donation With Monthly Installment
     ...                                   Donor Type=Account
     ...                                   Account=${data}[account][Name]
     ...                                   Amount= ${amount}
+    ...                                   Recurring Donation Name=Automation RD
     ...                                   Payment Method=Credit Card
     ...                                   Day of Month=${day_of_month}
     Click Rd2 Modal Button                Save

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_record.robot
@@ -3,14 +3,14 @@ Resource        robot/Cumulus/resources/NPSP.robot
 Library         cumulusci.robotframework.PageObjects
 ...             robot/Cumulus/resources/NPSPSettingsPageObject.py
 ...             robot/Cumulus/resources/ContactPageObject.py
-...             robot/Cumulus/resources/RecurringDonationsPageObject.pyS
+...             robot/Cumulus/resources/RecurringDonationsPageObject.py
 ...             robot/Cumulus/resources/OpportunityPageObject.py
 ...             robot/Cumulus/resources/NPSP.py
 Suite Setup     Run keywords
 ...             Open Test Browser
 ...             Setup Test Data
-#...             Enable RD2
-#Suite Teardown  Delete Records and Close Browser
+...             Enable RD2
+Suite Teardown  Delete Records and Close Browser
 
 
 ***Keywords***

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_effective_date_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_effective_date_erd_record.robot
@@ -14,8 +14,8 @@ Suite Teardown  Delete Records and Close Browser
 
 *** Keywords ***
 Setup Test Data
-     ${ns} =             Get NPSP Namespace Prefix
-     Set Suite Variable  ${ns}
+     ${NS} =             Get NPSP Namespace Prefix
+     Set Suite Variable  ${NS}
      ${EFFECTIVE_DATE_INITIAL} =           Get Current Date      result_format=%-m/%-d/%Y
      ${DATE}=                              Get current date      result_format=%Y-%m-%d %H:%M:%S.%f      increment=30 days
      ${DATE_TO_UPDATE} =                   Convert Date          ${DATE}                                 result_format=%Y-%m-%d
@@ -36,10 +36,10 @@ Setup Test Data
      ...                                                         npe03__Installment_Period__c=Monthly
      ...                                                         npe03__Amount__c=100
      ...                                                         npe03__Open_Ended_Status__c=${TYPE}
-     ...                                                         ${ns}Status__c=Active
-     ...                                                         ${ns}Day_of_Month__c=${DAY_OF_MONTH}
-     ...                                                         ${ns}InstallmentFrequency__c=${FREQUENCY}
-     ...                                                         ${ns}PaymentMethod__c=${METHOD}
+     ...                                                         ${NS}Status__c=Active
+     ...                                                         ${NS}Day_of_Month__c=${DAY_OF_MONTH}
+     ...                                                         ${NS}InstallmentFrequency__c=${FREQUENCY}
+     ...                                                         ${NS}PaymentMethod__c=${METHOD}
 
      Setupdata   contact             ${contact1_fields}          recurringdonation_data=${recurringdonation_fields}
 

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_effective_date_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_effective_date_erd_record.robot
@@ -14,13 +14,15 @@ Suite Teardown  Delete Records and Close Browser
 
 *** Keywords ***
 Setup Test Data
+     ${ns} =             Get NPSP Namespace Prefix
+     Set Suite Variable  ${ns}
      ${EFFECTIVE_DATE_INITIAL} =           Get Current Date      result_format=%-m/%-d/%Y
      ${DATE}=                              Get current date      result_format=%Y-%m-%d %H:%M:%S.%f      increment=30 days
      ${DATE_TO_UPDATE} =                   Convert Date          ${DATE}                                 result_format=%Y-%m-%d
      ${EFFECTIVE_MODIFIED_DATE}=           Get current date      result_format=%-m/%-d/%Y                increment=30 days
      ${CURRDATE}=                          Get Current Date      result_format=datetime
-     ${CURRENTVALUE} =                     Evaluate              (12-${CURRDATE.month}) * 100
-     ${NUM_MONTHS_NEW_VALUE} =             Evaluate              (12-${CURRDATE.month})-1
+     ${CURRENTVALUE} =                     Evaluate              (12-${CURRDATE.month}+1) * 100
+     ${NUM_MONTHS_NEW_VALUE} =             Evaluate              (12-${CURRDATE.month})
      ${CURRENTVALUE_EDITED}=               Evaluate              (${NUM_MONTHS_NEW_VALUE}*150) + 100
      Set Suite Variable  ${CURRENTVALUE}
      Set Suite Variable  ${DATE}
@@ -34,10 +36,10 @@ Setup Test Data
      ...                                                         npe03__Installment_Period__c=Monthly
      ...                                                         npe03__Amount__c=100
      ...                                                         npe03__Open_Ended_Status__c=${TYPE}
-     ...                                                         Status__c=Active
-     ...                                                         Day_of_Month__c=${DAY_OF_MONTH}
-     ...                                                         InstallmentFrequency__c=${FREQUENCY}
-     ...                                                         PaymentMethod__c=${METHOD}
+     ...                                                         ${ns}Status__c=Active
+     ...                                                         ${ns}Day_of_Month__c=${DAY_OF_MONTH}
+     ...                                                         ${ns}InstallmentFrequency__c=${FREQUENCY}
+     ...                                                         ${ns}PaymentMethod__c=${METHOD}
 
      Setupdata   contact             ${contact1_fields}          recurringdonation_data=${recurringdonation_fields}
 
@@ -61,7 +63,6 @@ Edit An Enhanced Recurring donation record of type open
     Go To Page                               Details
     ...                                      npe03__Recurring_Donation__c
     ...                                      object_id=${data}[contact_rd][Id]
-
     Validate Field Values Under Section
     ...                                      Amount=$100.00
     ...                                      Status=Active
@@ -84,7 +85,8 @@ Edit An Enhanced Recurring donation record of type open
     #Using backend API update the recurring donation record and modify the startDate field to next month's date
     API Modify Recurring Donation            ${data}[contact_rd][Id]
     ...                                      npe03__Amount__c=${AMOUNT_TO_UPDATE}
-    ...                                      StartDate__c=${DATE_TO_UPDATE}
+    ...                                      ${ns}StartDate__c=${DATE_TO_UPDATE}
+    Run Recurring Donations Batch            RD2
     Go To Page                               Details
     ...                                      npe03__Recurring_Donation__c
     ...                                      object_id=${data}[contact_rd][Id]

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
@@ -12,18 +12,18 @@ Suite Teardown  Delete Records and Close Browser
 *** Keywords ***
 
 Setup Test Data
-        ${ns} =             Get NPSP Namespace Prefix
-        Set Suite Variable  ${ns}
+        ${NS} =             Get NPSP Namespace Prefix
+        Set Suite Variable  ${NS}
         #Create a Recurring Donation type Open and installment period Monthly Associated To a contact using API
         &{contact1_fields}=   Create Dictionary                     Email=rd2tester@example.com
         &{recurringdonation_fields} =	Create Dictionary           Name=ERD Open Recurring Donation
         ...                                                         npe03__Installment_Period__c=Monthly
         ...                                                         npe03__Amount__c=100
         ...                                                         npe03__Open_Ended_Status__c=Open
-        ...                                                         ${ns}Status__c=Active
-        ...                                                         ${ns}Day_of_Month__c=2
-        ...                                                         ${ns}InstallmentFrequency__c=1
-        ...                                                         ${ns}PaymentMethod__c=Credit Card
+        ...                                                         ${NS}Status__c=Active
+        ...                                                         ${NS}Day_of_Month__c=2
+        ...                                                         ${NS}InstallmentFrequency__c=1
+        ...                                                         ${NS}PaymentMethod__c=Credit Card
 
         Setupdata   contact         ${contact1_fields}             recurringdonation_data=${recurringdonation_fields}
 

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
@@ -6,7 +6,7 @@ Library         cumulusci.robotframework.PageObjects
 Suite Setup     Run keywords
 ...             Open Test Browser
 ...             Setup Test Data
-#...             Enable RD2
+...             Enable RD2
 Suite Teardown  Delete Records and Close Browser
 
 *** Keywords ***

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
@@ -6,22 +6,24 @@ Library         cumulusci.robotframework.PageObjects
 Suite Setup     Run keywords
 ...             Open Test Browser
 ...             Setup Test Data
-...             Enable RD2
+#...             Enable RD2
 Suite Teardown  Delete Records and Close Browser
 
 *** Keywords ***
 
 Setup Test Data
+        ${ns} =             Get NPSP Namespace Prefix
+        Set Suite Variable  ${ns}
         #Create a Recurring Donation type Open and installment period Monthly Associated To a contact using API
         &{contact1_fields}=   Create Dictionary                     Email=rd2tester@example.com
         &{recurringdonation_fields} =	Create Dictionary           Name=ERD Open Recurring Donation
         ...                                                         npe03__Installment_Period__c=Monthly
         ...                                                         npe03__Amount__c=100
         ...                                                         npe03__Open_Ended_Status__c=Open
-        ...                                                         Status__c=Active
-        ...                                                         Day_of_Month__c=2
-        ...                                                         InstallmentFrequency__c=1
-        ...                                                         PaymentMethod__c=Credit Card
+        ...                                                         ${ns}Status__c=Active
+        ...                                                         ${ns}Day_of_Month__c=2
+        ...                                                         ${ns}InstallmentFrequency__c=1
+        ...                                                         ${ns}PaymentMethod__c=Credit Card
 
         Setupdata   contact         ${contact1_fields}             recurringdonation_data=${recurringdonation_fields}
 

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
@@ -9,7 +9,7 @@ Library         cumulusci.robotframework.PageObjects
 Suite Setup     Run keywords
 ...             Open Test Browser
 ...             Setup Test Data
-#...             Enable RD2
+...             Enable RD2
 Suite Teardown  Delete Records and Close Browser
 
 *** Keywords ***

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
@@ -15,8 +15,8 @@ Suite Teardown  Delete Records and Close Browser
 *** Keywords ***
 
 Setup Test Data
-        ${ns} =             Get NPSP Namespace Prefix
-        Set Suite Variable  ${ns}
+        ${NS} =             Get NPSP Namespace Prefix
+        Set Suite Variable  ${NS}
 
         #Create a Recurring Donation
         &{contact1_fields}=   Create Dictionary                     Email=rd2tester@example.com
@@ -25,10 +25,10 @@ Setup Test Data
         ...                                                         npe03__Amount__c=100
         ...                                                         npe03__Open_Ended_Status__c=Open
         ...                                                         npe03__Date_Established__c=2019-07-08
-        ...                                                         ${ns}Status__c=Active
-        ...                                                         ${ns}Day_of_Month__c=15
-        ...                                                         ${ns}InstallmentFrequency__c=1
-        ...                                                         ${ns}PaymentMethod__c=Check
+        ...                                                         ${NS}Status__c=Active
+        ...                                                         ${NS}Day_of_Month__c=15
+        ...                                                         ${NS}InstallmentFrequency__c=1
+        ...                                                         ${NS}PaymentMethod__c=Check
 
         Setupdata   contact         ${contact1_fields}             recurringdonation_data=${recurringdonation_fields}
 

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
@@ -9,12 +9,15 @@ Library         cumulusci.robotframework.PageObjects
 Suite Setup     Run keywords
 ...             Open Test Browser
 ...             Setup Test Data
-...             Enable RD2
+#...             Enable RD2
 Suite Teardown  Delete Records and Close Browser
 
 *** Keywords ***
 
 Setup Test Data
+        ${ns} =             Get NPSP Namespace Prefix
+        Set Suite Variable  ${ns}
+
         #Create a Recurring Donation
         &{contact1_fields}=   Create Dictionary                     Email=rd2tester@example.com
         &{recurringdonation_fields} =	Create Dictionary           Name=ERD Open Recurring Donation
@@ -22,10 +25,10 @@ Setup Test Data
         ...                                                         npe03__Amount__c=100
         ...                                                         npe03__Open_Ended_Status__c=Open
         ...                                                         npe03__Date_Established__c=2019-07-08
-        ...                                                         Status__c=Active
-        ...                                                         Day_of_Month__c=15
-        ...                                                         InstallmentFrequency__c=1
-        ...                                                         PaymentMethod__c=Check
+        ...                                                         ${ns}Status__c=Active
+        ...                                                         ${ns}Day_of_Month__c=15
+        ...                                                         ${ns}InstallmentFrequency__c=1
+        ...                                                         ${ns}PaymentMethod__c=Check
 
         Setupdata   contact         ${contact1_fields}             recurringdonation_data=${recurringdonation_fields}
 


### PR DESCRIPTION
During NPSP regression testing an issue has been raised by Rick that RD2 tests are working on Regression org.
To ensure that all RD2 tests work on Regression and QA org logic has been added to handle additional fields on the modal.



# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
