### PR TITLE
RD2: Handle Cancel and Save buttons on save/error

### DIFF
--- a/src/classes/RD2_EntryFormController.cls
+++ b/src/classes/RD2_EntryFormController.cls
@@ -138,7 +138,7 @@ public with sharing class RD2_EntryFormController {
      * @return True if the User has Read access to all required fields in the UI
      */
     @AuraEnabled(cacheable=true)
-    public static Boolean checkRequiredFieldPermissions() {
+    public static Boolean hasRequiredFieldPermissions() {
         Set<String> requiredFields = new Set<String>{
             'npe03__Amount__c',
             'npe03__Contact__c',
@@ -149,17 +149,17 @@ public with sharing class RD2_EntryFormController {
             UTIL_Namespace.StrTokenNSPrefix('StartDate__c')
         };
 
-        Boolean isMissingRequiredPermissions = true;
+        Boolean hasPermissions = true;
 
         for (String fld : requiredFields) {
             DescribeFieldResult dfr = UTIL_Describe.getFieldDescribe('npe03__Recurring_Donation__c', fld);
             if (!dfr.isAccessible()) {
-                isMissingRequiredPermissions = false;
+                hasPermissions = false;
                 break;
             }
         }
 
-        return isMissingRequiredPermissions;
+        return hasPermissions;
     }
 
     /**
@@ -281,7 +281,7 @@ public with sharing class RD2_EntryFormController {
     }
 
     /***
-    * @description Creates Elevate Commitment and 
+    * @description Creates Elevate Commitment and
     * updates the Recurring Donation with returned Commitment data
     * @param recordId Recurring Donation Id
     * @param jsonRequestBody JSON containing parameters for the purchase call request body
@@ -290,18 +290,18 @@ public with sharing class RD2_EntryFormController {
     @AuraEnabled
     public static String createCommitment(Id recordId, String jsonRequestBody) {
         UTIL_Http.Response response;
-        
+
         try {
             response = sendCommitmentRequest(jsonRequestBody);
 
             if (response.statusCode == UTIL_Http.STATUS_CODE_CREATED) {
-                // If the commitment is created, then update RD fields: 
+                // If the commitment is created, then update RD fields:
                 // Commitment Id, credit card expiry date and last 4.
 
-                // Ensure DML error (if any) on the RD update is returned to the LWC 
+                // Ensure DML error (if any) on the RD update is returned to the LWC
                 // as a response or an AuraHandled exception (either will work).
-            }        
-        
+            }
+
         } catch (Exception ex) {
             response = requestService.buildErrorResponse(ex);
 

--- a/src/classes/RD2_EntryFormController_TEST.cls
+++ b/src/classes/RD2_EntryFormController_TEST.cls
@@ -44,7 +44,7 @@ private with sharing class RD2_EntryFormController_TEST {
     @TestSetup
     private static void setUp() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
-        
+
         Contact c = UTIL_UnitTestData_TEST.getContact();
         insert c;
 
@@ -84,7 +84,7 @@ private with sharing class RD2_EntryFormController_TEST {
     }
 
     /***
-    * @description Verifies whether the org is the Elevate customer 
+    * @description Verifies whether the org is the Elevate customer
     * in order to display the Elevate credit card widget if so.
     */
     @isTest
@@ -103,7 +103,7 @@ private with sharing class RD2_EntryFormController_TEST {
     }
 
     /***
-    * @description Verifies whether the org is the Elevate customer 
+    * @description Verifies whether the org is the Elevate customer
     * in order to display the Elevate credit card widget if so.
     */
     @isTest
@@ -175,9 +175,9 @@ private with sharing class RD2_EntryFormController_TEST {
      * @description Validate that the System Admin User reports that they have the required field permissions
      */
     @IsTest
-    private static void shouldValidateUserHasPermissions() {
-        Boolean hasPerms = RD2_EntryFormController.checkRequiredFieldPermissions();
-        System.assert(hasPerms, 'Should determine that the Admin User has all permissions');
+    private static void shouldReturnTrueWhenUserHasPermissions() {
+        Boolean hasPerms = RD2_EntryFormController.hasRequiredFieldPermissions();
+        System.assertEquals(true, hasPerms, 'The Admin User shoud have permissions');
     }
 
     /**
@@ -185,7 +185,9 @@ private with sharing class RD2_EntryFormController_TEST {
      * are missing the required field permissions
      */
     @IsTest
-    private static void shouldValidateUserMissingPermissions() {
+    private static void shouldReturnFalseWhenUserIsMissingPermissions() {
+        User stdUser = UTIL_UnitTestData_TEST.createStandardProfileUser();
+
         Id stdProfileId = [SELECT Id FROM Profile WHERE Name = :UTIL_Profile.PROFILE_STANDARD_USER LIMIT 1].Id;
 
         FieldPermissions fldPerm = [
@@ -198,15 +200,16 @@ private with sharing class RD2_EntryFormController_TEST {
         fldPerm.PermissionsEdit = false;
         update fldPerm;
 
-        User roUser = UTIL_UnitTestData_TEST.createStandardProfileUser();
-        System.runAs(roUser) {
-            Boolean hasPerms = RD2_EntryFormController.checkRequiredFieldPermissions();
-            System.assert(!hasPerms, 'Should determine that the Standard User is missing permissions');
+        Test.startTest();
+        System.runAs(stdUser) {
+            Boolean hasPerms = RD2_EntryFormController.hasRequiredFieldPermissions();
+            System.assertEquals(false, hasPerms, 'The Standard User should be missing permissions');
         }
+        Test.stopTest();
     }
 
     /***
-    * @description Verifies that Entry Form Controller excluded all NPSP packaged field and predefined excluded fields 
+    * @description Verifies that Entry Form Controller excluded all NPSP packaged field and predefined excluded fields
     */
     @isTest
     private static void shouldReturnRD2CustomFieldsWithoutNPSPNameSpaceAndExcludedFields() {
@@ -225,10 +228,10 @@ private with sharing class RD2_EntryFormController_TEST {
     }
 
     /***
-    * @description Verifies Commitment Request Body is built as expected 
+    * @description Verifies Commitment Request Body is built as expected
     */
     @isTest
-    private static void shouldReturnCommitmentRequestBody() {        
+    private static void shouldReturnCommitmentRequestBody() {
         Id recordId = rdGateway.getRecords()[0].Id;
         final String paymentMethodToken = 'token-abcd-efgh-ijkl-mnop-qrst';
 
@@ -240,14 +243,14 @@ private with sharing class RD2_EntryFormController_TEST {
         );
 
         System.assertNotEquals(null, requestBody, 'The Commitment request body should be converted successfully');
-        System.assertEquals(paymentMethodToken, requestBody.paymentMethodToken, 'The payment token should match');        
+        System.assertEquals(paymentMethodToken, requestBody.paymentMethodToken, 'The payment token should match');
     }
 
     /***
     * @description Verifies Commitment response is created upon successful creation
     */
     @isTest
-    private static void shouldReturnResponseWhenCommitmentIsCreated() {     
+    private static void shouldReturnResponseWhenCommitmentIsCreated() {
         PS_IntegrationService.setConfiguration(PS_IntegrationServiceConfig_TEST.testConfig);
 
         Id recordId = rdGateway.getRecords()[0].Id;
@@ -267,8 +270,8 @@ private with sharing class RD2_EntryFormController_TEST {
         Test.stopTest();
 
         System.assertNotEquals(null, response, 'The Commitment response should be returned');
-        System.assertEquals(UTIL_Http.STATUS_CODE_CREATED, response.statusCode, 
-            'The response status code should match: ' + response);        
+        System.assertEquals(UTIL_Http.STATUS_CODE_CREATED, response.statusCode,
+            'The response status code should match: ' + response);
     }
 
 }

--- a/src/classes/RD2_EntryFormController_TEST.cls
+++ b/src/classes/RD2_EntryFormController_TEST.cls
@@ -177,7 +177,7 @@ private with sharing class RD2_EntryFormController_TEST {
     @IsTest
     private static void shouldReturnTrueWhenUserHasPermissions() {
         Boolean hasPerms = RD2_EntryFormController.hasRequiredFieldPermissions();
-        System.assertEquals(true, hasPerms, 'The Admin User shoud have permissions');
+        System.assertEquals(true, hasPerms, 'The Admin User should have permissions');
     }
 
     /**

--- a/src/lwc/rd2EntryForm/rd2EntryForm.html
+++ b/src/lwc/rd2EntryForm/rd2EntryForm.html
@@ -161,16 +161,14 @@
             </div>
         </div>
         <footer class="slds-modal__footer slds-clearfix">
-            <template if:true={isSettingReady}>
-                <div class="slds-float_right">
-                    <lightning-button label={customLabels.cancelButtonLabel} title={customLabels.cancelButtonLabel}
-                        variant="neutral" class="slds-m-right_small" onclick={handleCancel} disabled={isLoading}>
-                    </lightning-button>
-                    <lightning-button label={customLabels.saveButtonLabel} title={customLabels.saveButtonLabel}
-                        variant="brand" onclick={handleSubmit} data-id="submitButton">
-                    </lightning-button>
-                </div>
-            </template>
+            <div class="slds-float_right">
+                <lightning-button label={customLabels.cancelButtonLabel} title={customLabels.cancelButtonLabel}
+                    variant="neutral" class="slds-m-right_small" onclick={handleCancel} disabled={isLoading}>
+                </lightning-button>
+                <lightning-button label={customLabels.saveButtonLabel} title={customLabels.saveButtonLabel}
+                    variant="brand" onclick={handleSubmit} data-id="submitButton" disabled={isSaveButtonDisabled}>
+                </lightning-button>
+            </div>
         </footer>
 
     </lightning-record-edit-form>

--- a/src/lwc/rd2EntryForm/rd2EntryForm.html
+++ b/src/lwc/rd2EntryForm/rd2EntryForm.html
@@ -90,7 +90,7 @@
                                         <label for="currencyField"
                                             class="slds-form-element__label slds-no-flex">{fields.currency.label}</label>
                                         <lightning-input-field id="currencyField" data-id="currencyField"
-                                            field-name={fields.currency.apiName} variant="label-hidden" 
+                                            field-name={fields.currency.apiName} variant="label-hidden"
                                             required onchange={handleCurrencyChange}>
                                         </lightning-input-field>
                                     </div>
@@ -161,14 +161,16 @@
             </div>
         </div>
         <footer class="slds-modal__footer slds-clearfix">
-            <div class="slds-float_right">
-                <lightning-button label={customLabels.cancelButtonLabel} title={customLabels.cancelButtonLabel}
-                    variant="neutral" class="slds-m-right_small" onclick={handleCancel}>
-                </lightning-button>
-                <lightning-button label={customLabels.saveButtonLabel} title={customLabels.saveButtonLabel}
-                    variant="brand" onclick={handleSubmit} data-id="submitButton">
-                </lightning-button>
-            </div>
+            <template if:true={isSettingReady}>
+                <div class="slds-float_right">
+                    <lightning-button label={customLabels.cancelButtonLabel} title={customLabels.cancelButtonLabel}
+                        variant="neutral" class="slds-m-right_small" onclick={handleCancel} disabled={isLoading}>
+                    </lightning-button>
+                    <lightning-button label={customLabels.saveButtonLabel} title={customLabels.saveButtonLabel}
+                        variant="brand" onclick={handleSubmit} data-id="submitButton">
+                    </lightning-button>
+                </div>
+            </template>
         </footer>
 
     </lightning-record-edit-form>

--- a/src/lwc/rd2EntryForm/rd2EntryForm.js
+++ b/src/lwc/rd2EntryForm/rd2EntryForm.js
@@ -294,7 +294,6 @@ export default class rd2EntryForm extends LightningElement {
     */
     handlePaymentChange(event) {
         //reset the widget and the form related to the payment method
-        this.clearError();
         this.hasUserDisabledElevateWidget = false;
         this.evaluateElevateWidget(event.detail.value);
     }

--- a/src/lwc/rd2EntryForm/rd2EntryForm.js
+++ b/src/lwc/rd2EntryForm/rd2EntryForm.js
@@ -108,6 +108,7 @@ export default class rd2EntryForm extends LightningElement {
     @track hasCustomFields = false;
     isRecordReady = false;
     @track isSettingReady = false;
+    @track isSaveButtonDisabled = true;
 
     @track isElevateWidgetEnabled = false;
     hasUserDisabledElevateWidget = false;
@@ -141,6 +142,7 @@ export default class rd2EntryForm extends LightningElement {
                 this.isAutoNamingEnabled = response.isAutoNamingEnabled;
                 this.isMultiCurrencyEnabled = response.isMultiCurrencyEnabled;
                 this.isSettingReady = true;
+                this.isSaveButtonDisabled = false;
                 this.rdSettings = response;
                 this.customFields = response.customFieldSets;
                 this.hasCustomFields = Object.keys(this.customFields).length !== 0;
@@ -409,7 +411,7 @@ export default class rd2EntryForm extends LightningElement {
         this.clearError();
         this.isLoading = true;
         this.loadingText = this.customLabels.waitMessage;
-        this.saveButton.disabled = true;
+        this.isSaveButtonDisabled = true;
 
         const allFields = this.getAllSectionsInputValues();
 
@@ -418,7 +420,7 @@ export default class rd2EntryForm extends LightningElement {
 
         } else {
             this.isLoading = false;
-            this.saveButton.disabled = false;
+            this.isSaveButtonDisabled = false;
         }
     }
 
@@ -529,7 +531,7 @@ export default class rd2EntryForm extends LightningElement {
         const disableBtn = !!(isDisabled && isDisabled === true);
 
         this.isLoading = disableBtn;
-        this.saveButton.disabled = disableBtn;
+        this.isSaveButtonDisabled = disableBtn;
 
         this.template.querySelector(".slds-modal__header").scrollIntoView();
     }


### PR DESCRIPTION
- Display an error when the user is missing field permissions and disable the [Save] button. 
- Disable [Cancel] and [Save] buttons when the record is being saved.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
