### PR TITLE
RD2: Create an error record on Elevate API error response

### DIFF
--- a/src/classes/RD2_EntryFormController.cls
+++ b/src/classes/RD2_EntryFormController.cls
@@ -301,7 +301,7 @@ public with sharing class RD2_EntryFormController {
         }
 
         UTIL_Http.Response response;
-        String exceptionMessage;
+        String errorMessage;
 
         try {
             response = commitmentService.sendRequest(recordId, jsonRequestBody);
@@ -309,29 +309,30 @@ public with sharing class RD2_EntryFormController {
             if (response.statusCode == UTIL_Http.STATUS_CODE_CREATED) {
                 PS_CommitmentRequest.ResponseBody commitment = new PS_CommitmentRequest().getCommitment(response);
                 commitmentService.updateRecurringDonation(recordId, commitment);
+            } else {
+                errorMessage = response.getErrorMessages();
             }
 
         } catch (CalloutException e) {
-            exceptionMessage = e.getMessage();
+            UTIL_AuraEnabledCommon.throwAuraHandledException(e.getMessage());
 
         } catch (JSONException e) {
-            exceptionMessage = e.getMessage();
+            UTIL_AuraEnabledCommon.throwAuraHandledException(e.getMessage());
 
         } finally {
-            if (String.isNotBlank(exceptionMessage)) {
-                UTIL_AuraEnabledCommon.throwAuraHandledException(exceptionMessage);
-            }
-
-            if ((response != null && response.statusCode != UTIL_Http.STATUS_CODE_CREATED)
-                || String.isNotBlank(exceptionMessage)
-            ) {
-                processError((String.isNotBlank(exceptionMessage) ? exceptionMessage : response.body), recordId);
+            if (String.isNotBlank(errorMessage)) {
+                processError(errorMessage, recordId);
             }
         }
 
         return JSON.serialize(response);
     }
 
+    /**
+    * @description Process Elevate create commitment error
+    * @param errorMessage error message
+    * @param recordId Recurring Donation Id
+    */
     private static void processError(String errorMessage, Id recordId) {
         RD2_ElevateIntegrationService.Logger errorLogger = new RD2_ElevateIntegrationService.Logger();
                 errorLogger.addError(
@@ -397,7 +398,7 @@ public with sharing class RD2_EntryFormController {
         /***
         * @description Saves commitment Id and the credit card data onto the Recurring Donation record.
         * @param recordId Recurring Donation Id
-        * @param response Response from Elevate on the commitment create request
+        * @param commitment Commitment response body from Elevate on the commitment create request
         * @return void
         */
         public void updateRecurringDonation(Id recordId, PS_CommitmentRequest.ResponseBody commitment) {

--- a/src/classes/RD2_EntryFormController.cls
+++ b/src/classes/RD2_EntryFormController.cls
@@ -301,27 +301,47 @@ public with sharing class RD2_EntryFormController {
         }
 
         UTIL_Http.Response response;
+        String exceptionMessage;
 
         try {
             response = commitmentService.sendRequest(recordId, jsonRequestBody);
 
             if (response.statusCode == UTIL_Http.STATUS_CODE_CREATED) {
-                commitmentService.updateRecurringDonation(recordId, response);
+                PS_CommitmentRequest.ResponseBody commitment = new PS_CommitmentRequest().getCommitment(response);
+                commitmentService.updateRecurringDonation(recordId, commitment);
             }
 
-        } catch (Exception e) {
-            UTIL_AuraEnabledCommon.throwAuraHandledException(e.getMessage());
+        } catch (CalloutException e) {
+            exceptionMessage = e.getMessage();
+
+        } catch (JSONException e) {
+            exceptionMessage = e.getMessage();
 
         } finally {
-            if (response != null && response.statusCode != UTIL_Http.STATUS_CODE_CREATED) {
-                //create an error log for the RD and the failed response error message
+            if (String.isNotBlank(exceptionMessage)) {
+                UTIL_AuraEnabledCommon.throwAuraHandledException(exceptionMessage);
+            }
+
+            if ((response != null && response.statusCode != UTIL_Http.STATUS_CODE_CREATED)
+                || String.isNotBlank(exceptionMessage)
+            ) {
+                processError((String.isNotBlank(exceptionMessage) ? exceptionMessage : response.body), recordId);
             }
         }
 
         return JSON.serialize(response);
     }
 
+    private static void processError(String errorMessage, Id recordId) {
+        RD2_ElevateIntegrationService.Logger errorLogger = new RD2_ElevateIntegrationService.Logger();
+                errorLogger.addError(
+                    recordId,
+                    errorMessage,
+                    RD2_ElevateIntegrationService.LOG_TYPE_COMMITMENT_CREATE
+                );
 
+                errorLogger.processErrors();
+    }
     /**
     * @description Handles sending commitment request and saving its values on the RD
     */
@@ -380,33 +400,22 @@ public with sharing class RD2_EntryFormController {
         * @param response Response from Elevate on the commitment create request
         * @return void
         */
-        public void updateRecurringDonation(Id recordId, UTIL_Http.Response response) {
-            if (response == null
-                || response.statusCode != UTIL_Http.STATUS_CODE_CREATED
-            ) {
-                return;
+        public void updateRecurringDonation(Id recordId, PS_CommitmentRequest.ResponseBody commitment) {
+            if (commitment.hasId()) {
+                npe03__Recurring_Donation__c rd = new npe03__Recurring_Donation__c(
+                    Id = recordId,
+                    CommitmentId__c = commitment.id,
+                    CardLast4__c = commitment.getCardLast4(),
+                    CardExpirationMonth__c = commitment.getCardExpirationMonth(),
+                    CardExpirationYear__c = commitment.getCardExpirationYear()
+                );
+
+                UTIL_DMLService.updateRecordBatchAndLogErrors(
+                    new List<npe03__Recurring_Donation__c>{ rd }, ERR_Handler_API.Context.Elevate.name()
+                );
             }
 
-            try {
-                PS_CommitmentRequest.ResponseBody commitment = new PS_CommitmentRequest().getCommitment(response);
-
-                if (commitment.hasId()) {
-                    npe03__Recurring_Donation__c rd = new npe03__Recurring_Donation__c(
-                        Id = recordId,
-                        CommitmentId__c = commitment.id,
-                        CardLast4__c = commitment.getCardLast4(),
-                        CardExpirationMonth__c = commitment.getCardExpirationMonth(),
-                        CardExpirationYear__c = commitment.getCardExpirationYear()
-                    );
-
-                    UTIL_DMLService.updateRecordBatchAndLogErrors(
-                        new List<npe03__Recurring_Donation__c>{ rd }, ERR_Handler_API.Context.Elevate.name()
-                    );
-                }
-
-            } catch (Exception e) {
-                throw e;
-            }
+           
         }
     }
 

--- a/src/classes/RD2_EntryFormController.cls
+++ b/src/classes/RD2_EntryFormController.cls
@@ -306,37 +306,35 @@ public with sharing class RD2_EntryFormController {
             response = commitmentService.sendRequest(recordId, jsonRequestBody);
 
             if (response.statusCode == UTIL_Http.STATUS_CODE_CREATED) {
-                PS_CommitmentRequest.ResponseBody commitment = new PS_CommitmentRequest().getCommitment(response);
-                commitmentService.updateRecurringDonation(recordId, commitment);
+                commitmentService.updateRecurringDonation(recordId, response);
+
             } else {
-                processError(response.getErrorMessages(), recordId);
+                processError(recordId, response.getErrorMessages());
             }
 
-        } catch (CalloutException e) {
+        } catch (Exception e) {
             UTIL_AuraEnabledCommon.throwAuraHandledException(e.getMessage());
 
-        } catch (JSONException e) {
-            UTIL_AuraEnabledCommon.throwAuraHandledException(e.getMessage());
-
-        }
+         }
 
         return JSON.serialize(response);
     }
 
     /**
-    * @description Process Elevate create commitment error
-    * @param errorMessage error message
+    * @description Creates an error record for the specified record Id and error message
     * @param recordId Recurring Donation Id
+    * @param errorMessage Error message
+    * @return void
     */
-    private static void processError(String errorMessage, Id recordId) {
+    private static void processError(Id recordId, String errorMessage) {
         RD2_ElevateIntegrationService.Logger errorLogger = new RD2_ElevateIntegrationService.Logger();
-                errorLogger.addError(
-                    recordId,
-                    errorMessage,
-                    RD2_ElevateIntegrationService.LOG_TYPE_COMMITMENT_CREATE
-                );
+        errorLogger.addError(
+            recordId,
+            errorMessage,
+            RD2_ElevateIntegrationService.LOG_TYPE_COMMITMENT_CREATE
+        );
 
-                errorLogger.processErrors();
+        errorLogger.processErrors();
     }
     /**
     * @description Handles sending commitment request and saving its values on the RD
@@ -393,22 +391,34 @@ public with sharing class RD2_EntryFormController {
         /***
         * @description Saves commitment Id and the credit card data onto the Recurring Donation record.
         * @param recordId Recurring Donation Id
-        * @param commitment JSON deserialize response body from Elevate commitment create request
+        * @param response Response from Elevate on the commitment create request
         * @return void
         */
-        public void updateRecurringDonation(Id recordId, PS_CommitmentRequest.ResponseBody commitment) {
-            if (commitment.hasId()) {
-                npe03__Recurring_Donation__c rd = new npe03__Recurring_Donation__c(
-                    Id = recordId,
-                    CommitmentId__c = commitment.id,
-                    CardLast4__c = commitment.getCardLast4(),
-                    CardExpirationMonth__c = commitment.getCardExpirationMonth(),
-                    CardExpirationYear__c = commitment.getCardExpirationYear()
-                );
+        public void updateRecurringDonation(Id recordId, UTIL_Http.Response response) {
+            if (response == null
+                || response.statusCode != UTIL_Http.STATUS_CODE_CREATED
+            ) {
+                return;
+            }
 
-                UTIL_DMLService.updateRecordBatchAndLogErrors(
-                    new List<npe03__Recurring_Donation__c>{ rd }, ERR_Handler_API.Context.Elevate.name()
-                );
+            try {
+                PS_CommitmentRequest.ResponseBody commitment = new PS_CommitmentRequest().getCommitment(response);
+
+                if (commitment.hasId()) {
+                    npe03__Recurring_Donation__c rd = new npe03__Recurring_Donation__c(
+                        Id = recordId,
+                        CommitmentId__c = commitment.id,
+                        CardLast4__c = commitment.getCardLast4(),
+                        CardExpirationMonth__c = commitment.getCardExpirationMonth(),
+                        CardExpirationYear__c = commitment.getCardExpirationYear()
+                    );
+
+                    UTIL_DMLService.updateRecordBatchAndLogErrors(
+                        new List<npe03__Recurring_Donation__c>{ rd }, ERR_Handler_API.Context.Elevate.name()
+                    );
+                }
+            } catch (Exception e) {
+                throw e;
             }
 
            

--- a/src/classes/RD2_EntryFormController.cls
+++ b/src/classes/RD2_EntryFormController.cls
@@ -301,7 +301,6 @@ public with sharing class RD2_EntryFormController {
         }
 
         UTIL_Http.Response response;
-        String errorMessage;
 
         try {
             response = commitmentService.sendRequest(recordId, jsonRequestBody);
@@ -310,7 +309,7 @@ public with sharing class RD2_EntryFormController {
                 PS_CommitmentRequest.ResponseBody commitment = new PS_CommitmentRequest().getCommitment(response);
                 commitmentService.updateRecurringDonation(recordId, commitment);
             } else {
-                errorMessage = response.getErrorMessages();
+                processError(response.getErrorMessages(), recordId);
             }
 
         } catch (CalloutException e) {
@@ -319,10 +318,6 @@ public with sharing class RD2_EntryFormController {
         } catch (JSONException e) {
             UTIL_AuraEnabledCommon.throwAuraHandledException(e.getMessage());
 
-        } finally {
-            if (String.isNotBlank(errorMessage)) {
-                processError(errorMessage, recordId);
-            }
         }
 
         return JSON.serialize(response);
@@ -398,7 +393,7 @@ public with sharing class RD2_EntryFormController {
         /***
         * @description Saves commitment Id and the credit card data onto the Recurring Donation record.
         * @param recordId Recurring Donation Id
-        * @param commitment Commitment response body from Elevate on the commitment create request
+        * @param commitment JSON deserialize response body from Elevate commitment create request
         * @return void
         */
         public void updateRecurringDonation(Id recordId, PS_CommitmentRequest.ResponseBody commitment) {

--- a/src/classes/RD2_EntryFormController_TEST.cls
+++ b/src/classes/RD2_EntryFormController_TEST.cls
@@ -394,9 +394,13 @@ private with sharing class RD2_EntryFormController_TEST {
 
         List<Error__c> errors = errorGateway.getRecords();
         System.assertEquals(1, errors.size(),
-            'one error record should be created when the elevate returns error response');
+            'An error record should be created for an error response.');
+        System.assertEquals(rd.Id, errors[0].Related_Record_Id__c,
+            'The error record should contain RD record Id.');
+        System.assertEquals(ERR_Handler_API.Context.Elevate.name(),errors[0].Context_Type__c,
+            'The error record context type should match with Elevate context.');
         System.assert(errors[0].Full_Message__c.contains(UTIL_Http_TEST.BAD_REQUEST_MESSAGE),
-            'The error record should contains the message from the error response');
+            'The error record should contain error response message.');
     }
     
 

--- a/src/classes/RD2_EntryFormController_TEST.cls
+++ b/src/classes/RD2_EntryFormController_TEST.cls
@@ -46,6 +46,7 @@ private with sharing class RD2_EntryFormController_TEST {
     private static final String CARD_EXPIRATION_YEAR = '2019';
 
     private static final TEST_SObjectGateway.RecurringDonationGateway rdGateway = new TEST_SObjectGateway.RecurringDonationGateway();
+    private static final TEST_SObjectGateway.ErrorGateway errorGateway = new TEST_SObjectGateway.ErrorGateway();
 
     /****
     * @description Creates data required for unit tests
@@ -364,6 +365,38 @@ private with sharing class RD2_EntryFormController_TEST {
             'An exception should be generated when Recurring Donation Id is not provided');
         System.assertEquals(System.Label.RD2_ErrorRDIdIsMissingForCommitment, actualException.getMessage(),
             'The exception should be match');
+    }
+
+    /**
+    * @description Verifies an error record will be created when an error response is received from the Elevate API.
+    */
+    @isTest
+    private static void shouldCreateErrorRecordWhenElevateReturnsErrorResponse() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+        PS_IntegrationService.setConfiguration(PS_IntegrationServiceConfig_TEST.testConfig);
+
+        npe03__Recurring_Donation__c rd = TEST_RecurringDonationBuilder.constructEnhancedBuilder()
+            .withDefaultValues()
+            .withContact(getContact().Id)
+            .withAmount(100)
+            .withDateEstablished(START_DATE)
+            .withStartDate(START_DATE)
+            .withDayOfMonth('1')
+            .withCommitmentId(TEMP_COMMITMENT_ID)
+            .build();
+        insert rd;
+
+        Test.startTest();
+        UTIL_Http_TEST.mockBadRequestCalloutResponse();
+
+        String jsonResponse = RD2_EntryFormController.createCommitment(rd.Id, PAYMENT_METHOD_TOKEN);
+        Test.stopTest();
+
+        List<Error__c> errors = errorGateway.getRecords();
+        System.assertEquals(1, errors.size(),
+            'one error record should be created when the elevate returns error response');
+        System.assert(errors[0].Full_Message__c.contains(UTIL_Http_TEST.BAD_REQUEST_MESSAGE),
+            'The error record should contains the message from the error response');
     }
     
 

--- a/src/classes/UTIL_Http.cls
+++ b/src/classes/UTIL_Http.cls
@@ -189,9 +189,7 @@ public without sharing class UTIL_Http {
                 );
                 messages = responseBody.getMessages();
 
-            } catch (JSONException e) {
-                throw e;
-            }
+            } catch (Exception e) { }
 
             return String.isBlank(messages) ? status : messages;
         }

--- a/src/classes/UTIL_Http.cls
+++ b/src/classes/UTIL_Http.cls
@@ -189,7 +189,9 @@ public without sharing class UTIL_Http {
                 );
                 messages = responseBody.getMessages();
 
-            } catch (Exception e) { }
+            } catch (JSONException e) {
+                throw e;
+            }
 
             return String.isBlank(messages) ? status : messages;
         }


### PR DESCRIPTION
As a user I want to be presented with clear error messages when commitment either cannot be created or if created, cannot be connected to the Recurring Donation.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
