### PR TITLE
W-8066576 - Elevate - Donor Cover (2 of 3)

### DIFF
--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -454,6 +454,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
                     'Payment_Card_Expiration_Year',
                     'Payment_Card_Last_4',
                     'Payment_Card_Network',
+                    'Payment_Donor_Cover_Amount',
                     'Payment_Elevate_Created_Date',
                     'Payment_Elevate_Created_UTC_Timestamp',
                     'Payment_Elevate_ID',


### PR DESCRIPTION
[W-8066576](https://gus.my.salesforce.com/a07B0000008cykaIAA) Elevate - Donor Cover (2 of 3) - Update NPSP install script to push new object and field mappings.

- How to Test this:

1) Activate Advanced Mapping
2) Go to Setup > Custom Metadata Types > Data Import Object Mapping > Manage Records
2) Verify new migrated Payment object got created and also verify that 19 Data Field Mapping Records got created for that obect
3) Manually delete "Payment Donor Cover Amount" field mapping - You should have 18 data field mapping records now
4) Execute on Dev Console: 
`
List<String> newDefaultMappingStrings = new List<String>{          
    'Payment_Donor_Cover_Amount'
};
BDI_MigrationMappingHelper helper = new BDI_MigrationMappingHelper();
BDI_MigrationMappingUtility util = new BDI_MigrationMappingUtility(helper);
util.migrateNewDefaultToCustomMetadata(newDefaultMappingStrings);
`
5) Verify that a new field mapping record got created. You should have 19 data field mappings for the migrated Payment data object mapping.
6) Execute same script - verify that no new or duplicated fields got created.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
