### PR TITLE
Gift Entry: Fix for default values not overriding blank values from a related record

### DIFF
--- a/src/lwc/geBatchWizard/geBatchWizard.js
+++ b/src/lwc/geBatchWizard/geBatchWizard.js
@@ -229,12 +229,11 @@ export default class geBatchWizard extends NavigationMixin(LightningElement) {
                         if (isTrueFalsePicklist(fieldMapping)) {
                             element.picklistOptionsOverride = trueFalsePicklistOptions();
                         }
-
-                        Object.defineProperty(element, 'showDefaultValueInput', {
-                            get: function() { return this.dataType !== 'BOOLEAN' || !!this.picklistOptionsOverride; }
-                        });
-
                     }
+
+                    Object.defineProperty(element, 'showDefaultValueInput', {
+                        get: function() { return this.dataType !== 'BOOLEAN' || !!this.picklistOptionsOverride; }
+                    });
                 });
             }
         });

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -1298,7 +1298,7 @@ export default class GeFormRenderer extends LightningElement{
     getFieldValueForFormState(valueObject, fieldMapping) {
         const { value } = valueObject;
 
-        if (valueObject === null) {
+        if (value === null) {
             return this.defaultValueFor(fieldMapping.DeveloperName);
         } else if (isTrueFalsePicklist(fieldMapping)) {
             return this.transformForTrueFalsePicklist(value);


### PR DESCRIPTION
Part of this WorkItem: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008EI1TIAW/view
Fixes bug introduced in #6060 in [geFormRenderer](https://github.com/SalesforceFoundation/NPSP/pull/6060/files#diff-9245b98b99d94e57aa432f74669eb57fe9e2146c1b4670cc93e42ffd0dded09fR1301)

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
