### PR TITLE
W-8265140 Add ACH Fields and Mapping

### DIFF
--- a/src/customMetadata/Data_Import_Field_Mapping.Payment_ACH_Last_4.md
+++ b/src/customMetadata/Data_Import_Field_Mapping.Payment_ACH_Last_4.md
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Payment ACH Last 4</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Is_Deleted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">npsp__Payment_ACH_Last_4__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">npsp__ACH_Last_4__c</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">Payment</value>
+    </values>
+</CustomMetadata>

--- a/src/globalValueSets/Payment_ACH_Code.globalValueSet
+++ b/src/globalValueSets/Payment_ACH_Code.globalValueSet
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>PPD</fullName>
+        <default>false</default>
+        <label>Prearranged Payment and Deposit Entry (PPD)</label>
+    </customValue>
+    <customValue>
+        <fullName>CCD</fullName>
+        <default>false</default>
+        <label>Cash Concentration or Disbursement (CCD)</label>
+    </customValue>
+    <customValue>
+        <fullName>WEB</fullName>
+        <default>false</default>
+        <label>Web-initiated Entry (WEB)</label>
+    </customValue>
+    <customValue>
+        <fullName>TEL</fullName>
+        <default>false</default>
+        <label>Telephone-initiated Entry (TEL)</label>
+    </customValue>
+    <customValue>
+        <fullName>BOC</fullName>
+        <default>false</default>
+        <label>Back Office Conversion (BOC)</label>
+    </customValue>
+    <customValue>
+        <fullName>ARC</fullName>
+        <default>false</default>
+        <label>Accounts Receivable Conversion (ARC)</label>
+    </customValue>
+    <description>The Standard Entry Class (SEC) code used for this ACH transaction.</description>
+    <masterLabel>Payment ACH Code</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/src/objects/DataImport__c.object
+++ b/src/objects/DataImport__c.object
@@ -1286,6 +1286,43 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>Payment_ACH_Code__c</fullName>
+        <description>The Standard Entry Class (SEC) code used for this ACH transaction.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The Standard Entry Class (SEC) code used for this ACH transaction.</inlineHelpText>
+        <label>Payment ACH Code</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Picklist</type>
+        <valueSet>
+            <restricted>true</restricted>
+            <valueSetName>Payment_ACH_Code</valueSetName>
+        </valueSet>
+    </fields>
+    <fields>
+        <fullName>Payment_ACH_Last_4__c</fullName>
+        <description>The last four digits of the bank account used for this transaction.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The last four digits of the bank account used for this transaction.</inlineHelpText>
+        <label>Payment ACH Last 4</label>
+        <length>4</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>ACH_Consent__c</fullName>
+        <description>The Elevate Giving Page consent message the donor agreed to.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The Elevate Giving Page consent message the donor agreed to.</inlineHelpText>
+        <label>Payment ACH Consent Message</label>
+        <length>2000</length>
+        <trackTrending>false</trackTrending>
+        <type>LongTextArea</type>
+        <visibleLines>3</visibleLines>
+    </fields>
+    <fields>
         <fullName>PaymentImportStatus__c</fullName>
         <externalId>false</externalId>
         <label>Payment Import Status</label>

--- a/src/objects/npe01__OppPayment__c.object
+++ b/src/objects/npe01__OppPayment__c.object
@@ -79,6 +79,18 @@
         <label>Payment Wizard FS</label>
     </fieldSets>
     <fields>
+        <fullName>ACH_Last_4__c</fullName>
+        <description>The last four digits of the bank account used for this transaction.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The last four digits of the bank account used for this transaction.</inlineHelpText>
+        <label>ACH Last 4</label>
+        <length>4</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Authorized_Date__c</fullName>
         <description>The date and time the transaction was authorized.</description>
         <externalId>false</externalId>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1134,6 +1134,9 @@
         <members>DataImport__c.Opportunity_Contact_Role_2_ImportStatus__c</members>
         <members>DataImport__c.Opportunity_Contact_Role_2_Imported__c</members>
         <members>DataImport__c.Opportunity_Contact_Role_2_Role__c</members>
+        <members>DataImport__c.Payment_ACH_Code__c</members>
+        <members>DataImport__c.Payment_ACH_Last_4__c</members>
+        <members>DataImport__c.ACH_Consent__c</members>
         <members>DataImport__c.PaymentImportStatus__c</members>
         <members>DataImport__c.PaymentImported__c</members>
         <members>DataImport__c.Payment_Authorization_Token__c</members>
@@ -1421,6 +1424,7 @@
         <members>npe01__Contacts_And_Orgs_Settings__c.Organizational_Account_Addresses_Enabled__c</members>
         <members>npe01__Contacts_And_Orgs_Settings__c.Payments_Auto_Close_Stage_Name__c</members>
         <members>npe01__Contacts_And_Orgs_Settings__c.Simple_Address_Change_Treated_as_Update__c</members>
+        <members>npe01__OppPayment__c.ACH_Last_4__c</members>
         <members>npe01__OppPayment__c.Authorized_Date__c</members>
         <members>npe01__OppPayment__c.Authorized_UTC_Timestamp__c</members>
         <members>npe01__OppPayment__c.Batch_Number__c</members>
@@ -3177,6 +3181,7 @@
         <members>Data_Import_Field_Mapping.Opportunity_Contact_Role_1_Role</members>
         <members>Data_Import_Field_Mapping.Opportunity_Contact_Role_2_Contact</members>
         <members>Data_Import_Field_Mapping.Opportunity_Contact_Role_2_Role</members>
+        <members>Data_Import_Field_Mapping.Payment_ACH_Last_4</members>
         <members>Data_Import_Field_Mapping.Payment_Authorized_Date</members>
         <members>Data_Import_Field_Mapping.Payment_Authorized_UTC_Timestamp</members>
         <members>Data_Import_Field_Mapping.Payment_Card_Expiration_Month</members>
@@ -3751,6 +3756,10 @@
     <types>
         <members>Data_Import_Batch_Record_Home</members>
         <name>FlexiPage</name>
+    </types>
+    <types>
+        <members>Payment_ACH_Code</members>
+        <name>GlobalValueSet</name>
     </types>
     <types>
         <members>Account-Household Layout</members>


### PR DESCRIPTION
- New Global Picklist `Payment_ACH_Code__c`
- New field on Payment `ACH_Last_4__c`
- New fields on Data Import: `Payment_ACH_Last_4__c`, `Payment_ACH_Code__c`, and `ACH_Consent__c`
- New Custom Metadata Mapping between Payment's field `ACH_Last_4__c` and Data Import's field `Payment_ACH_Last_4__c`

# Critical Changes

# Changes
 - We added these fields and field mapping to support tracking ACH payments:
   - ACH Last 4 (on the Payments object)
   - Payment ACH Last 4, Payment ACH Code, ACH Consent (on the NPSP Data Import object)
   - Custom Metadata mapping between ACH Last 4 and Payment ACH Last 4

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
