### PR TITLE
Prevent cancellation of already cancelled commitment

### DIFF
--- a/src/classes/RD2_ElevateIntegrationService.cls
+++ b/src/classes/RD2_ElevateIntegrationService.cls
@@ -93,6 +93,26 @@ public inherited sharing class RD2_ElevateIntegrationService {
     }
 
     /***
+    * @description Determines whether a Recurring Donation transaction is from the Elevate integration
+    * @param rd Changed Recurring Donation
+    * @param oldRd Old Recurring Donation
+    * @return Boolean
+    */
+    public static Boolean isFromElevate(RD2_RecurringDonation rd, RD2_RecurringDonation oldRd) {
+        Boolean isFromElevate = false;
+
+        npe03__Recurring_Donation__c closedRd = rd.getSObject();
+        npe03__Recurring_Donation__c previousRD = oldRd.getSObject();
+        if (String.isNotEmpty(closedRd.LastElevateEventPlayed__c)
+            && closedRd.LastElevateEventPlayed__c != previousRd.LastElevateEventPlayed__c
+            ) {
+            isFromElevate = true;
+        }
+
+        return isFromElevate;
+    }
+
+    /***
      * @description Determines if the Recurring Donation can be changed
      * @param rd Changed Recurring Donation
      * @param oldRd Old Recurring Donation

--- a/src/classes/RD2_ElevateIntegrationService.cls
+++ b/src/classes/RD2_ElevateIntegrationService.cls
@@ -93,23 +93,18 @@ public inherited sharing class RD2_ElevateIntegrationService {
     }
 
     /***
-    * @description Determines whether a Recurring Donation transaction is from the Elevate integration
+    * @description Determines whether a Recurring Donation event is from the Elevate integration
     * @param rd Changed Recurring Donation
     * @param oldRd Old Recurring Donation
     * @return Boolean
     */
-    public static Boolean isFromElevate(RD2_RecurringDonation rd, RD2_RecurringDonation oldRd) {
-        Boolean isFromElevate = false;
+    public static Boolean isElevateEvent(RD2_RecurringDonation rd, RD2_RecurringDonation oldRd) {
+        String elevateEvent = rd.getSObject().LastElevateEventPlayed__c;
 
-        npe03__Recurring_Donation__c closedRd = rd.getSObject();
-        npe03__Recurring_Donation__c previousRD = oldRd.getSObject();
-        if (String.isNotEmpty(closedRd.LastElevateEventPlayed__c)
-            && closedRd.LastElevateEventPlayed__c != previousRd.LastElevateEventPlayed__c
-            ) {
-            isFromElevate = true;
-        }
+        Boolean isElevateEventChanged = String.isNotBlank(elevateEvent)
+            && elevateEvent != oldRd.getSObject().LastElevateEventPlayed__c;
 
-        return isFromElevate;
+        return isElevateEventChanged;
     }
 
     /***

--- a/src/classes/RD2_ElevateIntegrationService_TEST.cls
+++ b/src/classes/RD2_ElevateIntegrationService_TEST.cls
@@ -722,10 +722,10 @@ public class RD2_ElevateIntegrationService_TEST {
     }
 
     /***
-    * @description Should determine that transaction is from Elevate when Last Elevate Event Played changes
+    * @description Should determine that event is from Elevate when Last Elevate Event Played changes
     */
     @isTest
-    private static void shouldIdentifyTransactionFromElevateWhenLastElevateEventPlayedChanged() {
+    private static void shouldIdentifyEventFromElevateWhenLastElevateEventPlayedChanged() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
@@ -737,15 +737,15 @@ public class RD2_ElevateIntegrationService_TEST {
 
         System.assertEquals(
             true,
-            RD2_ElevateIntegrationService.isFromElevate(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
-            'Should recognize the transaction is from Elevate');
+            RD2_ElevateIntegrationService.isElevateEvent(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
+            'Should recognize the event is from Elevate');
     }
 
     /***
-    * @description Should determine that transaction is from Elevate when Last Elevate Event Played changes
+    * @description Should determine that event is from Elevate when Last Elevate Event Played changes
     */
     @isTest
-    private static void shouldIdentifyTransactionNotFromElevateWhenLastElevateEventPlayedUnchanged() {
+    private static void shouldIdentifyEventNotFromElevateWhenLastElevateEventPlayedUnchanged() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
@@ -757,15 +757,15 @@ public class RD2_ElevateIntegrationService_TEST {
 
         System.assertEquals(
             false,
-            RD2_ElevateIntegrationService.isFromElevate(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
-            'Should recognize the transaction is not from Elevate');
+            RD2_ElevateIntegrationService.isElevateEvent(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
+            'Should recognize the event is not from Elevate');
     }
 
     /***
-    * @description Should determine that transaction is from Elevate when Last Elevate Event Played changes
+    * @description Should determine that event is from Elevate when Last Elevate Event Played changes
     */
     @isTest
-    private static void shouldIdentifyTransactionNotFromElevateWhenLastElevateEventPlayedEmpty() {
+    private static void shouldIdentifyEventNotFromElevateWhenLastElevateEventPlayedEmpty() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
@@ -775,8 +775,8 @@ public class RD2_ElevateIntegrationService_TEST {
 
         System.assertEquals(
             false,
-            RD2_ElevateIntegrationService.isFromElevate(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
-            'Should recognize the transaction is not from Elevate');
+            RD2_ElevateIntegrationService.isElevateEvent(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
+            'Should recognize the event is not from Elevate');
     }
 
 

--- a/src/classes/RD2_ElevateIntegrationService_TEST.cls
+++ b/src/classes/RD2_ElevateIntegrationService_TEST.cls
@@ -721,6 +721,64 @@ public class RD2_ElevateIntegrationService_TEST {
         assertCancelCommitmentError(UTIL_Http_TEST.MESSAGE_DATA_CONFLICT, rd.Id);
     }
 
+    /***
+    * @description Should determine that transaction is from Elevate when Last Elevate Event Played changes
+    */
+    @isTest
+    private static void shouldIdentifyTransactionFromElevateWhenLastElevateEventPlayedChanged() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
+            .withStatusClosed()
+            .build();
+        npe03__Recurring_Donation__c oldRd = newRd.clone();
+        newRd.LastElevateEventPlayed__c = 'event-v2';
+        oldRd.LastElevateEventPlayed__c = 'event-v1';
+
+        System.assertEquals(
+            true,
+            RD2_ElevateIntegrationService.isFromElevate(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
+            'Should recognize the transaction is from Elevate');
+    }
+
+    /***
+    * @description Should determine that transaction is from Elevate when Last Elevate Event Played changes
+    */
+    @isTest
+    private static void shouldIdentifyTransactionNotFromElevateWhenLastElevateEventPlayedUnchanged() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
+            .withStatusClosed()
+            .build();
+        npe03__Recurring_Donation__c oldRd = newRd.clone();
+        newRd.LastElevateEventPlayed__c = 'event-v1';
+        oldRd.LastElevateEventPlayed__c = 'event-v1';
+
+        System.assertEquals(
+            false,
+            RD2_ElevateIntegrationService.isFromElevate(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
+            'Should recognize the transaction is not from Elevate');
+    }
+
+    /***
+    * @description Should determine that transaction is from Elevate when Last Elevate Event Played changes
+    */
+    @isTest
+    private static void shouldIdentifyTransactionNotFromElevateWhenLastElevateEventPlayedEmpty() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
+            .withStatusClosed()
+            .build();
+        npe03__Recurring_Donation__c oldRd = newRd.clone();
+
+        System.assertEquals(
+            false,
+            RD2_ElevateIntegrationService.isFromElevate(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
+            'Should recognize the transaction is not from Elevate');
+    }
+
 
     // Helpers
     ///////////////////

--- a/src/classes/RD2_RecurringDonations_TDTM.cls
+++ b/src/classes/RD2_RecurringDonations_TDTM.cls
@@ -566,7 +566,7 @@ public class RD2_RecurringDonations_TDTM extends TDTM_Runnable {
 
             if (rd.isElevateRecord() && rd.isClosed() && !oldRd.isClosed()) {
 
-                if (RD2_ElevateIntegrationService.isFromElevate(rd, oldRd)) {
+                if (RD2_ElevateIntegrationService.isElevateEvent(rd, oldRd)) {
                     continue;
                 }
 

--- a/src/classes/RD2_RecurringDonations_TDTM.cls
+++ b/src/classes/RD2_RecurringDonations_TDTM.cls
@@ -168,20 +168,20 @@ public class RD2_RecurringDonations_TDTM extends TDTM_Runnable {
         Map<Id, npe03__Recurring_Donation__c> oldRdsById = new Map<Id, npe03__Recurring_Donation__c>();
         Map<Id, List<Opportunity>> oppsByRDId = new Map<Id, List<Opportunity>>();
         Map<Id, List<RecurringDonationSchedule__c>> schedulesByRdId = new Map<Id, List<RecurringDonationSchedule__c>>();
-        
+
         if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
             oldRdsById = new Map<Id, npe03__Recurring_Donation__c>(oldRds);
             oppsByRDId = new RD2_OpportunityEvaluationService().getOpportunitiesByRDId(UTIL_SObject.extractIds(rds));
             schedulesByRdId = scheduleService.getAllSchedules(rds, oldRds);
         }
 
-        for (npe03__Recurring_Donation__c rd : rds) { 
+        for (npe03__Recurring_Donation__c rd : rds) {
             if (triggerAction == TDTM_Runnable.Action.BeforeInsert) {
                 RD2_RecurringDonation rdRecord = new RD2_RecurringDonation(rd)
                     .revisePlannedInstallments()
                     .reviseNextDonationDateBeforeInsert(scheduleService);
 
-            } else if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {                
+            } else if (triggerAction == TDTM_Runnable.Action.BeforeUpdate) {
                 RD2_RecurringDonation rdRecord = new RD2_RecurringDonation(rd, oppsByRDId.get(rd.Id))
                     .revisePlannedInstallments()
                     .reviseStatus(currentDate, scheduleService)
@@ -437,7 +437,7 @@ public class RD2_RecurringDonations_TDTM extends TDTM_Runnable {
                     rdIds.add(rd.Id);
                 }
 
-                if (rd.npe03__Next_Payment_Date__c != oldRd.npe03__Next_Payment_Date__c 
+                if (rd.npe03__Next_Payment_Date__c != oldRd.npe03__Next_Payment_Date__c
                     || !getFieldsChangingSchedule(rd, oldRd).isEmpty()
                 ) {
                     rdIdsWhereScheduleChanged.add(rd.Id);
@@ -565,6 +565,11 @@ public class RD2_RecurringDonations_TDTM extends TDTM_Runnable {
             RD2_RecurringDonation oldRd = new RD2_RecurringDonation(oldRds[i]);
 
             if (rd.isElevateRecord() && rd.isClosed() && !oldRd.isClosed()) {
+
+                if (RD2_ElevateIntegrationService.isFromElevate(rd, oldRd)) {
+                    continue;
+                }
+
                 //send the RD details including the user provided Closed Reason to the commitment service
                 commitmentRDs.add(new npe03__Recurring_Donation__c(
                     Id = closedRd.Id,


### PR DESCRIPTION
We implemented a change to the handling of cancelled Recurring Donations to recognize and prevent reprocessing of cancellations from the Elevate integration.
# Critical Changes

# Changes

 - We implemented a change to recognize and prevent reprocessing of Recurring Donation cancellations from the Elevate integration.

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
