### PR TITLE
RD2: Update open Opp to the Next Donation Date on schedule change

### DIFF
--- a/src/classes/RD2_OpportunityEvaluationService.cls
+++ b/src/classes/RD2_OpportunityEvaluationService.cls
@@ -543,6 +543,31 @@ public inherited sharing class RD2_OpportunityEvaluationService {
         return Database.query(soql);
     }
 
+    /***
+    * @description Retrieves Recurring Donation current and future closed and open Opportunities
+    * required to calculate Next Donation Date
+    * @param rdIds Recurring Donation Ids
+    * @return Map<Id, List<Opportunity>>
+    */
+    public Map<Id, List<Opportunity>> getOpportunitiesByRDId(Set<Id> rdIds) { 
+        Map<Id, List<Opportunity>> oppsByRDId = new Map<Id, List<Opportunity>>();
+
+        Set<String> queryFields = new Set<String>{ 'Id' };
+        queryFields.add(getOpportunitySubQuery());
+
+        String soql = new UTIL_Query()
+            .withFrom(npe03__Recurring_Donation__c.SObjectType)
+            .withSelectFields(queryFields)
+            .withWhere('Id IN :rdIds')
+            .build();
+
+        for (npe03__Recurring_Donation__c rd : Database.query(soql)) {
+            oppsByRDId.put(rd.Id, rd.npe03__Donations__r);
+        }
+    
+        return oppsByRDId;
+    }
+
     /**
      * @description Returns query on Recurring Donation Schedule
      * Return all schedules for the RD Schedule visualization.

--- a/src/classes/RD2_OpportunityEvaluationService_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluationService_TEST.cls
@@ -207,7 +207,7 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
 
         List<Opportunity> opps = new List<Opportunity>{
-            getOpportunityBuilder(rdOld)
+            TEST_OpportunityBuilder.getOpportunityBuilder(rdOld)
                 .withMockId()
                 .withAccount(rdOld.npe03__Organization__c)
                 .withOpenStage()
@@ -300,7 +300,7 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
 
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
@@ -399,7 +399,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact()).build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withName()
             .withCloseDate(START_DATE.addMonths(1))
             .withClosedWonStage()
@@ -661,7 +661,7 @@ private class RD2_OpportunityEvaluationService_TEST {
 
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(today.addDays(1))
             .withOpenStage()
             .build();
@@ -701,7 +701,7 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(START_DATE)
             .withOpenStage()
             .build();
@@ -737,7 +737,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id).build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withName()
@@ -816,7 +816,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id).build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>();
         for (Integer i = 0; i < MONTHS_TO_YEAR_END + 2; i++) {
             oppBuilder = oppBuilder
@@ -865,7 +865,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id).build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>();
         for (Integer i = 0; i < MONTHS_TO_YEAR_END + 1; i++) {
             oppBuilder = oppBuilder
@@ -913,7 +913,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id).build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withName()
@@ -977,7 +977,7 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>();
 
         Date closeDate = startDate;
@@ -1025,7 +1025,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id).build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>();
         for (Integer i = 0; i < MONTHS_TO_YEAR_END + 2; i++) {
             oppBuilder = oppBuilder
@@ -1074,7 +1074,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id).build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withName()
@@ -1126,7 +1126,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id).build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd).withClosedWonStage();
         List<Opportunity> opps = new List<Opportunity>();
         for (Integer i = 0; i < MONTHS_TO_YEAR_END; i++) { //create closed own opps till the end of the year
             opps.add(oppBuilder
@@ -1208,7 +1208,7 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd).withClosedWonStage();
         List<Opportunity> opps = new List<Opportunity>();
 
         Date closeDate = startDate;
@@ -1273,7 +1273,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id).build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd).withClosedWonStage();
         List<Opportunity> opps = new List<Opportunity>();
         for (Integer i = 0; i < 2; i++) {
             opps.add(oppBuilder
@@ -1385,7 +1385,7 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd).withClosedWonStage();
         List<Opportunity> opps = new List<Opportunity>();
         for (Integer month = 1; month <= 3; month++) {
             opps.add(oppBuilder
@@ -1456,7 +1456,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact()).build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withName()
             .withCloseDate(START_DATE.addMonths(1))
             .withOpenStage()
@@ -1499,7 +1499,7 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd).withClosedWonStage();
         List<Opportunity> opps = new List<Opportunity>();
         for (Integer month = 0; month < paidInstallments; month++){
             opps.add(oppBuilder
@@ -1545,7 +1545,7 @@ private class RD2_OpportunityEvaluationService_TEST {
             .build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd).withClosedWonStage();
         List<Opportunity> opps = new List<Opportunity>();
 
         for (Integer month = 0; month < paidInstallments; month++){
@@ -1672,7 +1672,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         rd.npe03__Next_Payment_Date__c = today;
         update rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withName()
@@ -1728,7 +1728,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         rd.npe03__Next_Payment_Date__c = nextDonationDate;
         update rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withName()
@@ -1793,7 +1793,7 @@ private class RD2_OpportunityEvaluationService_TEST {
         rd.npe03__Next_Payment_Date__c = today;
         update rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withName()
@@ -1876,19 +1876,6 @@ private class RD2_OpportunityEvaluationService_TEST {
             FROM Contact
             LIMIT 1
         ];
-    }
-
-    /**
-     * @description Instantiate an Opp builder for the specified Recurring Donation
-     * @param rd Recurring Donation
-     * @return TEST_OpportunityBuilder New Opp builder
-     */
-    private static TEST_OpportunityBuilder getOpportunityBuilder(npe03__Recurring_Donation__c rd) {
-        return new TEST_OpportunityBuilder()
-            .withContact(rd.npe03__Contact__c)
-            .withRecurringDonation(rd.Id)
-            .withAmount(rd.npe03__Amount__c)
-            .withInstallmentNumber(1);
     }
 
     /**

--- a/src/classes/RD2_OpportunityEvaluation_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluation_TEST.cls
@@ -105,7 +105,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
             .build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withClosedWonStage()
             .withCloseDate(START_DATE)
             .build();
@@ -167,7 +167,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withOpenStage()
             .withCloseDate(today)
             .build();
@@ -199,7 +199,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withOpenStage()
             .withCloseDate(nextCloseDate)
             .build();
@@ -234,7 +234,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withName()
@@ -282,7 +282,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withClosedWonStage()
             .withCloseDate(prevCloseDate)
             .build();
@@ -345,7 +345,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
 
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withOpenStage()
             .withCloseDate(prevCloseDate)
             .build();
@@ -378,7 +378,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
 
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withOpenStage()
             .withCloseDate(prevCloseDate)
             .build();
@@ -417,7 +417,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
             .build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withClosedWonStage()
             .withCloseDate(prevCloseDate)
             .build();
@@ -506,7 +506,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withOpenStage()
             .withCloseDate(START_DATE)
             .build();
@@ -652,7 +652,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withInstallmentNumberMigrationFlag()
             .withClosedLostStage()
             .withCloseDate(nextCloseDate)
@@ -693,7 +693,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
         insert rd;
 
-        Opportunity opp = getOpportunityBuilder(rd)
+        Opportunity opp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withClosedLostStage()
             .withCloseDate(nextCloseDate)
             .build();
@@ -812,7 +812,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationBuilder().build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withClosedWonStage()
             .withCloseDate(START_DATE)
             .build();
@@ -845,7 +845,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
             .build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withClosedWonStage()
             .withCloseDate(startDate)
             .build();
@@ -881,7 +881,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
             .build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withClosedWonStage()
             .withCloseDate(startDate)
             .build();
@@ -917,7 +917,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
             .build();
         insert rd;
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withClosedWonStage()
             .withCloseDate(START_DATE)
             .build();
@@ -959,7 +959,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
             .build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd).withClosedWonStage();
         List<Opportunity> opps = new List<Opportunity>();
 
         for (Integer month = 0; month < plannedInstallments; month++){
@@ -1019,7 +1019,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         insert rd;
 
         List<Opportunity> opps = new List<Opportunity>();
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd).withClosedWonStage();
         for (Integer month = 0; month < paidInstallments; month++){
             opps.add(oppBuilder
                 .withName()
@@ -1069,7 +1069,7 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
         insert rd;
 
         List<Opportunity> opps = new List<Opportunity>();
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd).withClosedWonStage();
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd).withClosedWonStage();
         for (Integer month = 0; month < paidInstallments; month++){
             opps.add(oppBuilder
                 .withName()
@@ -1179,19 +1179,6 @@ public with sharing class RD2_OpportunityEvaluation_TEST {
             .withDayOfMonth('15')
             .withContact(getContact().Id)
             .withAmount(100);
-    }
-
-    /**
-     * @description Instantiate an Opp builder for the specified Recurring Donation
-     * @param rd Recurring Donation
-     * @return TEST_OpportunityBuilder New Opportunity builder
-     */
-    private static TEST_OpportunityBuilder getOpportunityBuilder(npe03__Recurring_Donation__c rd) {
-        return new TEST_OpportunityBuilder()
-            .withContact(rd.npe03__Contact__c)
-            .withRecurringDonation(rd.Id)
-            .withAmount(rd.npe03__Amount__c)
-            .withInstallmentNumber(1);
     }
 
     /****

--- a/src/classes/RD2_OpportunityService.cls
+++ b/src/classes/RD2_OpportunityService.cls
@@ -143,7 +143,9 @@ public with sharing class RD2_OpportunityService {
 
         Integer numberOfInstallments = 1;
         for (npe03__Recurring_Donation__c rd : rds) {
-            RD2_OpportunityMatcher.Record nextDonationDateRecord = scheduleService.getNextDonationDateRecord(rd, rd.RecurringDonationSchedules__r);
+            RD2_OpportunityMatcher.Record nextDonationDateRecord = scheduleService.getNextDonationDateRecord(
+                new RD2_RecurringDonation(rd), rd.RecurringDonationSchedules__r
+            );
 
             if (nextDonationDateRecord == null
                 || !nextDonationDateRecord.isNew()
@@ -256,11 +258,8 @@ public with sharing class RD2_OpportunityService {
             RD2_ScheduleService.Installment earliestUnmatchedInstallment;
 
             for (RD2_OpportunityMatcher.Record record : matcher.getRecords()) {
-                isOpenOppMatched = false;
 
-                if (record.hasInstallment() 
-                    && (record.isNew() || !record.getInstallment().isSkipped)
-                ) {
+                if (record.hasInstallment() && record.isNew()) {
                     earliestUnmatchedInstallment = getEarliestInstallment(record.getInstallment(), earliestUnmatchedInstallment);
                 }
 
@@ -269,7 +268,7 @@ public with sharing class RD2_OpportunityService {
                 }
 
                 Opportunity opp = record.getOpportunity();
-                if (record.hasInstallment() && !record.getInstallment().isSkipped) {
+                if (record.hasInstallment()) {
                     installmentByOppId.put(opp.Id, record.getInstallment());
                     isOpenOppMatched = true;
 
@@ -311,7 +310,7 @@ public with sharing class RD2_OpportunityService {
         Boolean isEarlier = earliestInstallment == null
             || currentInstallment.nextDonationDate < earliestInstallment.nextDonationDate;
 
-        if (isEarlier && !currentInstallment.isSkipped) {
+        if (isEarlier) {
             earliestInstallment = currentInstallment;
         }
 

--- a/src/classes/RD2_OpportunityService_TEST.cls
+++ b/src/classes/RD2_OpportunityService_TEST.cls
@@ -272,7 +272,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         //create an installment Opp since installment Opps are not created
         //due to async call to opp service
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
             .build();
@@ -306,7 +306,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation();
 
-        Opportunity opp = getOpportunityBuilder(rd)
+        Opportunity opp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
             .build();
@@ -342,7 +342,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation();
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(TODAY)
             .withOpenStage()
             .build();
@@ -376,7 +376,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation();
 
-        Opportunity opp = getOpportunityBuilder(rd)
+        Opportunity opp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(TODAY)
             .withClosedLostStage()
             .build();
@@ -415,7 +415,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation();
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withInstallmentNumber(1)
@@ -475,7 +475,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation();
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd)
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withOpenStage();
 
         List<Opportunity> opps = new List<Opportunity>{
@@ -529,7 +529,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation();
 
-        Opportunity opp = getOpportunityBuilder(rd)
+        Opportunity opp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCampaign(rd.npe03__Recurring_Donation_Campaign__c)
             .withCloseDate(CLOSE_DATE)
             .withClosedWonStage()
@@ -559,7 +559,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation();
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCampaign(rd.npe03__Recurring_Donation_Campaign__c)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
@@ -584,6 +584,54 @@ private with sharing class RD2_OpportunityService_TEST {
     }
 
     /***
+    * @description Verifies open Opp Close Date is correctly updated when
+    * the RD has a current/future closed Opp and a future open Opp
+    * and the RD Schedule is changed
+    */
+    @isTest
+    private static void shouldUpdateOpenOppCloseDateWhenClosedOppExistsAndRDScheduleIsModified() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_Settings_TEST.configureForASyncFirstOpportunityCreate();
+        setUpConfiguration();
+
+        npe03__Recurring_Donation__c rd = createRecurringDonation();
+
+        Date nextCloseDate = CLOSE_DATE.addMonths(1);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
+        List<Opportunity> opps = new List<Opportunity>{
+            oppBuilder
+                .withCloseDate(CLOSE_DATE)
+                .withClosedWonStage()
+                .build(),
+            oppBuilder
+                .withCloseDate(nextCloseDate)
+                .withOpenStage()
+                .build()
+        };
+        insert opps;
+
+        //update Day of Month on the RD
+        Integer newDayOfMonth = 3;
+        Date nextDonationDate = Date.newInstance(nextCloseDate.year(), nextCloseDate.month(), newDayOfMonth);
+
+        Test.startTest();
+        rd.Day_Of_Month__c = String.valueOf(newDayOfMonth);
+        rd.StartDate__c = nextDonationDate;
+        update rd;
+        Test.stopTest();
+
+        rd = rdGateway.getRecord(rd.Id);
+        System.assertEquals(nextDonationDate, rd.npe03__Next_Payment_Date__c, 
+            'Next Donation Date should be updated on the RD');
+
+        Map<Id, Opportunity> oppById = new Map<Id, Opportunity>(oppGateway.getRecords(rd));
+        System.assertEquals(2, oppById.size(),
+            'Number of expected Opps should match: ' + oppById.values());
+        System.assertEquals(nextDonationDate, oppById.get(opps[1].Id).CloseDate, 
+            'Close Date on the open Opp should be changed to the new Next Donation Date: ' + oppById.values());
+    }
+
+    /***
     * @description Verify Opportunity's campaign is updated when
     * there is update to the campaign on the RD
     * and add campaign is enabled in RD custom settings
@@ -596,7 +644,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation();
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCampaign(rd.npe03__Recurring_Donation_Campaign__c)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
@@ -629,7 +677,7 @@ private with sharing class RD2_OpportunityService_TEST {
         Id rdCampaignId = rd.npe03__Recurring_Donation_Campaign__c;
         System.assertNotEquals(null, rdCampaignId, 'Campaign Id should be set on the RD');
 
-        insert getOpportunityBuilder(rd)
+        insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCampaign(rdCampaignId)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
@@ -704,8 +752,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation(accts[0]);
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
-
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps =  new List<Opportunity>{
             oppBuilder
                 .withCloseDate(TODAY.addMonths(-2))
@@ -788,7 +835,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation(CURRENCY_CAD);
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withCurrencyIsoCode(CURRENCY_CAD)
@@ -820,7 +867,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation(CURRENCY_CAD);
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withCurrencyIsoCode(CURRENCY_CAD)
@@ -853,7 +900,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation(CURRENCY_CAD);
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withCurrencyIsoCode(CURRENCY_CAD)
@@ -898,7 +945,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation(CURRENCY_CAD);
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd);
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd);
         List<Opportunity> opps = new List<Opportunity>{
             oppBuilder
                 .withCurrencyIsoCode(CURRENCY_CAD)
@@ -1015,7 +1062,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation(acc);
 
-        Opportunity opp = getOpportunityBuilder(rd)
+        Opportunity opp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
             .build();
@@ -1055,7 +1102,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
         npe03__Recurring_Donation__c rd = createRecurringDonation(organizations[0]);
 
-        Opportunity opp = getOpportunityBuilder(rd)
+        Opportunity opp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
             .build();
@@ -1096,7 +1143,7 @@ private with sharing class RD2_OpportunityService_TEST {
             .build();
         insert rd;
 
-        Opportunity opp = getOpportunityBuilder(rd)
+        Opportunity opp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
             .build();
@@ -1143,7 +1190,7 @@ private with sharing class RD2_OpportunityService_TEST {
             .build();
         insert rd;
 
-        Opportunity opp = getOpportunityBuilder(rd)
+        Opportunity opp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCloseDate(CLOSE_DATE)
             .withOpenStage()
             .build();
@@ -1313,20 +1360,6 @@ private with sharing class RD2_OpportunityService_TEST {
             System.Label.npe03.RecurringDonationPrefix + ' (' +
             (rd.npe03__Total_Paid_Installments__c != null ? rd.npe03__Total_Paid_Installments__c + 1 : 1) + ') ' +
             closeDate.format();
-    }
-
-    /**
-     * @description Instantiate an Opportunity builder for the specified Recurring Donation
-     * @param rd Recurring Donation
-     * @return TEST_OpportunityBuilder New Opportunity builder
-     */
-    private static TEST_OpportunityBuilder getOpportunityBuilder(npe03__Recurring_Donation__c rd) {
-        return new TEST_OpportunityBuilder()
-            .withContact(rd.npe03__Contact__c)
-            .withRecurringDonation(rd.Id)
-            .withAccount(rd.npe03__Organization__c)
-            .withAmount(rd.npe03__Amount__c)
-            .withInstallmentNumber(1);
     }
 
     /***

--- a/src/classes/RD2_PauseForm_TEST.cls
+++ b/src/classes/RD2_PauseForm_TEST.cls
@@ -138,14 +138,9 @@ public with sharing class RD2_PauseForm_TEST {
 
         Integer totalSkipped = 4;
         Test.startTest();
-        RD2_PauseForm_CTRL.PauseData pause = new RD2_PauseForm_CTRL.PauseData();
-        pause.rdId = rd.Id;
-        pause.startDate = START_DATE.addMonths(3);
-        pause.resumeAfterDate = START_DATE.addMonths(6);
-        pause.pausedReason = new RD2_PauseForm_CTRL.PausedReason();
-        pause.pausedReason.value = PAUSED_REASON_VALUE;
-
-        RD2_PauseForm_CTRL.savePause(JSON.serialize(pause));
+        Date pauseStartDate = START_DATE.addMonths(3);
+        Date pauseEndDate = START_DATE.addMonths(6);
+        RD2_PauseForm_CTRL.PauseData pause = savePauseOnTheForm(rd.Id, pauseStartDate, pauseEndDate);
         Test.stopTest();
 
         List<RecurringDonationSchedule__c> pauseSchedules = getPauseSchedules(rd);
@@ -205,14 +200,9 @@ public with sharing class RD2_PauseForm_TEST {
         //Extend the pause for the next two months
         Integer totalSkipped = 4;
         Test.startTest();
-        RD2_PauseForm_CTRL.PauseData pause = new RD2_PauseForm_CTRL.PauseData();
-        pause.rdId = rd.Id;
-        pause.startDate = existingPause.StartDate__c.addMonths(2);
-        pause.resumeAfterDate = existingPause.EndDate__c.addMonths(2);
-        pause.pausedReason = new RD2_PauseForm_CTRL.PausedReason();
-        pause.pausedReason.value = PAUSED_REASON_VALUE;
-
-        RD2_PauseForm_CTRL.savePause(JSON.serialize(pause));
+        Date pauseStartDate = existingPause.StartDate__c.addMonths(2);
+        Date pauseEndDate = existingPause.EndDate__c.addMonths(2);
+        RD2_PauseForm_CTRL.PauseData pause = savePauseOnTheForm(rd.Id, pauseStartDate, pauseEndDate);
         Test.stopTest();
 
         Map<Id, RecurringDonationSchedule__c> pauseScheduleById = new Map<Id, RecurringDonationSchedule__c>(getPauseSchedules(rd));
@@ -246,14 +236,9 @@ public with sharing class RD2_PauseForm_TEST {
         // Pass in PauseData without setting Start and End Dates since
         // no installment is selected and the current pause is deactivated.
         Test.startTest();
-        RD2_PauseForm_CTRL.PauseData pause = new RD2_PauseForm_CTRL.PauseData();
-        pause.rdId = rd.Id;
-        pause.startDate = null;
-        pause.resumeAfterDate = null;
-        pause.pausedReason = new RD2_PauseForm_CTRL.PausedReason();
-        pause.pausedReason.value = PAUSED_REASON_VALUE;
-
-        RD2_PauseForm_CTRL.savePause(JSON.serialize(pause));
+        Date pauseStartDate = null;
+        Date pauseEndDate = null;
+        savePauseOnTheForm(rd.Id, pauseStartDate, pauseEndDate);
         Test.stopTest();
 
         Map<Id, RecurringDonationSchedule__c> pauseScheduleById = new Map<Id, RecurringDonationSchedule__c>(getPauseSchedules(rd));
@@ -280,7 +265,7 @@ public with sharing class RD2_PauseForm_TEST {
 
         npe03__Recurring_Donation__c rd = rdGateway.getRecords()[0];
 
-        Opportunity nextDonationOpp = getOpportunityBuilder(rd)
+        Opportunity nextDonationOpp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withOpenStage()
             .withCloseDate(nextDonationDate)
             .build();
@@ -288,15 +273,9 @@ public with sharing class RD2_PauseForm_TEST {
 
         Integer oppCount = 2;
         Integer totalSkipped = 3;
-        Test.startTest();
-        RD2_PauseForm_CTRL.PauseData pause = new RD2_PauseForm_CTRL.PauseData();
-        pause.rdId = rd.Id;
-        pause.startDate = nextDonationDate;
-        pause.resumeAfterDate = nextDonationDate.addMonths(2);
-        pause.pausedReason = new RD2_PauseForm_CTRL.PausedReason();
-        pause.pausedReason.value = PAUSED_REASON_VALUE;
 
-        RD2_PauseForm_CTRL.savePause(JSON.serialize(pause));
+        Test.startTest();
+        savePauseOnTheForm(rd.Id, nextDonationDate, nextDonationDate.addMonths(2));
         Test.stopTest();
 
         rd = rdGateway.getRecords()[0];
@@ -562,10 +541,130 @@ public with sharing class RD2_PauseForm_TEST {
         System.assertEquals(null, pause.pausedReason, 'The Paused Reason should not be initialized for a closed RD');
     }
 
+    /***
+    * @description Verifies the open Opp Close Date is correctly updated when
+    * the RD has a current/future closed Opp and a future open Opp
+    * and the Pause is modified
+    */
+    @isTest
+    private static void shouldUpdateOpenOppCloseDateWhenPauseIsModified() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ScheduleService.currentDate = START_DATE;
+
+        npe03__Recurring_Donation__c rd = rdGateway.getRecords()[0];
+
+        //skip second and third installments
+        Date pauseStartDate = START_DATE.addMonths(1);
+        Date pauseEndDate = pauseStartDate.addMonths(1);
+        RD2_ScheduleService_TEST.createPauseSchedule(rd.Id, pauseStartDate, pauseEndDate);
+
+        //Close the first Opp and create an open Opp after the pause ends
+        List<Opportunity> opps = oppGateway.getRecords(rd);
+        System.assertEquals(1, opps.size(), 'One Opp should exist: ' + opps);
+        opps[0].StageName = UTIL_UnitTestData_TEST.getClosedWonStage();
+        update opps[0];
+
+        Opportunity openOpp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
+            .withCloseDate(pauseEndDate.addMonths(1))
+            .withOpenStage()
+            .build();
+        insert openOpp;
+
+        opps = oppGateway.getRecords(rd);
+        System.assertEquals(2, opps.size(), 'Number of expected Opps should match: ' + opps);
+
+        //deselect the third installment and keep the second as paused
+        Test.startTest();
+        savePauseOnTheForm(rd.Id, pauseStartDate, pauseStartDate);
+        Test.stopTest();
+
+        rd = rdGateway.getRecord(rd.Id);
+        Date nextDonationDate = pauseStartDate.addMonths(1);
+        System.assertEquals(nextDonationDate, rd.npe03__Next_Payment_Date__c, 
+            'Next Donation Date should be the first installment after the pause');
+
+        Map<Id, Opportunity> oppById = new Map<Id, Opportunity>(oppGateway.getRecords(rd));
+        System.assertEquals(2, oppById.size(),
+            'Number of expected Opps should match: ' + oppById.values());
+        System.assertEquals(nextDonationDate, oppById.get(openOpp.Id).CloseDate, 
+            'Close Date on the open Opp should be changed to the new Next Donation Date');
+    }
+
+    /***
+    * @description Verifies the open Opp Close Date is correctly updated when
+    * the RD has a current/future closed Opp and a future open Opp
+    * and the Pause is deactivated
+    */
+    @isTest
+    private static void shouldUpdateOpenOppCloseDateWhenPauseIsDeactivated() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        RD2_ScheduleService.currentDate = START_DATE;
+
+        npe03__Recurring_Donation__c rd = rdGateway.getRecords()[0];
+
+        //skip second and third installments
+        Date pauseStartDate = START_DATE.addMonths(1);
+        Date pauseEndDate = pauseStartDate.addMonths(1);
+        RD2_ScheduleService_TEST.createPauseSchedule(rd.Id, pauseStartDate, pauseEndDate);
+
+        //Close the first Opp and create an open Opp after the pause ends
+        List<Opportunity> opps = oppGateway.getRecords(rd);
+        System.assertEquals(1, opps.size(), 'One Opp should exist: ' + opps);
+        opps[0].StageName = UTIL_UnitTestData_TEST.getClosedWonStage();
+        update opps[0];
+
+        Opportunity openOpp = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
+            .withCloseDate(pauseEndDate.addMonths(1))
+            .withOpenStage()
+            .build();
+        insert openOpp;
+
+        opps = oppGateway.getRecords(rd);
+        System.assertEquals(2, opps.size(), 'Number of expected Opps should match: ' + opps);
+
+        //deactivate the current pause
+        Test.startTest();
+        pauseStartDate = null;
+        pauseEndDate = null;
+        savePauseOnTheForm(rd.Id, pauseStartDate, pauseStartDate);
+        Test.stopTest();
+
+        rd = rdGateway.getRecord(rd.Id);
+        Date nextDonationDate = START_DATE.addMonths(1);
+        System.assertEquals(nextDonationDate, rd.npe03__Next_Payment_Date__c, 
+            'Next Donation Date should be the second installment date');
+
+        Map<Id, Opportunity> oppById = new Map<Id, Opportunity>(oppGateway.getRecords(rd));
+        System.assertEquals(2, oppById.size(),
+            'Number of expected Opps should match: ' + oppById.values());
+        System.assertEquals(nextDonationDate, oppById.get(openOpp.Id).CloseDate, 
+            'Close Date on the open Opp should be changed to the new Next Donation Date');
+    }
+
 
 
     //Helpers
     /////////////
+
+    /**
+     * @description Saves the pause
+     * @param rdId Recurring Donation Id
+     * @param pauseStartDate Pause Start Date
+     * @param pauseEndDate Pause End Date
+     * @return RD2_PauseForm_CTRL.PauseData
+     */
+    private static RD2_PauseForm_CTRL.PauseData savePauseOnTheForm(Id rdId, Date pauseStartDate, Date pauseEndDate) {
+        RD2_PauseForm_CTRL.PauseData pause = new RD2_PauseForm_CTRL.PauseData();
+        pause.rdId = rdId;
+        pause.startDate = pauseStartDate;
+        pause.resumeAfterDate = pauseEndDate;
+        pause.pausedReason = new RD2_PauseForm_CTRL.PausedReason();
+        pause.pausedReason.value = PAUSED_REASON_VALUE;
+
+        RD2_PauseForm_CTRL.savePause(JSON.serialize(pause));
+
+        return pause;
+    }
 
     /**
      * @description Retrieves pause data
@@ -659,19 +758,6 @@ public with sharing class RD2_PauseForm_TEST {
             .withPaymentMethod(PAYMENT_CHECK)
             .withDateEstablished(START_DATE)
             .withStartDate(START_DATE);
-    }
-
-    /**
-     * @description Instantiate an Opp builder for the specified Recurring Donation
-     * @param rd Recurring Donation
-     * @return TEST_OpportunityBuilder New Opportunity builder
-     */
-    private static TEST_OpportunityBuilder getOpportunityBuilder(npe03__Recurring_Donation__c rd) {
-        return new TEST_OpportunityBuilder()
-            .withContact(rd.npe03__Contact__c)
-            .withRecurringDonation(rd.Id)
-            .withAmount(rd.npe03__Amount__c)
-            .withInstallmentNumber(1);
     }
 
     /****

--- a/src/classes/RD2_RecurringDonation.cls
+++ b/src/classes/RD2_RecurringDonation.cls
@@ -57,6 +57,11 @@ public inherited sharing class RD2_RecurringDonation {
     }
 
     /**
+    * @description Recurring Donation record current and future Opportunities
+    */
+    List<Opportunity> opportunities = new List<Opportunity>();
+
+    /**
     * @description A list of the fields that have been changed by one of the revise methods.
     */
     private Set<Schema.SObjectField> changedFields = new Set<Schema.SObjectField>();
@@ -66,7 +71,28 @@ public inherited sharing class RD2_RecurringDonation {
     * @param rd Recurring Donation record
     */
     public RD2_RecurringDonation(npe03__Recurring_Donation__c rd) {
+        this(rd, rd.npe03__Donations__r);
+    }
+
+    /**
+    * @description Constructor
+    * @param rd Recurring Donation record
+    * @param opportunities Recurring Donation current and future Opportunities
+    */
+    public RD2_RecurringDonation(npe03__Recurring_Donation__c rd, List<Opportunity> opportunities) {
         this.rd = rd;
+
+        this.opportunities = opportunities == null 
+            ? new List<Opportunity>()
+            : opportunities;
+    }
+
+    /**
+    * @description Returns current and future Opportunities on the Recurring Donation
+    * @param List<Opportunity>
+    */
+    public List<Opportunity> getOpportunities() {
+        return this.opportunities;
     }
 
     /**
@@ -100,7 +126,7 @@ public inherited sharing class RD2_RecurringDonation {
     */
     public RD2_RecurringDonation reviseNextDonationDate(RD2_ScheduleService scheduleService, List<RecurringDonationSchedule__c> rdSchedules) {
         return setNextDonationDate(
-            scheduleService.getNextDonationDate(rd, rdSchedules)
+            scheduleService.getNextDonationDate(this, rdSchedules)
         );
     }
 
@@ -125,13 +151,13 @@ public inherited sharing class RD2_RecurringDonation {
     * @return RD2_RecurringDonation This record instance
     */
     public RD2_RecurringDonation reviseYearValues(RD2_YearValueProcessor processor) {
-        Decimal value = processor.calcCurrentYearValue(rd.npe03__Donations__r, rd.RecurringDonationSchedules__r);
+        Decimal value = processor.calcCurrentYearValue(opportunities, rd.RecurringDonationSchedules__r);
         if (value != rd.CurrentYearValue__c) {
             rd.CurrentYearValue__c = value;
             changedFields.add(npe03__Recurring_Donation__c.CurrentYearValue__c);
         }
 
-        value = processor.calcNextYearValue(rd.npe03__Donations__r, rd.RecurringDonationSchedules__r);
+        value = processor.calcNextYearValue(opportunities, rd.RecurringDonationSchedules__r);
         if (value != rd.NextYearValue__c) {
             rd.NextYearValue__c = value;
             changedFields.add(npe03__Recurring_Donation__c.NextYearValue__c);
@@ -382,7 +408,7 @@ public inherited sharing class RD2_RecurringDonation {
     */
     public Boolean isNew() {
         return isNew == null
-            ? rd.npe03__Donations__r.isEmpty()
+            ? opportunities.isEmpty()
             : isNew;
     }
 
@@ -393,7 +419,7 @@ public inherited sharing class RD2_RecurringDonation {
     */
     public Boolean hasCurrentOpenOpportunity(Date currentDate) {
         return new RD2_OpportunityMatcher(currentDate)
-            .includeCurrent(rd.npe03__Donations__r)
+            .includeCurrent(opportunities)
             .hasOpenOpportunity();
     }
 
@@ -402,7 +428,7 @@ public inherited sharing class RD2_RecurringDonation {
     * @return Boolean
     */
     public Boolean hasOpenOpportunity() {
-        for (Opportunity opp : rd.npe03__Donations__r) {
+        for (Opportunity opp : opportunities) {
             if (opp.IsClosed == false) {
                 return true;
             }

--- a/src/classes/RD2_RecurringDonationsOpp_TEST.cls
+++ b/src/classes/RD2_RecurringDonationsOpp_TEST.cls
@@ -69,7 +69,7 @@ private class RD2_RecurringDonationsOpp_TEST {
             .build();
         insert rd;
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd)
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withCurrencyIsoCode(CURRENCY_CAD);
         insert new List<Opportunity>{
             oppBuilder
@@ -259,7 +259,7 @@ private class RD2_RecurringDonationsOpp_TEST {
         Exception actualException;
         try {
             Test.startTest();
-            insert getOpportunityBuilder(rd)
+            insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
                 .withCurrencyIsoCode(CURRENCY_USD)
                 .withCloseDate(START_DATE)
                 .withOpenStage()
@@ -293,7 +293,7 @@ private class RD2_RecurringDonationsOpp_TEST {
         Exception actualException;
         try {
             Test.startTest();
-            insert getOpportunityBuilder(rd)
+            insert TEST_OpportunityBuilder.getOpportunityBuilder(rd)
                 .withCurrencyIsoCode(CURRENCY_CAD)
                 .withCloseDate(START_DATE)
                 .withOpenStage()
@@ -644,19 +644,6 @@ private class RD2_RecurringDonationsOpp_TEST {
 
         System.assert(false, 'The Recurring Donation should have Opportunity to return');
         return null;
-    }
-
-    /**
-     * @description Instantiate an Opp builder for the specified Recurring Donation
-     * @param rd Recurring Donation
-     * @return TEST_OpportunityBuilder New Opp builder
-     */
-    private static TEST_OpportunityBuilder getOpportunityBuilder(npe03__Recurring_Donation__c rd) {
-        return new TEST_OpportunityBuilder()
-            .withContact(rd.npe03__Contact__c)
-            .withRecurringDonation(rd.Id)
-            .withAmount(rd.npe03__Amount__c)
-            .withInstallmentNumber(1);
     }
 
     /**

--- a/src/classes/RD2_RecurringDonations_TDTM.cls
+++ b/src/classes/RD2_RecurringDonations_TDTM.cls
@@ -163,23 +163,25 @@ public class RD2_RecurringDonations_TDTM extends TDTM_Runnable {
             return;
         }
 
-        Map<Id, npe03__Recurring_Donation__c> oldRdsById = triggerAction == TDTM_Runnable.Action.BeforeUpdate
-            ? new Map<Id, npe03__Recurring_Donation__c>(oldRds)
-            : new Map<Id, npe03__Recurring_Donation__c>();
+        Map<Id, npe03__Recurring_Donation__c> oldRdsById = new Map<Id, npe03__Recurring_Donation__c>();
+        Map<Id, List<Opportunity>> oppsByRDId = new Map<Id, List<Opportunity>>();
+        Map<Id, List<RecurringDonationSchedule__c>> schedulesByRdId = new Map<Id, List<RecurringDonationSchedule__c>>();
+        
+        if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
+            oldRdsById = new Map<Id, npe03__Recurring_Donation__c>(oldRds);
+            oppsByRDId = new RD2_OpportunityEvaluationService().getOpportunitiesByRDId(UTIL_SObject.extractIds(rds));
+            schedulesByRdId = scheduleService.getAllSchedules(rds, oldRds);
+        }
 
-        Map<Id, List<RecurringDonationSchedule__c>> schedulesByRdId = triggerAction == TDTM_Runnable.Action.BeforeUpdate
-            ? scheduleService.getAllSchedules(rds, oldRds)
-            : new Map<Id, List<RecurringDonationSchedule__c>>();
-
-        for (npe03__Recurring_Donation__c rd : rds) {
-            RD2_RecurringDonation rdRecord = new RD2_RecurringDonation(rd)
-                .revisePlannedInstallments();
-
+        for (npe03__Recurring_Donation__c rd : rds) { 
             if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
-                rdRecord.reviseNextDonationDateBeforeInsert(scheduleService);
+                RD2_RecurringDonation rdRecord = new RD2_RecurringDonation(rd)
+                    .revisePlannedInstallments()
+                    .reviseNextDonationDateBeforeInsert(scheduleService);
 
-            } else if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
-                rdRecord
+            } else if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {                
+                RD2_RecurringDonation rdRecord = new RD2_RecurringDonation(rd, oppsByRDId.get(rd.Id))
+                    .revisePlannedInstallments()
                     .reviseStatus(currentDate)
                     .reviseNextDonationDate(scheduleService, schedulesByRdId.get(rd.Id));
 
@@ -205,6 +207,25 @@ public class RD2_RecurringDonations_TDTM extends TDTM_Runnable {
         }
 
         npe03__Recurring_Donation__c rd = rdRecord.getSObject();
+        List<String> changedFields = getFieldsChangingSchedule(rd, oldRd);
+
+        if (!changedFields.isEmpty() && scheduleService.pauseHandler.hasActivePause(schedules, currentDate)) {
+            rd.addError(
+                String.format(
+                    System.Label.RD2_PauseCannotExistOnScheduleChange,
+                    new String[]{ String.join(changedFields, ', ') }
+                )
+            );
+        }
+    }
+
+    /***
+    * @description Get changed fields on the RD that impact schedule date change
+    * @param rd The Recurring Donation to validate
+    * @param oldRd The old Recurring Donation
+    * @return List<String>
+    */
+    private List<String> getFieldsChangingSchedule(npe03__Recurring_Donation__c rd, npe03__Recurring_Donation__c oldRd) {
         List<String> changedFields = new List<String>();
 
         if (rd.npe03__Installment_Period__c != oldRd.npe03__Installment_Period__c) {
@@ -217,18 +238,7 @@ public class RD2_RecurringDonations_TDTM extends TDTM_Runnable {
             changedFields.add(SObjectType.npe03__Recurring_Donation__c.fields.Day_of_Month__c.getLabel());
         }
 
-        if (changedFields.isEmpty()) {
-            return;
-        }
-
-        if (scheduleService.pauseHandler.hasActivePause(schedules, currentDate)) {
-            rd.addError(
-                String.format(
-                    System.Label.RD2_PauseCannotExistOnScheduleChange,
-                    new String[]{ String.join(changedFields, ', ') }
-                )
-            );
-        }
+        return changedFields;
     }
 
     /***
@@ -418,10 +428,15 @@ public class RD2_RecurringDonations_TDTM extends TDTM_Runnable {
             Map<Id, npe03__Recurring_Donation__c> oldRdsById = new Map<Id, npe03__Recurring_Donation__c>(oldRds);
 
             for (npe03__Recurring_Donation__c rd : rds) {
-                if (evalService.hasKeyFieldChanged(rd, oldRdsById.get(rd.Id))) {
+                npe03__Recurring_Donation__c oldRd = oldRdsById.get(rd.Id);
+
+                if (evalService.hasKeyFieldChanged(rd, oldRd)) {
                     rdIds.add(rd.Id);
                 }
-                if (rd.npe03__Next_Payment_Date__c != oldRdsById.get(rd.Id).npe03__Next_Payment_Date__c) {
+
+                if (rd.npe03__Next_Payment_Date__c != oldRd.npe03__Next_Payment_Date__c 
+                    || !getFieldsChangingSchedule(rd, oldRd).isEmpty()
+                ) {
                     rdIdsWhereScheduleChanged.add(rd.Id);
                 }
             }

--- a/src/classes/RD2_ScheduleService.cls
+++ b/src/classes/RD2_ScheduleService.cls
@@ -456,17 +456,17 @@ public without sharing class RD2_ScheduleService {
     * @return Date
     */
     public Date getNextDonationDate(npe03__Recurring_Donation__c rd) {
-        return getNextDonationDate(rd, buildNewSchedules(rd));
+        return getNextDonationDate(new RD2_RecurringDonation(rd), buildNewSchedules(rd));
     }
 
     /***
     * @description Calculates the date of the next donation for an existing Recurring Donation
-    * @param rd Recurring Donation record
+    * @param rdRecord Recurring Donation record
     * @param rdSchedules Schedules on the Recurring Donation record
     * @return Date
     */
-    public Date getNextDonationDate(npe03__Recurring_Donation__c rd, List<RecurringDonationSchedule__c> rdSchedules) {
-        RD2_OpportunityMatcher.Record record = getNextDonationDateRecord(rd, rdSchedules);
+    public Date getNextDonationDate(RD2_RecurringDonation rdRecord, List<RecurringDonationSchedule__c> rdSchedules) {
+        RD2_OpportunityMatcher.Record record = getNextDonationDateRecord(rdRecord, rdSchedules);
 
         return record != null && record.getInstallment() != null
             ? record.getInstallment().nextDonationDate
@@ -476,12 +476,11 @@ public without sharing class RD2_ScheduleService {
     /***
     * @description Calculates the date of the next donation and returns the Opportunity matcher record
     * that contains the next donation installment and might contain the matching open Opportunity.
-    * @param rd Recurring Donation record
+    * @param rdRecord Recurring Donation record
     * @param rdSchedules Schedules on the Recurring Donation record
     * @return RD2_OpportunityMatcher.Record
     */
-    public RD2_OpportunityMatcher.Record getNextDonationDateRecord(npe03__Recurring_Donation__c rd, List<RecurringDonationSchedule__c> rdSchedules) {
-        RD2_RecurringDonation rdRecord = new RD2_RecurringDonation(rd);
+    public RD2_OpportunityMatcher.Record getNextDonationDateRecord(RD2_RecurringDonation rdRecord, List<RecurringDonationSchedule__c> rdSchedules) {
 
         if (rdSchedules == null || rdSchedules.isEmpty()
             || rdRecord.isClosed()
@@ -493,7 +492,7 @@ public without sharing class RD2_ScheduleService {
         evaluateScheduleEndDate(rdRecord, rdSchedules);
 
         RD2_OpportunityMatcher matcher = new RD2_OpportunityMatcher(currentDate)
-            .includeCurrent(rd.npe03__Donations__r);
+            .includeCurrent(rdRecord.getOpportunities());
 
         Integer numberOfInstallments = matcher.getNumberOfOpportunities() + 1;
         matcher.match(getVisualizedInstallments(
@@ -857,10 +856,10 @@ public without sharing class RD2_ScheduleService {
     public void evaluateScheduleEndDateForFixedLength(RD2_RecurringDonation rdRecord, List<RecurringDonationSchedule__c> rdSchedules) {
         Integer plannedInstallments = rdRecord.getPlannedInstallments();
         Integer paidInstallments = rdRecord.getPaidInstallments();
-        Integer estimatedOpenSlots = plannedInstallments - paidInstallments + rdRecord.getSobject().npe03__Donations__r.size();
+        Integer estimatedOpenSlots = plannedInstallments - paidInstallments + rdRecord.getOpportunities().size();
 
         List<RD2_OpportunityMatcher.Record> records = new RD2_OpportunityMatcher(currentDate)
-            .include(rdRecord.getSobject().npe03__Donations__r)
+            .include(rdRecord.getOpportunities())
             .match(
                 getVisualizedInstallments(currentDate, estimatedOpenSlots, rdSchedules)
             )

--- a/src/classes/RD2_ScheduleService_TEST.cls
+++ b/src/classes/RD2_ScheduleService_TEST.cls
@@ -1230,7 +1230,7 @@ public with sharing class RD2_ScheduleService_TEST {
 
         System.assertEquals(scheduleEndDate, rdSchedules[0].EndDate__c, 'The End Date should be set');
 
-        Date nextDonationDate = service.getNextDonationDate(rd, rdSchedules);
+        Date nextDonationDate = service.getNextDonationDate(new RD2_RecurringDonation(rd), rdSchedules);
         System.assertEquals(startDate, nextDonationDate, 
             'The Next Donation Date should be the first installment Opp Close Date');
     }
@@ -1258,7 +1258,7 @@ public with sharing class RD2_ScheduleService_TEST {
             .withPaidInstallments(paidInstallments)
             .build();
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd)
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withMockId()
             .withClosedWonStage();
 
@@ -1280,7 +1280,7 @@ public with sharing class RD2_ScheduleService_TEST {
 
         System.assertEquals(scheduleEndDate, rdSchedules[0].EndDate__c, 'The End Date should be set');
 
-        Date nextDonationDate = service.getNextDonationDate(rd, rdSchedules);
+        Date nextDonationDate = service.getNextDonationDate(new RD2_RecurringDonation(rd), rdSchedules);
         System.assertEquals(scheduleEndDate, nextDonationDate, 
             'The Next Donation Date should be the same as the schedule end date');
     }
@@ -1309,7 +1309,7 @@ public with sharing class RD2_ScheduleService_TEST {
             .withPaidInstallments(paidInstallments)
             .build();
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd)
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withClosedLostStage()
             .withMockId();
 
@@ -1342,7 +1342,7 @@ public with sharing class RD2_ScheduleService_TEST {
 
         System.assertEquals(scheduleEndDate, rdSchedules[0].EndDate__c, 'The End Date should be set');
 
-        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd, rdSchedules), 
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(new RD2_RecurringDonation(rd), rdSchedules), 
             'The Next Donation Date should be the next installment Next Donation Date');
     }
 
@@ -1369,7 +1369,7 @@ public with sharing class RD2_ScheduleService_TEST {
             .withPaidInstallments(paidInstallments)
             .build();
 
-        TEST_OpportunityBuilder oppBuilder = getOpportunityBuilder(rd)
+        TEST_OpportunityBuilder oppBuilder = TEST_OpportunityBuilder.getOpportunityBuilder(rd)
             .withMockId()
             .withClosedWonStage();
 
@@ -1402,7 +1402,7 @@ public with sharing class RD2_ScheduleService_TEST {
         System.assertEquals(scheduleEndDate, rdSchedules[0].EndDate__c, 
             'The End Date should be the last planned Opp Close Date');
 
-        Date nextDonationDate = service.getNextDonationDate(rd, rdSchedules);
+        Date nextDonationDate = service.getNextDonationDate(new RD2_RecurringDonation(rd), rdSchedules);
         System.assertEquals(null, nextDonationDate, 
             'The Next Donation Date should be empty when number of planned installments has been reached');
     }
@@ -1461,7 +1461,7 @@ public with sharing class RD2_ScheduleService_TEST {
 
         System.assertEquals(nextDonationDate, rd.RecurringDonationSchedules__r[0].EndDate__c,
             'The schedule end date should be set to the next installment after the current Opp is Closed Lost');
-        System.assertEquals(nextDonationDate, service.getNextDonationDate(rd, rdSchedules), 
+        System.assertEquals(nextDonationDate, service.getNextDonationDate(new RD2_RecurringDonation(rd), rdSchedules), 
             'The Next Donation Date should be the next installment Next Donation Date');
     }
 
@@ -1517,7 +1517,7 @@ public with sharing class RD2_ScheduleService_TEST {
 
         System.assertEquals(Date.newInstance(2020, plannedInstallments + 1, 1), rd.RecurringDonationSchedules__r[0].EndDate__c,
             'The schedule end date should be moved one month forward since one Opp is Closed Lost');
-        System.assertEquals(opps[4].CloseDate, service.getNextDonationDate(rd, rdSchedules), 
+        System.assertEquals(opps[4].CloseDate, service.getNextDonationDate(new RD2_RecurringDonation(rd), rdSchedules), 
             'The Next Donation Date should be the first open Opp installment');
     }
 
@@ -2198,19 +2198,6 @@ public with sharing class RD2_ScheduleService_TEST {
         RD2_ScheduleService.currentDate = currentDate;
 
         return new RD2_ScheduleService();
-    }
-
-    /**
-     * @description Instantiate an Opp builder for the specified Recurring Donation
-     * @param rd Recurring Donation
-     * @return TEST_OpportunityBuilder New Opp builder
-     */
-    private static TEST_OpportunityBuilder getOpportunityBuilder(npe03__Recurring_Donation__c rd) {
-        return new TEST_OpportunityBuilder()
-            .withContact(rd.npe03__Contact__c)
-            .withRecurringDonation(rd.Id)
-            .withAmount(rd.npe03__Amount__c)
-            .withInstallmentNumber(1);
     }
 
     /**

--- a/src/classes/TEST_OpportunityBuilder.cls
+++ b/src/classes/TEST_OpportunityBuilder.cls
@@ -300,6 +300,20 @@ public without sharing class TEST_OpportunityBuilder {
     }
 
     /**
+     * @description Instantiate an Opportunity builder for the specified Recurring Donation
+     * @param rd Recurring Donation
+     * @return TEST_OpportunityBuilder New Opportunity builder
+     */
+    public static TEST_OpportunityBuilder getOpportunityBuilder(npe03__Recurring_Donation__c rd) {
+        return new TEST_OpportunityBuilder()
+            .withContact(rd.npe03__Contact__c)
+            .withRecurringDonation(rd.Id)
+            .withAccount(rd.npe03__Organization__c)
+            .withAmount(rd.npe03__Amount__c)
+            .withInstallmentNumber(1);
+    }
+
+    /**
      * @description Sets IsClosed and IsWon fields where applicable for specified Opportunities
      * @param opps Opportunities
      * @return void

--- a/src/classes/TEST_RecurringDonationBuilder.cls
+++ b/src/classes/TEST_RecurringDonationBuilder.cls
@@ -524,7 +524,8 @@ public without sharing class TEST_RecurringDonationBuilder {
     }
 
     /***
-    * @description Tell the build process to call the getNextDonationDate() method in the ScheduleService
+    * @description Tell the build process to call the ScheduleService method
+    * to calculate the Next Donation Date on the Recurring Donation
     * @return TEST_RecurringDonationBuilder Builder instance
     */
     public TEST_RecurringDonationBuilder withCalculateNextDonationDate() {


### PR DESCRIPTION
When "Day of Month", "Installment Frequency" and/or "Installment Period" is updated on a Recurring Donation having a closed current/future Opportunity and an open Opportunity, then the open Opportunity Close Date should be updated to the Next Donation Date value.

# Critical Changes

# Changes

# Issues Closed
- Fixes #5750 

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
