### PR TITLE
W-8486213 - ACH - Add Payment Paid field to Data Import

### DIFF
--- a/src/classes/STG_InstallScript.cls
+++ b/src/classes/STG_InstallScript.cls
@@ -465,6 +465,7 @@ global without sharing class STG_InstallScript implements InstallHandler {
                     'Payment_Origin_ID',
                     'Payment_Origin_Name',
                     'Payment_Origin_Type',
+                    'Payment_Paid',
                     'Payment_Type',
                     'Donation_Elevate_Recurring_ID'
             };

--- a/src/customMetadata/Data_Import_Field_Mapping.Payment_Paid.md
+++ b/src/customMetadata/Data_Import_Field_Mapping.Payment_Paid.md
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Payment Paid</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Is_Deleted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">npsp__Payment_Paid__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">npe01__Paid__c</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">Payment</value>
+    </values>
+</CustomMetadata>

--- a/src/objects/DataImport__c.object
+++ b/src/objects/DataImport__c.object
@@ -1578,6 +1578,31 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>Payment_Paid__c</fullName>
+        <externalId>false</externalId>
+        <description>Indicates if this payment is paid or not.</description>
+        <inlineHelpText>Indicates if this payment is paid or not.</inlineHelpText>
+        <label>Payment Paid</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Picklist</type>
+        <valueSet>
+            <valueSetDefinition>
+                <sorted>false</sorted>
+                <value>
+                    <fullName>Yes</fullName>
+                    <default>false</default>
+                    <label>Yes</label>
+                </value>
+                <value>
+                    <fullName>No</fullName>
+                    <default>false</default>
+                    <label>No</label>
+                </value>                
+            </valueSetDefinition>
+        </valueSet>
+    </fields>
+    <fields>
         <fullName>Payment_Possible_Matches__c</fullName>
         <description>A comma-separated list of Ids for the first 10 possible Payment matches for a Donation.</description>
         <externalId>false</externalId>

--- a/src/objects/DataImport__c.object
+++ b/src/objects/DataImport__c.object
@@ -1590,14 +1590,14 @@
             <valueSetDefinition>
                 <sorted>false</sorted>
                 <value>
-                    <fullName>Yes</fullName>
+                    <fullName>True</fullName>
                     <default>false</default>
-                    <label>Yes</label>
+                    <label>True</label>
                 </value>
                 <value>
-                    <fullName>No</fullName>
+                    <fullName>False</fullName>
                     <default>false</default>
-                    <label>No</label>
+                    <label>False</label>
                 </value>                
             </valueSetDefinition>
         </valueSet>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1161,6 +1161,7 @@
         <members>DataImport__c.Payment_Origin_ID__c</members>
         <members>DataImport__c.Payment_Origin_Name__c</members>
         <members>DataImport__c.Payment_Origin_Type__c</members>
+        <members>DataImport__c.Payment_Paid__c</members>
         <members>DataImport__c.Payment_Possible_Matches__c</members>
         <members>DataImport__c.Payment_Status__c</members>
         <members>DataImport__c.Payment_Type__c</members>
@@ -3210,6 +3211,7 @@
         <members>Data_Import_Field_Mapping.Payment_Origin_ID</members>
         <members>Data_Import_Field_Mapping.Payment_Origin_Name</members>
         <members>Data_Import_Field_Mapping.Payment_Origin_Type</members>
+        <members>Data_Import_Field_Mapping.Payment_Paid</members>
         <members>Data_Import_Field_Mapping.Payment_Type</members>
         <members>Data_Import_Field_Mapping_Set.Default_Field_Mapping_Set</members>
         <members>Data_Import_Object_Mapping.Account1</members>


### PR DESCRIPTION
[W-8486213](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008jtc7IAA/view) - Elevate - ACH - Add the Payment Paid field to Data Import

To test npsp update-script you can just run the following script in Dev Console:
```
List<String> newDefaultMappingStrings = new List<String>{'Payment_Paid'};
BDI_MigrationMappingHelper helper = new BDI_MigrationMappingHelper();
BDI_MigrationMappingUtility util = new BDI_MigrationMappingUtility(helper);
util.migrateNewDefaultToCustomMetadata(newDefaultMappingStrings);
```

# Critical Changes

# Changes
- New fields on Data Import: `Payment_Paid__c`
- New Custom Metadata Mapping between Payment's field `npe01__Paid__c` and Data Import's field `Payment_Paid__c`
- Updates to `STG_InstallScripts.cls` to include new advance mapping.

# Issues Closed

# Community Ideas Delivered

# New Metadata
- New custom field: DataImport__c.Payment_Paid__c 
- New custom metadata: Data_Import_Field_Mapping.Payment_Paid.md

# Deleted Metadata
