### PR TITLE
handle when there are no default batch table columns selected

### DIFF
--- a/src/lwc/geTemplateBuilder/geTemplateBuilder.js
+++ b/src/lwc/geTemplateBuilder/geTemplateBuilder.js
@@ -311,7 +311,9 @@ export default class geTemplateBuilder extends NavigationMixin(LightningElement)
             this.batchHeaderFields = formTemplate.batchHeaderFields;
             this.formLayout = formTemplate.layout;
             this.formSections = this.formLayout.sections;
-            this.selectedBatchTableColumnOptions = formTemplate.defaultBatchTableColumns;
+
+            this.selectedBatchTableColumnOptions = isEmpty(formTemplate.defaultBatchTableColumns) ?
+                [] : formTemplate.defaultBatchTableColumns;
 
             this.catalogFieldsForTemplateEdit();
         }


### PR DESCRIPTION
# Critical Changes

# Changes
When a field is deleted on the default GE template before any batch table columns are configured, it will no longer throw a component error

# Issues Closed
#5663 

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
