### PR TITLE
Fixing flakiness on remove affiliations testcase

### DIFF
--- a/robot/Cumulus/tests/browser/1_batch_gift_entry/create_new_account_and_payment.robot
+++ b/robot/Cumulus/tests/browser/1_batch_gift_entry/create_new_account_and_payment.robot
@@ -13,17 +13,16 @@ Suite Teardown  Delete Records and Close Browser
 
 Create a new account and enter payment information
     #Create a new account and enter payment information, then process batch
-    [tags]  unstable
     ${ns} =  Get NPSP Namespace Prefix
-    &{batch} =       API Create DataImportBatch    
-    ...    ${ns}Batch_Process_Size__c=50    
-    ...    ${ns}Batch_Description__c=Created via API    
-    ...    ${ns}Donation_Matching_Behavior__c=Single Match or Create    
-    ...    ${ns}Donation_Matching_Rule__c=donation_amount__c;donation_date__c    
-    ...    ${ns}RequireTotalMatch__c=false    
-    ...    ${ns}Run_Opportunity_Rollups_while_Processing__c=true   
-    ...    ${ns}GiftBatch__c=true    
-    ...    ${ns}Active_Fields__c=[{"label":"Donation Amount","name":"${ns}Donation_Amount__c","sObjectName":"Opportunity","defaultValue":null,"required":true,"hide":false,"sortOrder":0,"type":"number","options":null},{"label":"Donation Date","name":"${ns}Donation_Date__c","sObjectName":"Opportunity","defaultValue":null,"required":false,"hide":false,"sortOrder":1,"type":"date","options":null}]     
+    &{batch} =       API Create DataImportBatch
+    ...    ${ns}Batch_Process_Size__c=50
+    ...    ${ns}Batch_Description__c=Created via API
+    ...    ${ns}Donation_Matching_Behavior__c=Single Match or Create
+    ...    ${ns}Donation_Matching_Rule__c=donation_amount__c;donation_date__c
+    ...    ${ns}RequireTotalMatch__c=false
+    ...    ${ns}Run_Opportunity_Rollups_while_Processing__c=true
+    ...    ${ns}GiftBatch__c=true
+    ...    ${ns}Active_Fields__c=[{"label":"Donation Amount","name":"${ns}Donation_Amount__c","sObjectName":"Opportunity","defaultValue":null,"required":true,"hide":false,"sortOrder":0,"type":"number","options":null},{"label":"Donation Date","name":"${ns}Donation_Date__c","sObjectName":"Opportunity","defaultValue":null,"required":false,"hide":false,"sortOrder":1,"type":"date","options":null}]
     Go To Page                        Listing                      Batch_Gift_Entry
     Click Link With Text    ${batch}[Name]
     Wait For Locator    bge.title    Batch Gift Entry
@@ -37,14 +36,14 @@ Create a new account and enter payment information
     Select Record Type         Organization
     Populate Form
     ...                        Account Name=${acc_name}
-    Click Modal Button         Save    
+    Click Modal Button         Save
     Wait Until Modal Is Closed
     Fill BGE Form
     ...                       Donation Amount=20
     Select Date From Datepicker    Donation Date    Today
     Click BGE Button       Save
     Wait For Locator    bge.title    Batch Gift Entry
-    Verify Row Count    1 
+    Verify Row Count    1
     Wait For Locator    bge.edit_button    Donation Amount
     SeleniumLibrary.Element Text Should Be    //td[@data-label="Donation"]//lightning-formatted-url    ${Empty}
     Click BGE Button       Process Batch
@@ -59,7 +58,7 @@ Create a new account and enter payment information
     ${opp_name}    Return Locator Value    check_field_spl    Opportunity
     Click Link    ${opp_name}
     Current Page Should Be    Details    Opportunity
-    ${opp_id} =           Save Current Record ID For Deletion      Opportunity  
+    ${opp_id} =           Save Current Record ID For Deletion      Opportunity
     Select Tab    Details
     Navigate To And Validate Field Value    Amount    contains    $20.00
     ${opp_date} =     Get Current Date    result_format=%-m/%-d/%Y

--- a/robot/Cumulus/tests/browser/affiliations/remove_primary_affiliation.robot
+++ b/robot/Cumulus/tests/browser/affiliations/remove_primary_affiliation.robot
@@ -32,7 +32,7 @@ Remove Primary Affiliation for Contact
     [Documentation]                   Creates a contact, organization account and primary affiliation via API
     ...                               Open contact and delete affiliation from organization affiliation related list
     ...                               Verifies that contact does not show under affiliated contacts in the account page
-    [tags]                            unstable                     W-037651                     feature:Affiliations
+    [tags]                            W-037651                     feature:Affiliations
     Go To Page                        Details                      Contact                 object_id=${contact1}[Id]
     Select Tab                        Related
     Click Related Item Popup Link     Organization Affiliations    ${account1}[Name]       Delete
@@ -48,7 +48,7 @@ Remove Primary Affiliation for Contact2
     ...                               Edit Primary Affiliation field and delete affiliation to organization account.
     ...                               Verifies that affiliation to account shows under organization affiliation as former
     ...                               Verifies that on account page contact shows under affiliated contacts as former
-    [tags]                            W-037651                     feature:Affiliations    unstable
+    [tags]                            W-037651                     feature:Affiliations
     Go To Page                        Details                      Contact                 object_id=${contact2}[Id]
     Select Tab                        Details
     Delete Record Field Value         Primary Affiliation          ${account2}[Name]

--- a/robot/Cumulus/tests/browser/affiliations/remove_primary_affiliation.robot
+++ b/robot/Cumulus/tests/browser/affiliations/remove_primary_affiliation.robot
@@ -38,6 +38,7 @@ Remove Primary Affiliation for Contact
     Click Related Item Popup Link     Organization Affiliations    ${account1}[Name]       Delete
     Wait For Modal                    New                          Affiliation             expected_heading=Delete Affiliation
     Click Modal Button                Delete
+    Wait Until Modal Is Closed
     Go To Page                        Details                      Account                 object_id=${account1}[Id]
     Select Tab                        Related
     Verify Related List               Affiliated Contacts          does not contain        ${contact1}[FirstName] ${contact1}[LastName]

--- a/robot/Cumulus/tests/browser/affiliations/remove_secondary_affiliation.robot
+++ b/robot/Cumulus/tests/browser/affiliations/remove_secondary_affiliation.robot
@@ -30,6 +30,7 @@ Remove Secondary Affiliation for Contact
     Click Related Item Popup Link     Organization Affiliations    ${account}[Name]        Delete
     Wait For Modal                    New                          Affiliation             expected_heading=Delete Affiliation
     Click Modal Button                Delete
+    Wait Until Modal Is Closed
     Go To Page                        Details                      Account                 object_id=${account}[Id]
     Select Tab                        Related
     Verify Related List               Affiliated Contacts          does not contain        ${contact}[FirstName] ${contact}[LastName]

--- a/robot/Cumulus/tests/browser/affiliations/remove_secondary_affiliation.robot
+++ b/robot/Cumulus/tests/browser/affiliations/remove_secondary_affiliation.robot
@@ -24,7 +24,7 @@ Remove Secondary Affiliation for Contact
     [Documentation]                   Creates a contact, organization account and secondary affiliation via API
     ...                               Open contact and delete affiliation from organization affiliation related list
     ...                               Verifies that contact does not show under affiliated contacts in the account page
-    [tags]                            unstable                     W-037651                feature:Affiliations
+    [tags]                            W-037651                feature:Affiliations
     Go To Page                        Details                      Contact                 object_id=${contact}[Id]
     Select Tab                        Related
     Click Related Item Popup Link     Organization Affiliations    ${account}[Name]        Delete

--- a/robot/Cumulus/tests/browser/levels/create_edit_delete_level.robot
+++ b/robot/Cumulus/tests/browser/levels/create_edit_delete_level.robot
@@ -131,7 +131,7 @@ Create and edit level to verify fields
 
 3. Delete a Level
     [Documentation]                      Delete the Level from the levels listing page
-    [tags]                                  unstable    W-038641                 feature:Level
+    [tags]                                  W-038641                 feature:Level
 
     Go To Page                              Details
     ...                                     Level__c

--- a/robot/Cumulus/tests/browser/levels/create_edit_delete_level.robot
+++ b/robot/Cumulus/tests/browser/levels/create_edit_delete_level.robot
@@ -136,8 +136,12 @@ Create and edit level to verify fields
     Go To Page                              Details
     ...                                     Level__c
     ...                                     object_id=${level_id}
+    Wait Until Loading Is Complete
+    Current Page Should be                  Details    Level__c
     Click Show More Actions Button          Delete
+    Wait Until Modal Is Open
     Click Modal Button                      Delete
+    Wait Until Modal Is Closed
     Go To Page                              Details
     ...                                     Contact
     ...                                     object_id=${data}[contact][Id]


### PR DESCRIPTION
fixing flakiness for remove primary, secondary affiliations and delete level. Moving a BGE test to stable as the Summer20 issue for New Account/New Contact lookup option is fixed.
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
