### PR TITLE
Remove reference to unpackaged OppPayment Payment_Status__c field

### DIFF
--- a/unpackaged/config/trial/permissionsets/Gift_Entry.permissionset
+++ b/unpackaged/config/trial/permissionsets/Gift_Entry.permissionset
@@ -976,11 +976,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>npe01__OppPayment__c.%%%NAMESPACE%%%Payment_Status__c</field>
-        <readable>false</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>npe5__Affiliation__c.%%%NAMESPACE%%%Contact_Link__c</field>
         <readable>false</readable>
     </fieldPermissions>


### PR DESCRIPTION
Remove a reference to the unmanaged Payment_Status__c field on OppPayment in the Gift Entry permissionset

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
