### PR TITLE
[RD] Add ACH Payment Method

### DIFF
--- a/src/classes/RD2_ScheduleService_TEST.cls
+++ b/src/classes/RD2_ScheduleService_TEST.cls
@@ -41,7 +41,7 @@ public with sharing class RD2_ScheduleService_TEST {
     private static final Date DATE_ESTABLISHED = Date.newInstance(2019, 9, 15);
     private static final String PAYMENT_CREDIT_CARD = 'Credit Card';
     private static final String PAYMENT_CHECK = 'Check';
-    private static final String PAYMENT_ACH_EFT = 'ACH/EFT';
+    private static final String PAYMENT_ACH = 'ACH';
     private static final Integer NUM_INSTALLMENTS = 12;
     public static final String PAUSE_REASON = 'Unknown';
 
@@ -86,7 +86,7 @@ public with sharing class RD2_ScheduleService_TEST {
 
         npe03__Recurring_Donation__c rd = getRecurringDonationFirstAndFifteenthBuilder()
             .withStartDate(startDate)
-            .withPaymentMethod(PAYMENT_ACH_EFT)
+            .withPaymentMethod(PAYMENT_ACH)
             .withInstallmentFrequency(2)
             .build();
 
@@ -95,7 +95,7 @@ public with sharing class RD2_ScheduleService_TEST {
         System.assertEquals(2, schedules.size(), 'Two schedules should exist for Installment Period 1st and 15th');
         for (RecurringDonationSchedule__c schedule : schedules) {
             System.assertEquals(rd.npe03__Amount__c, schedule.InstallmentAmount__c, 'Installment Amount should match RD Amount');
-            System.assertEquals(PAYMENT_ACH_EFT, schedule.PaymentMethod__c, 'Payment Method should match RD Payment Method');
+            System.assertEquals(PAYMENT_ACH, schedule.PaymentMethod__c, 'Payment Method should match RD Payment Method');
             System.assertEquals(rd.InstallmentFrequency__c, schedule.InstallmentFrequency__c, 'Installment Frequency should match RD Installment Frequency');
             System.assertEquals(RD2_Constants.INSTALLMENT_PERIOD_FIRST_AND_FIFTEENTH, schedule.InstallmentPeriod__c, 'Installment Period should be 1st and 15th');
             System.assertEquals(startDate, schedule.StartDate__c, 'Schedule Start Date should be RD Effective Date');
@@ -656,7 +656,7 @@ public with sharing class RD2_ScheduleService_TEST {
         npe03__Recurring_Donation__c rd = getRecurringDonationMonthlyBuilder().build();
 
         npe03__Recurring_Donation__c changeRd = rd.clone();
-        changeRd.PaymentMethod__c = PAYMENT_ACH_EFT;
+        changeRd.PaymentMethod__c = PAYMENT_ACH;
 
         RD2_ScheduleService schedule = new RD2_ScheduleService();
         Boolean updateNeeded = schedule.isScheduleUpdateNeeded(changeRd, rd);

--- a/src/objectTranslations/RecurringDonationSchedule__c-de.objectTranslation
+++ b/src/objectTranslations/RecurringDonationSchedule__c-de.objectTranslation
@@ -235,8 +235,8 @@
         <label>Zahlungsmethode</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation>ACH/EFT</translation>
+            <masterLabel>ACH</masterLabel>
+            <translation>ACH</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/RecurringDonationSchedule__c-en_US.objectTranslation
+++ b/src/objectTranslations/RecurringDonationSchedule__c-en_US.objectTranslation
@@ -203,8 +203,8 @@
         <label><!-- Payment Method --></label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation><!-- ACH/EFT --></translation>
+            <masterLabel>ACH</masterLabel>
+            <translation><!-- ACH --></translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/RecurringDonationSchedule__c-es.objectTranslation
+++ b/src/objectTranslations/RecurringDonationSchedule__c-es.objectTranslation
@@ -203,8 +203,8 @@
         <label>Método de pago</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation>ACH/EFT</translation>
+            <masterLabel>ACH</masterLabel>
+            <translation>ACH</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/RecurringDonationSchedule__c-fr.objectTranslation
+++ b/src/objectTranslations/RecurringDonationSchedule__c-fr.objectTranslation
@@ -203,7 +203,7 @@
         <label>Mode de paiement</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
+            <masterLabel>ACH</masterLabel>
             <translation>CCA/TEF</translation>
         </picklistValues>
         <picklistValues>

--- a/src/objectTranslations/RecurringDonationSchedule__c-fr.objectTranslation
+++ b/src/objectTranslations/RecurringDonationSchedule__c-fr.objectTranslation
@@ -204,7 +204,7 @@
         <name>PaymentMethod__c</name>
         <picklistValues>
             <masterLabel>ACH</masterLabel>
-            <translation>CCA/TEF</translation>
+            <translation>CCA</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/RecurringDonationSchedule__c-iw.objectTranslation
+++ b/src/objectTranslations/RecurringDonationSchedule__c-iw.objectTranslation
@@ -215,8 +215,8 @@
         <label><!-- Payment Method --></label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation><!-- ACH/EFT --></translation>
+            <masterLabel>ACH</masterLabel>
+            <translation><!-- ACH --></translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/RecurringDonationSchedule__c-ja.objectTranslation
+++ b/src/objectTranslations/RecurringDonationSchedule__c-ja.objectTranslation
@@ -199,8 +199,8 @@
         <label>支払方法</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation>ACH/EFT</translation>
+            <masterLabel>ACH</masterLabel>
+            <translation>ACH</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/RecurringDonationSchedule__c-nl_NL.objectTranslation
+++ b/src/objectTranslations/RecurringDonationSchedule__c-nl_NL.objectTranslation
@@ -203,8 +203,8 @@
         <label>Betalingswijze</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation>ACH/EFT</translation>
+            <masterLabel>ACH</masterLabel>
+            <translation>ACH</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/npe03__Recurring_Donation__c-de.objectTranslation
+++ b/src/objectTranslations/npe03__Recurring_Donation__c-de.objectTranslation
@@ -202,8 +202,8 @@
         <label>Zahlungsmethode</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation>ACH/EFT</translation>
+            <masterLabel>ACH</masterLabel>
+            <translation>ACH</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/npe03__Recurring_Donation__c-es.objectTranslation
+++ b/src/objectTranslations/npe03__Recurring_Donation__c-es.objectTranslation
@@ -202,8 +202,8 @@
         <label>Método de pago</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation>ACH/EFT</translation>
+            <masterLabel>ACH</masterLabel>
+            <translation>ACH</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/npe03__Recurring_Donation__c-fr.objectTranslation
+++ b/src/objectTranslations/npe03__Recurring_Donation__c-fr.objectTranslation
@@ -202,7 +202,7 @@
         <label>Mode de paiement</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
+            <masterLabel>ACH</masterLabel>
             <translation>CCA/TEF</translation>
         </picklistValues>
         <picklistValues>

--- a/src/objectTranslations/npe03__Recurring_Donation__c-fr.objectTranslation
+++ b/src/objectTranslations/npe03__Recurring_Donation__c-fr.objectTranslation
@@ -203,7 +203,7 @@
         <name>PaymentMethod__c</name>
         <picklistValues>
             <masterLabel>ACH</masterLabel>
-            <translation>CCA/TEF</translation>
+            <translation>CCA</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/npe03__Recurring_Donation__c-iw.objectTranslation
+++ b/src/objectTranslations/npe03__Recurring_Donation__c-iw.objectTranslation
@@ -202,8 +202,8 @@
         <label><!-- Payment Method --></label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation><!-- ACH/EFT --></translation>
+            <masterLabel>ACH</masterLabel>
+            <translation><!-- ACH --></translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/npe03__Recurring_Donation__c-ja.objectTranslation
+++ b/src/objectTranslations/npe03__Recurring_Donation__c-ja.objectTranslation
@@ -202,8 +202,8 @@
         <label>支払方法</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation>ACH/EFT</translation>
+            <masterLabel>ACH</masterLabel>
+            <translation>ACH</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objectTranslations/npe03__Recurring_Donation__c-nl_NL.objectTranslation
+++ b/src/objectTranslations/npe03__Recurring_Donation__c-nl_NL.objectTranslation
@@ -202,8 +202,8 @@
         <label>Betalingswijze</label>
         <name>PaymentMethod__c</name>
         <picklistValues>
-            <masterLabel>ACH/EFT</masterLabel>
-            <translation>ACH/EFT</translation>
+            <masterLabel>ACH</masterLabel>
+            <translation>ACH</translation>
         </picklistValues>
         <picklistValues>
             <masterLabel>Check</masterLabel>

--- a/src/objects/RecurringDonationSchedule__c.object
+++ b/src/objects/RecurringDonationSchedule__c.object
@@ -487,11 +487,6 @@
                     <label>Check</label>
                 </value>
                 <value>
-                    <fullName>ACH/EFT</fullName>
-                    <default>false</default>
-                    <label>ACH/EFT</label>
-                </value>
-                <value>
                     <fullName>ACH</fullName>
                     <default>false</default>
                     <label>ACH</label>

--- a/src/objects/RecurringDonationSchedule__c.object
+++ b/src/objects/RecurringDonationSchedule__c.object
@@ -491,6 +491,11 @@
                     <default>false</default>
                     <label>ACH/EFT</label>
                 </value>
+                <value>
+                    <fullName>ACH</fullName>
+                    <default>false</default>
+                    <label>ACH</label>
+                </value>
             </valueSetDefinition>
         </valueSet>
     </fields>

--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -385,11 +385,6 @@
                     <label>Check</label>
                 </value>
                 <value>
-                    <fullName>ACH/EFT</fullName>
-                    <default>false</default>
-                    <label>ACH/EFT</label>
-                </value>
-                <value>
                     <fullName>ACH</fullName>
                     <default>false</default>
                     <label>ACH</label>

--- a/src/objects/npe03__Recurring_Donation__c.object
+++ b/src/objects/npe03__Recurring_Donation__c.object
@@ -389,6 +389,11 @@
                     <default>false</default>
                     <label>ACH/EFT</label>
                 </value>
+                <value>
+                    <fullName>ACH</fullName>
+                    <default>false</default>
+                    <label>ACH</label>
+                </value>
             </valueSetDefinition>
         </valueSet>
     </fields>


### PR DESCRIPTION
# Critical Changes

# Changes
 - We added `ACH` to the Payment Method field on Recurring Donations to support Elevate customers. This new value is meant to replace the existing `ACH/EFT` value. If you already upgraded to Enhanced Recurring Donations, you should take the following action:
   - Go to **Setup** and click **Object Manager**.
   - Find and click **Recurring Donation**.
   - Click **Fields & Relationships**.
   - Click **Payment Method**.
   - Click **Del** next to ACH/EFT.
   - Click **OK**.
   - For Replace value on records with, select `ACH`.
   - Click **Save**.

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
