### PR TITLE
Add Last Elevate Event Played field

### DIFF
--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -337,6 +337,18 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>LastElevateEventPlayed__c</fullName>
+        <description>The last Elevate event played resulting in an update to this Recurring Donation.</description>
+        <externalId>true</externalId>
+        <inlineHelpText>The last Elevate event played resulting in an update to this Recurring Donation.</inlineHelpText>
+        <label>Last Elevate Event Played</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>NextYearValue__c</fullName>
         <description>This Recurring Donation&apos;s total expected amount for the next calendar or fiscal year (read only).</description>
         <externalId>false</externalId>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1452,6 +1452,7 @@
         <members>npe03__Recurring_Donation__c.DisableFirstInstallment__c</members>
         <members>npe03__Recurring_Donation__c.EndDate__c</members>
         <members>npe03__Recurring_Donation__c.InstallmentFrequency__c</members>
+        <members>npe03__Recurring_Donation__c.LastElevateEventPlayed__c</members>
         <members>npe03__Recurring_Donation__c.NextYearValue__c</members>
         <members>npe03__Recurring_Donation__c.PaymentMethod__c</members>
         <members>npe03__Recurring_Donation__c.RecurringType__c</members>

--- a/unpackaged/config/rd2_post_config/profiles/Admin.profile
+++ b/unpackaged/config/rd2_post_config/profiles/Admin.profile
@@ -74,6 +74,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>npe03__Recurring_Donation__c.%%%NAMESPACE%%%LastElevateEventPlayed__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>npe03__Recurring_Donation__c.%%%NAMESPACE%%%NextYearValue__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/config/rd2_post_config/profiles/Standard.profile
+++ b/unpackaged/config/rd2_post_config/profiles/Standard.profile
@@ -74,6 +74,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>npe03__Recurring_Donation__c.%%%NAMESPACE%%%LastElevateEventPlayed__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>npe03__Recurring_Donation__c.%%%NAMESPACE%%%NextYearValue__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
# Critical Changes

# Changes
 - We added a new field, Last Elevate Event Played, to the Recurring Donation object. This field supports Elevate integration with NPSP. It's a system field so you don't need to add to your page layouts. We included Read access on the Standard and System Administrator profiles.

# Issues Closed

# Community Ideas Delivered

# New Metadata
- Custom field:
    - npe03__Recurring_Donation__c.LastElevateEventPlayed__c

# Deleted Metadata
