### PR TITLE
Fixing RD2 test failures on regression

### DIFF
--- a/robot/Cumulus/resources/RecurringDonationsPageObject.py
+++ b/robot/Cumulus/resources/RecurringDonationsPageObject.py
@@ -47,6 +47,7 @@ class RDListingPage(BaseNPSPPage, ListingPage):
     @capture_screenshot_on_error
     def populate_rd2_modal_form(self, **kwargs):
         """Populates the RD2 modal form fields with the respective fields and values"""
+        self.builtin.sleep(1,"For Rd2 modal dropdown values to get populated")
         ns=self.npsp.get_npsp_namespace_prefix()
         for key, value in kwargs.items():
             locator = npsp_lex_locators["erd"]["modal_input_field"].format(key)
@@ -158,6 +159,7 @@ class RDDetailPage(BaseNPSPPage, DetailPage):
                     self.selenium.scroll_element_into_view(locator)
                     self.salesforce._jsclick(locator)
                     self.selenium.wait_until_element_is_visible(selection_value,30)
+                    self.selenium.scroll_element_into_view(selection_value)
                     self.selenium.click_element(selection_value)
                 else:
                     self.builtin.log(f"Element {key} not present")

--- a/robot/Cumulus/resources/RecurringDonationsPageObject.py
+++ b/robot/Cumulus/resources/RecurringDonationsPageObject.py
@@ -16,6 +16,13 @@ class RDListingPage(BaseNPSPPage, ListingPage):
     object_name = "npe03__Recurring_Donation__c"
 
     @capture_screenshot_on_error
+    def wait_for_rd2_modal(self):
+        """Based on the button name (Cancel)  or (Save) on the modal footer, selects and clicks on the respective button"""
+        btnlocator = npsp_lex_locators["button-with-text"].format("Save")
+        self.selenium.scroll_element_into_view(btnlocator)
+        self.selenium.wait_until_element_is_visible(btnlocator,60)
+    
+    @capture_screenshot_on_error
     def click_rd2_modal_button(self, name):
         """Based on the button name (Cancel)  or (Save) on the modal footer, selects and clicks on the respective button"""
         btnlocator = npsp_lex_locators["button-with-text"].format(name)
@@ -121,7 +128,6 @@ class RDDetailPage(BaseNPSPPage, DetailPage):
         edit_button = self.selenium.get_webelement(locator)
         self.selenium.wait_until_element_is_visible(edit_button,60)
         self.selenium.click_element(locator)
-        self.salesforce.wait_until_modal_is_open()
         self.selenium.reload_page()
         self.selenium.reload_page()
         time.sleep(3)
@@ -157,14 +163,16 @@ class RDDetailPage(BaseNPSPPage, DetailPage):
                     self.builtin.log(f"Element {key} not present")
 
     @capture_screenshot_on_error
-    def pause_recurring_donation(self, **kwargs):
+    def pause_recurring_donation(self, type=None):
         """Finds the pause button on the recurring donations details
         view page, clicks the button and waits for the modal to appear"""
         locator = npsp_lex_locators["bge"]["button"].format("Pause")
         pause_button = self.selenium.get_webelement(locator)
         self.selenium.wait_until_element_is_visible(pause_button)
         self.selenium.click_element(locator)
-        self.salesforce.wait_until_modal_is_open()
+        if type != "Closed":
+            btnlocator = npsp_lex_locators["button-with-text"].format("Save")
+            self.selenium.wait_until_element_is_visible(btnlocator,60)
 
     @capture_screenshot_on_error
     def populate_pause_modal(self,**kwargs):

--- a/robot/Cumulus/resources/RecurringDonationsPageObject.py
+++ b/robot/Cumulus/resources/RecurringDonationsPageObject.py
@@ -18,6 +18,7 @@ class RDListingPage(BaseNPSPPage, ListingPage):
     @capture_screenshot_on_error
     def wait_for_rd2_modal(self):
         """Based on the button name (Cancel)  or (Save) on the modal footer, selects and clicks on the respective button"""
+        self.builtin.sleep(1,"Wait Needed for now to wait for the new modal")
         btnlocator = npsp_lex_locators["button-with-text"].format("Save")
         self.selenium.scroll_element_into_view(btnlocator)
         self.selenium.wait_until_element_is_visible(btnlocator,60)
@@ -78,14 +79,14 @@ class RDDetailPage(BaseNPSPPage, DetailPage):
             by verifying that the url contains '/view'
         """
         for i in range(3):
-            time.sleep(1)
+            time.sleep(2)
             self.selenium.location_should_contain(
                 "/lightning/r/npe03__Recurring_Donation__c/",
                 message="Current page is not a Recurring Donations record view",
             )
             locator = npsp_lex_locators["bge"]["button"].format("Edit")
+            self.selenium.wait_until_page_contains_element(locator, error="Recurring donations Details page did not load fully")
             edit_button = self.selenium.get_webelement(locator)
-            self.selenium.wait_until_page_contains_element(edit_button, error="Recurring donations Details page did not load fully")
             if self.npsp.check_if_element_displayed(edit_button):
                 return
             else:

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_fixed_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_fixed_erd_record.robot
@@ -10,7 +10,7 @@ Suite Setup     Run keywords
 ...             Enable RD2
 ...             Open Test Browser
 ...             Setup Test Data
-#Suite Teardown  Delete Records and Close Browser
+Suite Teardown  Delete Records and Close Browser
 
 ***Keywords***
 # Setup a contact with parameters specified

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_fixed_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_fixed_erd_record.robot
@@ -44,7 +44,6 @@ Create Fixed Recurring Donation With Monthly Installment
     Go To Page                              Listing                                   npe03__Recurring_Donation__c
     Reload Page
     Click Link                              New
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Wait For Rd2 Modal
     # Create Enhanced recurring donation of type Fixed
     Populate Rd2 Modal Form

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_fixed_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_fixed_erd_record.robot
@@ -10,7 +10,7 @@ Suite Setup     Run keywords
 ...             Enable RD2
 ...             Open Test Browser
 ...             Setup Test Data
-Suite Teardown  Delete Records and Close Browser
+#Suite Teardown  Delete Records and Close Browser
 
 ***Keywords***
 # Setup a contact with parameters specified
@@ -42,12 +42,10 @@ Create Fixed Recurring Donation With Monthly Installment
     [tags]                       unstable                     W-040346               feature:RD2
 
     Go To Page                              Listing                                   npe03__Recurring_Donation__c
-
-    Click Object Button                     New
-    Wait For Modal                          New                                       Recurring Donation
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Reload Page
-    Wait For Modal                          New                                       Recurring Donation
+    Click Link                              New
+    # Reload page is a temporary fix till the developers fix the ui-modal
+    Wait For Rd2 Modal
     # Create Enhanced recurring donation of type Fixed
     Populate Rd2 Modal Form
     ...                                     Donor Type=Account

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_for_contact.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_for_contact.robot
@@ -33,12 +33,11 @@ ${METHOD}  Credit Card
     [tags]                                 unstable               W-042701                     feature:RD2
 
     Go To Page                             Listing                                            npe03__Recurring_Donation__c
-    Click Object Button                    New
-    Wait For Modal                         New                                                Recurring Donation
 
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Reload Page
-    Wait For Modal                         New                                                Recurring Donation
+    Click Link                              New
+    # Reload page is a temporary fix till the developers fix the ui-modal
+    Wait For Rd2 Modal
 
     # Create Enhanced recurring donation of type Open and assign it to a contact
     Populate Rd2 Modal Form

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_for_contact.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_for_contact.robot
@@ -36,7 +36,6 @@ ${METHOD}  Credit Card
 
     Reload Page
     Click Link                              New
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Wait For Rd2 Modal
 
     # Create Enhanced recurring donation of type Open and assign it to a contact

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_record.robot
@@ -43,11 +43,10 @@ Create Open Recurring Donation With Monthly Installment
     [tags]                       unstable               W-040346                     feature:RD2
 
     Go To Page                             Listing                                   npe03__Recurring_Donation__c
-    Click Object Button                    New
-    Wait For Modal                         New                                       Recurring Donation
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Reload Page
-    Wait For Modal                         New                                       Recurring Donation
+    Click Link                              New
+    # Reload page is a temporary fix till the developers fix the ui-modal
+    Wait For Rd2 Modal
 
     # Create Enhanced recurring donation of type Open
     Populate Rd2 Modal Form

--- a/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zcreate_open_erd_record.robot
@@ -44,8 +44,7 @@ Create Open Recurring Donation With Monthly Installment
 
     Go To Page                             Listing                                   npe03__Recurring_Donation__c
     Reload Page
-    Click Link                              New
-    # Reload page is a temporary fix till the developers fix the ui-modal
+    Click Link                             New
     Wait For Rd2 Modal
 
     # Create Enhanced recurring donation of type Open

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_day_of_month.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_day_of_month.robot
@@ -45,10 +45,10 @@ Edit Day Of Month For Enhanced Recurring donation record of type open
 
     Go To Page                              Listing                                   npe03__Recurring_Donation__c
     Current Page Should Be                  Listing                                   npe03__Recurring_Donation__c
-    Click Object Button                     New
-    Wait For Modal                          New                                       Recurring Donation
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Reload Page
+    Click Link                              New
+        # Reload page is a temporary fix till the developers fix the ui-modal
+    Wait For Rd2 Modal
 
     Go To Page                              Details
     ...                                     npe03__Recurring_Donation__c

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_day_of_month.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_day_of_month.robot
@@ -47,7 +47,6 @@ Edit Day Of Month For Enhanced Recurring donation record of type open
     Current Page Should Be                  Listing                                   npe03__Recurring_Donation__c
     Reload Page
     Click Link                              New
-        # Reload page is a temporary fix till the developers fix the ui-modal
     Wait For Rd2 Modal
 
     Go To Page                              Details

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_day_of_month_with_manual_opportunity.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_day_of_month_with_manual_opportunity.robot
@@ -28,7 +28,7 @@ Setup Test Data
         ...                                                         npe03__Open_Ended_Status__c=Open
         ...                                                         npe03__Date_Established__c=2019-07-08
         ...                                                         ${NS}Status__c=Active
-        ...                                                         ${NS}Day_of_Month__c=20
+        ...                                                         ${NS}Day_of_Month__c=10
         ...                                                         ${NS}InstallmentFrequency__c=1
         ...                                                         ${NS}PaymentMethod__c=Check
 

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
@@ -48,10 +48,10 @@ Edit Installment Period For An Enhanced Recurring donation record of type open
 
     Go To Page                              Listing                                   npe03__Recurring_Donation__c
     Current Page Should be                  Listing                                   npe03__Recurring_Donation__c
-    Click Object Button                     New
-    Wait For Modal                          New                                       Recurring Donation
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Reload Page
+    Click Link                              New
+    # Reload page is a temporary fix till the developers fix the ui-modal
+    Wait For Rd2 Modal
     Go To Page                              Details
     ...                                     npe03__Recurring_Donation__c
     ...                                     object_id=${data}[contact_rd][Id]

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
@@ -7,7 +7,7 @@ Suite Setup     Run keywords
 ...             Enable RD2
 ...             Open Test Browser
 ...             Setup Test Data
-#Suite Teardown  Delete Records and Close Browser
+Suite Teardown  Delete Records and Close Browser
 
 *** Keywords ***
 
@@ -50,7 +50,6 @@ Edit Installment Period For An Enhanced Recurring donation record of type open
     Current Page Should be                  Listing                                   npe03__Recurring_Donation__c
     Reload Page
     Click Link                              New
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Wait For Rd2 Modal
     Go To Page                              Details
     ...                                     npe03__Recurring_Donation__c

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_erd_installment_period.robot
@@ -7,7 +7,7 @@ Suite Setup     Run keywords
 ...             Enable RD2
 ...             Open Test Browser
 ...             Setup Test Data
-Suite Teardown  Delete Records and Close Browser
+#Suite Teardown  Delete Records and Close Browser
 
 *** Keywords ***
 
@@ -56,7 +56,7 @@ Edit Installment Period For An Enhanced Recurring donation record of type open
     ...                                     npe03__Recurring_Donation__c
     ...                                     object_id=${data}[contact_rd][Id]
     Current Page Should be                  Details                                   npe03__Recurring_Donation__c
-    Wait Until Loading Is Complete
+
     Edit Recurring Donation Status
     ...                                     Recurring Period=Advanced
     ...                                     Every=3

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
@@ -45,10 +45,10 @@ Edit An Enhanced Recurring donation record of type open
 
     Go To Page                              Listing                                   npe03__Recurring_Donation__c
 
-    Click Object Button                     New
-    Wait For Modal                          New                                       Recurring Donation
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Reload Page
+    Click Link                              New
+    # Reload page is a temporary fix till the developers fix the ui-modal
+    Wait For Rd2 Modal
 
     Go To Page                             Details
     ...                                    npe03__Recurring_Donation__c

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_open_erd_record.robot
@@ -47,7 +47,6 @@ Edit An Enhanced Recurring donation record of type open
 
     Reload Page
     Click Link                              New
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Wait For Rd2 Modal
 
     Go To Page                             Details

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_paused_rd.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_paused_rd.robot
@@ -59,8 +59,7 @@ Edit An Enhanced Recurring donation record of type open
     Go To Page                                    Listing                                   npe03__Recurring_Donation__c
 
     Reload Page
-    Click Link                              New
-    # Reload page is a temporary fix till the developers fix the ui-modal
+    Click Link                                    New
     Wait For Rd2 Modal
     Go To Page                                    Details
     ...                                           npe03__Recurring_Donation__c

--- a/robot/Cumulus/tests/browser/recurring_donations/zedit_paused_rd.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zedit_paused_rd.robot
@@ -58,9 +58,10 @@ Edit An Enhanced Recurring donation record of type open
 
     Go To Page                                    Listing                                   npe03__Recurring_Donation__c
 
-    Click Object Button                           New
-    Wait For Modal                                New                                       Recurring Donation
     Reload Page
+    Click Link                              New
+    # Reload page is a temporary fix till the developers fix the ui-modal
+    Wait For Rd2 Modal
     Go To Page                                    Details
     ...                                           npe03__Recurring_Donation__c
     ...                                           object_id=${data}[contact_rd][Id]

--- a/robot/Cumulus/tests/browser/recurring_donations/zpause_closed_rd.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zpause_closed_rd.robot
@@ -51,7 +51,6 @@ Edit An Enhanced Recurring donation record of type open
 
     Reload Page
     Click Link                              New
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Wait For Rd2 Modal
     Go To Page                              Details
     ...                                     npe03__Recurring_Donation__c

--- a/robot/Cumulus/tests/browser/recurring_donations/zpause_closed_rd.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zpause_closed_rd.robot
@@ -49,9 +49,10 @@ Edit An Enhanced Recurring donation record of type open
 
     Go To Page                              Listing                                   npe03__Recurring_Donation__c
 
-    Click Object Button                     New
-    Wait For Modal                          New                                       Recurring Donation
     Reload Page
+    Click Link                              New
+    # Reload page is a temporary fix till the developers fix the ui-modal
+    Wait For Rd2 Modal
     Go To Page                              Details
     ...                                     npe03__Recurring_Donation__c
     ...                                     object_id=${data}[contact_rd][Id]
@@ -65,5 +66,5 @@ Edit An Enhanced Recurring donation record of type open
 
     Current Page Should be                  Details                                  npe03__Recurring_Donation__c
     #Pause the recurring donation and validate the warning message displayed
-    Pause_Recurring Donation
+    Pause Recurring Donation                Closed
     Validate Message Text                   You can't Pause a Closed Recurring Donation

--- a/robot/Cumulus/tests/browser/recurring_donations/zpause_consecutive_payments.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zpause_consecutive_payments.robot
@@ -54,9 +54,10 @@ Edit An Enhanced Recurring donation record of type open
 
     Go To Page                                    Listing                                   npe03__Recurring_Donation__c
 
-    Click Object Button                           New
-    Wait For Modal                                New                                       Recurring Donation
     Reload Page
+    Click Link                                    New
+    # Reload page is a temporary fix till the developers fix the ui-modal
+    Wait For Rd2 Modal
     Go To Page                                    Details
     ...                                           npe03__Recurring_Donation__c
     ...                                           object_id=${data}[contact_rd][Id]

--- a/robot/Cumulus/tests/browser/recurring_donations/zpause_consecutive_payments.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zpause_consecutive_payments.robot
@@ -56,7 +56,6 @@ Edit An Enhanced Recurring donation record of type open
 
     Reload Page
     Click Link                                    New
-    # Reload page is a temporary fix till the developers fix the ui-modal
     Wait For Rd2 Modal
     Go To Page                                    Details
     ...                                           npe03__Recurring_Donation__c

--- a/robot/Cumulus/tests/browser/recurring_donations/zverify_pause_modal_behavior.robot
+++ b/robot/Cumulus/tests/browser/recurring_donations/zverify_pause_modal_behavior.robot
@@ -50,9 +50,9 @@ Edit An Enhanced Recurring donation record of type open
 
     Go To Page                                    Listing                                   npe03__Recurring_Donation__c
 
-    Click Object Button                           New
-    Wait For Modal                                New                                       Recurring Donation
     Reload Page
+    Click Link                                    New
+    Wait For Rd2 Modal
     Go To Page                                    Details
     ...                                           npe03__Recurring_Donation__c
     ...                                           object_id=${data}[contact_rd][Id]


### PR DESCRIPTION
On regression Rd2 tests most of them are failing as click_object_button from salesforce library is not helping with clicking the button
Also there are few other checks to handle

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
