### PR TITLE
remove reference to GE_Template class blocking regression orgs

### DIFF
--- a/unpackaged/config/qa/permissionsets/Gift_Entry.permissionset
+++ b/unpackaged/config/qa/permissionsets/Gift_Entry.permissionset
@@ -30,10 +30,6 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
-        <apexClass>%%%NAMESPACE%%%GE_Template</apexClass>
-        <enabled>true</enabled>
-    </classAccesses>
-    <classAccesses>
         <apexClass>%%%NAMESPACE%%%GE_GiftEntryController</apexClass>
         <enabled>true</enabled>
     </classAccesses>


### PR DESCRIPTION
Removes a reference the GE_Template class not available when assembling regression orgs

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
