### PR TITLE
RD2: Prevent a Canceled Elevate RD from being re-activated

### DIFF
--- a/src/classes/RD2_ElevateIntegrationService.cls
+++ b/src/classes/RD2_ElevateIntegrationService.cls
@@ -120,6 +120,22 @@ public inherited sharing class RD2_ElevateIntegrationService {
         return !isChanged;
     }
 
+    /***
+     * @description Determines whether an Elevate Recurring Donation is changing from Closed to some other state
+     * @param rd Changed Recurring Donation
+     * @param oldRd Old Recurring Donation
+     * @return Boolean true if RD Status is changing from Closed to another state on an Elevate RD
+     */
+    public Boolean isElevateStatusChangeFromClosed(npe03__Recurring_Donation__c rd, npe03__Recurring_Donation__c oldRd) {
+        if (String.isNotBlank(oldRd.CommitmentId__c)
+            && new RD2_RecurringDonation(oldRd).isClosed()
+            && !new RD2_RecurringDonation(rd).isClosed()
+        ) {
+            return true;
+        }
+        return false;
+    }
+
     /**
     * @description For each CommitmentId, find any existing Opportunities with the matching Commitmentid
     * and update the RecuringDonation lookup field (only if null).

--- a/src/classes/RD2_ElevateIntegrationService.cls
+++ b/src/classes/RD2_ElevateIntegrationService.cls
@@ -141,22 +141,6 @@ public inherited sharing class RD2_ElevateIntegrationService {
         return isReactivated;
     }
 
-    /***
-     * @description Determines whether an Elevate Recurring Donation is changing from Closed to some other state
-     * @param rd Changed Recurring Donation
-     * @param oldRd Old Recurring Donation
-     * @return Boolean true if RD Status is changing from Closed to another state on an Elevate RD
-     */
-    public Boolean isElevateStatusChangeFromClosed(npe03__Recurring_Donation__c rd, npe03__Recurring_Donation__c oldRd) {
-        if (String.isNotBlank(oldRd.CommitmentId__c)
-            && new RD2_RecurringDonation(oldRd).isClosed()
-            && !new RD2_RecurringDonation(rd).isClosed()
-        ) {
-            return true;
-        }
-        return false;
-    }
-
     /**
     * @description For each CommitmentId, find any existing Opportunities with the matching Commitmentid
     * and update the RecuringDonation lookup field (only if null).

--- a/src/classes/RD2_ElevateIntegrationService.cls
+++ b/src/classes/RD2_ElevateIntegrationService.cls
@@ -121,6 +121,27 @@ public inherited sharing class RD2_ElevateIntegrationService {
     }
 
     /***
+     * @description Determines whether an Elevate Recurring Donation is changing from closed state to another state
+     * @param rd Changed Recurring Donation
+     * @param oldRd Old Recurring Donation
+     * @return Boolean
+     */
+    public Boolean isElevateRecordReactivated(npe03__Recurring_Donation__c rd, npe03__Recurring_Donation__c oldRd) {
+        if (!isIntegrationEnabled()) {
+            return false;
+        }
+
+        RD2_RecurringDonation rdRecord = new RD2_RecurringDonation(rd);
+        RD2_RecurringDonation oldRDRecord = new RD2_RecurringDonation(oldRd);
+
+        Boolean isReactivated = oldRDRecord.isElevateRecord()
+            && oldRDRecord.isClosed()
+            && !rdRecord.isClosed();
+
+        return isReactivated;
+    }
+
+    /***
      * @description Determines whether an Elevate Recurring Donation is changing from Closed to some other state
      * @param rd Changed Recurring Donation
      * @param oldRd Old Recurring Donation

--- a/src/classes/RD2_ElevateIntegrationService_TEST.cls
+++ b/src/classes/RD2_ElevateIntegrationService_TEST.cls
@@ -124,7 +124,7 @@ public class RD2_ElevateIntegrationService_TEST {
 
         RD2_ElevateIntegrationService service = new RD2_ElevateIntegrationService();
 
-        System.assertEquals(true, service.isElevateStatusChangeFromClosed(rd, oldRd),
+        System.assertEquals(true, service.isElevateRecordReactivated(rd, oldRd),
             'Elevate RD Status update should not be permitted when Status is Closed');
     }
 
@@ -145,7 +145,7 @@ public class RD2_ElevateIntegrationService_TEST {
 
         RD2_ElevateIntegrationService service = new RD2_ElevateIntegrationService();
 
-        System.assertEquals(false, service.isElevateStatusChangeFromClosed(rd, oldRd),
+        System.assertEquals(false, service.isElevateRecordReactivated(rd, oldRd),
             'RD Status update should be permitted when Status is Closed for Non Elevate RD');
     }
 

--- a/src/classes/RD2_ElevateIntegrationService_TEST.cls
+++ b/src/classes/RD2_ElevateIntegrationService_TEST.cls
@@ -108,6 +108,48 @@ public class RD2_ElevateIntegrationService_TEST {
     }
 
     /***
+    * @description Verifies user is prevented from updating the Status of an Elevate RD when
+    * the state of the RD is Closed
+    */
+    @isTest
+    private static void shouldPreventElevateRDStatusUpdateWhenStatusClosed() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        enableElevateUserPermissions();
+
+        npe03__Recurring_Donation__c oldRd = getElevateRecurringDonationBaseBuilder()
+            .withStatus(RD2_Constants.STATUS_CLOSED)
+            .build();
+        npe03__Recurring_Donation__c rd = oldRd.clone();
+        rd.Status__c = RD2_Constants.STATUS_ACTIVE;
+
+        RD2_ElevateIntegrationService service = new RD2_ElevateIntegrationService();
+
+        System.assertEquals(true, service.isElevateStatusChangeFromClosed(rd, oldRd),
+            'Elevate RD Status update should not be permitted when Status is Closed');
+    }
+
+    /***
+    * @description Verifies user is permitted to update the Status of a non-Elevate RD when
+    * the state of the RD is Closed
+    */
+    @isTest
+    private static void shouldAllowNonElevateRDUpdateWhenStateClosed() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        enableElevateUserPermissions();
+
+        npe03__Recurring_Donation__c oldRd = getRecurringDonationBaseBuilder()
+            .withStatus(RD2_Constants.STATUS_CLOSED)
+            .build();
+        npe03__Recurring_Donation__c rd = oldRd.clone();
+        rd.Status__c = RD2_Constants.STATUS_ACTIVE;
+
+        RD2_ElevateIntegrationService service = new RD2_ElevateIntegrationService();
+
+        System.assertEquals(false, service.isElevateStatusChangeFromClosed(rd, oldRd),
+            'RD Status update should be permitted when Status is Closed for Non Elevate RD');
+    }
+
+    /***
     * @description Verifies user can update an RD originated in Elevate when
     * integration is enabled and user does not have permissions assigned
     * but the changed RD field is unrestricted (unlocked) field

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -193,8 +193,8 @@ public with sharing class RD2_ValidationService {
             npe03__Recurring_Donation__c rd = rds[i];
             npe03__Recurring_Donation__c oldRd = oldRds[i];
 
-            if (elevateService.isElevateStatusChangeFromClosed(rd, oldRd)) {
-                rd.addError(System.Label.RD2_ElevateClosedStatusChangeError);
+            if (elevateService.isElevateRecordReactivated(rd, oldRd)) {
+                rd.addError(System.Label.RD2_ElevateRDClosedStatusCannotBeChanged);
                 continue;
             }
 

--- a/src/classes/RD2_ValidationService.cls
+++ b/src/classes/RD2_ValidationService.cls
@@ -193,6 +193,11 @@ public with sharing class RD2_ValidationService {
             npe03__Recurring_Donation__c rd = rds[i];
             npe03__Recurring_Donation__c oldRd = oldRds[i];
 
+            if (elevateService.isElevateStatusChangeFromClosed(rd, oldRd)) {
+                rd.addError(System.Label.RD2_ElevateClosedStatusChangeError);
+                continue;
+            }
+
             if (!elevateService.hasUpdatePermissions(rd, oldRd)) {
                 rd.addError(System.Label.RD2_ElevatePermissionRequired);
                 continue;

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1602,14 +1602,6 @@
         <value>&lt;b&gt;WARNING: You have Enhanced Recurring Donations enabled. If you disable Customizable Rollups, rollups to Recurring Donations will no longer function.&lt;/b&gt;</value>
     </labels>
     <labels>
-        <fullName>RD2_ElevateClosedStatusChangeError</fullName>
-        <categories>Recurring-Donations, Error</categories>
-        <language>en_US</language>
-        <protected>true</protected>
-        <shortDescription>Error when an attempt is made to change the Status of a Closed Elevate RD</shortDescription>
-        <value>You can&apos;t edit the Status for an Elevate connected Recurring Donation when Status is Closed</value>
-    </labels>
-    <labels>
         <fullName>RD2_ElevatePermissionRequired</fullName>
         <categories>Recurring-Donations, Error</categories>
         <language>en_US</language>
@@ -1632,6 +1624,14 @@
         <protected>true</protected>
         <shortDescription>Status Reason to indicates Elevate Service is in progress.</shortDescription>
         <value>Pending Elevate Process</value>
+    </labels>
+    <labels>
+        <fullName>RD2_ElevateRDClosedStatusCannotBeChanged</fullName>
+        <categories>Recurring-Donations, Error</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Error when an attempt is made to change the Status of a Closed Elevate RD</shortDescription>
+        <value>You can&apos;t edit the Status for an Elevate connected Recurring Donation when Status is Closed</value>
     </labels>
     <labels>
         <fullName>RD2_EnablementDisabledHeader</fullName>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1602,6 +1602,14 @@
         <value>&lt;b&gt;WARNING: You have Enhanced Recurring Donations enabled. If you disable Customizable Rollups, rollups to Recurring Donations will no longer function.&lt;/b&gt;</value>
     </labels>
     <labels>
+        <fullName>RD2_ElevateClosedStatusChangeError</fullName>
+        <categories>Recurring-Donations, Error</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Error when an attempt is made to change the Status of a Closed Elevate RD</shortDescription>
+        <value>You can&apos;t edit the Status for an Elevate connected Recurring Donation when Status is Closed</value>
+    </labels>
+    <labels>
         <fullName>RD2_ElevatePermissionRequired</fullName>
         <categories>Recurring-Donations, Error</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1667,6 +1667,7 @@
         <members>RD2_DayOfMonthIsRequiredForMonthlyInstallment</members>
         <members>RD2_DayOfMonthMustBeValid</members>
         <members>RD2_DisableCustomizableRollupWarning</members>
+        <members>RD2_ElevateClosedStatusChangeError</members>
         <members>RD2_ElevateNotSupported</members>
         <members>RD2_ElevatePendingStatus</members>
         <members>RD2_ElevatePermissionRequired</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1667,10 +1667,10 @@
         <members>RD2_DayOfMonthIsRequiredForMonthlyInstallment</members>
         <members>RD2_DayOfMonthMustBeValid</members>
         <members>RD2_DisableCustomizableRollupWarning</members>
-        <members>RD2_ElevateClosedStatusChangeError</members>
         <members>RD2_ElevateNotSupported</members>
         <members>RD2_ElevatePendingStatus</members>
         <members>RD2_ElevatePermissionRequired</members>
+        <members>RD2_ElevateRDClosedStatusCannotBeChanged</members>
         <members>RD2_EnablementDisabledHeader</members>
         <members>RD2_EnablementDisabledMessage</members>
         <members>RD2_EnablementDryRunBatchTitle</members>


### PR DESCRIPTION
We prohibited re-activating a Recurring Donation linked to Elevate.

# Critical Changes

# Changes
 - To preserve data integrity with Elevate, you can't edit the Status for an Elevate connected Recurring Donation when Status is Closed.

# Issues Closed

# Community Ideas Delivered

# New Metadata
- Custom Label:
    - RD2_ElevateRDClosedStatusCannotBeChanged

# Deleted Metadata
