### PR TITLE
Update link to invalid help text mappings docs

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -10245,7 +10245,7 @@ Selecting Don't Auto Schedule Default NPSP Jobs tells NPSP not to check for or r
             &lt;b&gt;This message won't be displayed if you leave this page! Take a screenshot of this page or copy the information in the table below to track the Help Text mappings you need correct. &lt;/b&gt;
             &lt;br/&gt;
             &lt;br/&gt;
-            We couldn't convert some of your existing Help Text mappings because they're invalid. &lt;a href=&quot;https://powerofus.force.com//NPSP_Help_Text_Mapping&quot; target=&quot;_blank&quot;&gt;Read more about common Help Text mapping issues&lt;/a&gt;. We recommend disabling Advanced Mapping, correcting the invalid Help Text mappings, then re-enabling Advanced Mapping. Alternatively, you could add these mappings when you configure Advanced Mapping on the next screen, but these additional mappings will revert to the original invalid Help Text if you disable Advanced Mapping.
+            We couldn't convert some of your existing Help Text mappings because they're invalid. &lt;a href=&quot;https://powerofus.force.com/NPSP_Troubleshoot_Help_Text&quot; target=&quot;_blank&quot;&gt;Read more about common Help Text mapping issues&lt;/a&gt;. We recommend disabling Advanced Mapping, correcting the invalid Help Text mappings, then re-enabling Advanced Mapping. Alternatively, you could add these mappings when you configure Advanced Mapping on the next screen, but these additional mappings will revert to the original invalid Help Text if you disable Advanced Mapping.
         </value>
     </labels>
     <labels>


### PR DESCRIPTION
# Critical Changes

# Changes
When an admin receives the invalid help text mapping after enabling advanced mapping in NPSP Settings, the link that directs user to troubleshooting invalid help text mappings will now redirect to a different URL.

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
