### PR TITLE
RD2: Disable First Installment When Field Checked 

### DIFF
--- a/src/classes/RD2_OpportunityEvaluationService.cls
+++ b/src/classes/RD2_OpportunityEvaluationService.cls
@@ -241,6 +241,7 @@ public inherited sharing class RD2_OpportunityEvaluationService {
         String.valueOf(npe03__Recurring_Donation__c.CommitmentId__c),
         String.valueOf(npe03__Recurring_Donation__c.CurrentYearValue__c),
         String.valueOf(npe03__Recurring_Donation__c.Day_of_Month__c),
+        String.valueOf(npe03__Recurring_Donation__c.DisableFirstInstallment__c),
         String.valueOf(npe03__Recurring_Donation__c.EndDate__c),
         String.valueOf(npe03__Recurring_Donation__c.InstallmentFrequency__c),
         String.valueOf(npe03__Recurring_Donation__c.NextYearValue__c),
@@ -492,7 +493,7 @@ public inherited sharing class RD2_OpportunityEvaluationService {
             return !rdSettings.isDisableAllInstallments;
 
         } else if (rd.isNew()) {
-            return rdSettings.isFirstInstallmentEnabled;
+            return !rd.isFirstInstallmentDisabled() && rdSettings.isFirstInstallmentEnabled;
 
         } else if (!rd.hasCurrentOpenOpportunity(currentDate)) {
             return rdSettings.isNextInstallmentEnabled;

--- a/src/classes/RD2_OpportunityEvaluationService_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluationService_TEST.cls
@@ -1864,8 +1864,8 @@ private class RD2_OpportunityEvaluationService_TEST {
     }
 
     /**
-    * @description Verifies that when Disable First Installment is true,
-    *   No installment will be created on RD insert regardless of NPSP Installment Auto Creation Setting
+    * @description Verifies no Opportunity is created when "Disable First Installment" on RD is true,
+    * and the org setting NPSP Installment Auto Creation is "Always Create Next Installment".
     */
     @IsTest
     private static void shouldNotCreateFirstInstallmentWhenDisableFirstInstallmentIsTrue() {
@@ -1887,8 +1887,8 @@ private class RD2_OpportunityEvaluationService_TEST {
         List<Opportunity> opportunities = oppGateway.getRecords(rd);
 
         System.assert(rd.DisableFirstInstallment__c, 'Disable First Installment should be true');
-        System.assertEquals(0, opportunities.size(),
-            'No opportunity should be create when DisableFirstInstallment__c is true');
+        System.assert(opportunities.isEmpty(),
+            'No Opportunity should be created when the Disable First Installment is true');
     }
 
     // Helpers

--- a/src/classes/RD2_OpportunityEvaluationService_TEST.cls
+++ b/src/classes/RD2_OpportunityEvaluationService_TEST.cls
@@ -1863,6 +1863,34 @@ private class RD2_OpportunityEvaluationService_TEST {
         
     }
 
+    /**
+    * @description Verifies that when Disable First Installment is true,
+    *   No installment will be created on RD insert regardless of NPSP Installment Auto Creation Setting
+    */
+    @IsTest
+    private static void shouldNotCreateFirstInstallmentWhenDisableFirstInstallmentIsTrue() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        RD2_Settings_TEST.setUpConfiguration(new Map<String, Object> {
+            'InstallmentOppAutoCreateOption__c' => OPTION_NAME_ALWAYS_CREATE_NEXT
+        });
+
+        npe03__Recurring_Donation__c rd = getRecurringDonationBuilder(getContact().Id)
+            .withFirstInstallmentDisabled()
+            .build();
+
+        Test.startTest();
+        insert rd;
+        Test.stopTest();
+
+        rd = rdGateway.getRecord(rd.Id);
+        List<Opportunity> opportunities = oppGateway.getRecords(rd);
+
+        System.assert(rd.DisableFirstInstallment__c, 'Disable First Installment should be true');
+        System.assertEquals(0, opportunities.size(),
+            'No opportunity should be create when DisableFirstInstallment__c is true');
+    }
+
     // Helpers
     ///////////////////
 

--- a/src/classes/RD2_RecurringDonation.cls
+++ b/src/classes/RD2_RecurringDonation.cls
@@ -413,6 +413,14 @@ public inherited sharing class RD2_RecurringDonation {
     }
 
     /**
+    * @description Indicates if the Recurring Donation has first installment creation disabled.
+    * @return Boolean 
+    */
+    public Boolean isFirstInstallmentDisabled() {
+        return rd.DisableFirstInstallment__c == true;
+    }
+
+    /**
     * @description Indicates if the Recurring Donation has an open Opportunity with Close Date >= current date
     * @param currentDate The current date
     * @return Boolean

--- a/src/classes/TEST_RecurringDonationBuilder.cls
+++ b/src/classes/TEST_RecurringDonationBuilder.cls
@@ -534,6 +534,16 @@ public without sharing class TEST_RecurringDonationBuilder {
         return this;
     }
 
+    /***
+    * @description Set DisableFirstInstallment field to true. This field is by default false.
+    * @return TEST_RecurringDonationBuilder Builder instance
+    */
+    public TEST_RecurringDonationBuilder withFirstInstallmentDisabled() {
+        validateMode(Mode.Enhanced);
+        valuesByFieldName.put('DisableFirstInstallment__c', true);
+        return this;
+    }
+
     /**
     * @description Configure the RD with the appropriate default values based on the mode
     */
@@ -549,7 +559,6 @@ public without sharing class TEST_RecurringDonationBuilder {
 
         return this;
     }
-
 
     /***
     * @description Builds Recurring Donation sObject based on the provided values

--- a/src/classes/TEST_SObjectGateway.cls
+++ b/src/classes/TEST_SObjectGateway.cls
@@ -97,6 +97,7 @@ public class TEST_SObjectGateway {
                     npe03__Paid_Amount__c,
                     npe03__Date_Established__c,
                     Day_of_Month__c,
+                    DisableFirstInstallment__c,
                     StartDate__c,
                     EndDate__c,
                     npe03__Next_Payment_Date__c,

--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -265,7 +265,17 @@
             </valueSetDefinition>
         </valueSet>
     </fields>
-        <fields>
+    <fields>
+        <fullName>DisableFirstInstallment__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Prevents creation of the first installment Opportunity for a new Recurring Donation, regardless of the Installment Opportunity Auto-Creation setting in NPSP Settings.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Prevents creation of the first installment Opportunity for a new Recurring Donation, regardless of the Installment Opportunity Auto-Creation setting in NPSP Settings.</inlineHelpText>
+        <label>Disable First Installment</label>
+        <trackFeedHistory>false</trackFeedHistory>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>EndDate__c</fullName>
         <description>After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed.</description>
         <externalId>false</externalId>

--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -272,7 +272,8 @@
         <externalId>false</externalId>
         <inlineHelpText>Prevents creation of the first installment Opportunity for a new Recurring Donation, regardless of the Installment Opportunity Auto-Creation setting in NPSP Settings.</inlineHelpText>
         <label>Disable First Installment</label>
-        <trackFeedHistory>false</trackFeedHistory>
+        <trackHistory>false</trackHistory>
+        <trackTrending>false</trackTrending>
         <type>Checkbox</type>
     </fields>
     <fields>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1193,8 +1193,8 @@
         <members>Engagement_Plan__c.Total_EP_Tasks__c</members>
         <members>Engagement_Plan__c.Total_Tasks__c</members>
         <members>Error_Settings__c.Async_Error_Check_Last_Run__c</members>
-        <members>Error_Settings__c.Disable_Error_Handling__c</members>
         <members>Error_Settings__c.DisableRecordDataHealthChecks__c</members>
+        <members>Error_Settings__c.Disable_Error_Handling__c</members>
         <members>Error_Settings__c.Don_t_Auto_Schedule_Default_NPSP_Jobs__c</members>
         <members>Error_Settings__c.Enable_Debug__c</members>
         <members>Error_Settings__c.Error_Notifications_On__c</members>
@@ -1431,6 +1431,7 @@
         <members>npe03__Recurring_Donation__c.CommitmentId__c</members>
         <members>npe03__Recurring_Donation__c.CurrentYearValue__c</members>
         <members>npe03__Recurring_Donation__c.Day_of_Month__c</members>
+        <members>npe03__Recurring_Donation__c.DisableFirstInstallment__c</members>
         <members>npe03__Recurring_Donation__c.EndDate__c</members>
         <members>npe03__Recurring_Donation__c.InstallmentFrequency__c</members>
         <members>npe03__Recurring_Donation__c.NextYearValue__c</members>

--- a/unpackaged/config/rd2_post_config/profiles/Admin.profile
+++ b/unpackaged/config/rd2_post_config/profiles/Admin.profile
@@ -44,6 +44,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>npe03__Recurring_Donation__c.%%%NAMESPACE%%%DisableFirstInstallment__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>npe03__Recurring_Donation__c.%%%NAMESPACE%%%EndDate__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/config/rd2_post_config/profiles/Standard.profile
+++ b/unpackaged/config/rd2_post_config/profiles/Standard.profile
@@ -44,6 +44,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>npe03__Recurring_Donation__c.%%%NAMESPACE%%%DisableFirstInstallment__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>npe03__Recurring_Donation__c.%%%NAMESPACE%%%EndDate__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
As an admin using integrations, I want to select which RDs have their first Opportunities created, on a per-record basis, so that I can handle different import scenarios.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata
- Custom Field: 
    - npe03__Recurring_Donation__c.DisableFirstInstallment__c

# Deleted Metadata
