### PR TITLE
Run Jest tests in GitHub Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,6 @@
 /app.json             @SalesforceFoundation/release-engineering-reviewers
 /requirements.txt     @SalesforceFoundation/release-engineering-reviewers
 /runtime.txt          @SalesforceFoundation/release-engineering-reviewers
+
+# GitHub Actions
+.github/workflows/    @SalesforceFoundation/release-engineering-reviewers

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ runner.os }}-${{ steps.node-version.outputs.ver }}-${{ hashFiles('package.json') }}
+          key: ${{ runner.os }}-${{ steps.node-version.outputs.ver }}-${{ hashFiles('package.json', 'yarn.lock') }}
       - name: Install Packages
         run: |
           yarn install

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,0 +1,24 @@
+name: Jest
+on: [push]
+jobs:
+  jest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+      - name: Determine Node Version
+        id: node-version
+        run: |
+          echo "::set-output name=ver::$(node --version)"
+      - uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ steps.node-version.outputs.ver }}-${{ hashFiles('package.json') }}
+      - name: Install Packages
+        run: |
+          yarn install
+      - name: Run Jest Tests
+        run: |
+          npx lwc-jest


### PR DESCRIPTION
This PR enables Jest tests for LWC to run in GitHub Actions.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
