### PR TITLE
Update text on Elevate widget in template builder

### DIFF
--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -7910,6 +7910,14 @@ If preferred, you can disable Gift Entry and instead use older Batch Gift Entry 
         <value>Note: This field bundle is only available for single gifts and will not show up when entering batches of gifts.</value>
     </labels>
     <labels>
+        <fullName>geTextFieldBundlePaymentMethod</fullName>
+        <categories>Gift Entry</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Instructions to add Payment Method</shortDescription>
+        <value>Salesforce.org Elevate field bundle includes fields for entering payment information. Allow users to switch payment types by adding Payment Method from the Payment object to the form before this field bundle.</value>
+    </labels>
+    <labels>
         <fullName>geJWTUtilInvalidBase64Message</fullName>
         <categories>Gift Entry</categories>
         <language>en_US</language>

--- a/src/lwc/geLabelService/geLabelService.js
+++ b/src/lwc/geLabelService/geLabelService.js
@@ -197,6 +197,7 @@ import geTabBatchSettings from '@salesforce/label/c.geTabBatchSettings';
 import geTabBatchTableColumns from '@salesforce/label/c.geTabBatchTableColumns';
 import geTabFormFields from '@salesforce/label/c.geTabFormFields';
 import geTabTemplateInfo from '@salesforce/label/c.geTabTemplateInfo';
+import geTextFieldBundlePaymentMethod from '@salesforce/label/c.geTextFieldBundlePaymentMethod';
 import geTextChargingCard from '@salesforce/label/c.geTextChargingCard';
 import geTextListViewItemCount from '@salesforce/label/c.geTextListViewItemCount';
 import geTextListViewItemsCount from '@salesforce/label/c.geTextListViewItemsCount';
@@ -424,6 +425,7 @@ class GeLabelService {
         geTabBatchTableColumns,
         geTabFormFields,
         geTabTemplateInfo,
+        geTextFieldBundlePaymentMethod,
         geTextChargingCard,
         geTextListViewItemCount,
         geTextListViewItemsCount,

--- a/src/lwc/geTemplateBuilderFormField/geTemplateBuilderFormField.html
+++ b/src/lwc/geTemplateBuilderFormField/geTemplateBuilderFormField.html
@@ -18,7 +18,7 @@
                     </div>
                 </template>
                 <template if:true={shouldRender}>
-                    <div class="slds-size_5-of-12 slds-p-right_small">
+                    <div class={renderedWidgetClass}>
                         <template if:true={showDefaultValueInput}>
                             <c-util-input type={field.dataType}
                                           form-field-type={field.elementType}
@@ -35,9 +35,6 @@
                             </c-util-input>
                         </template>
                     </div>
-                <template if:true={isWidget}>
-                    <div class="slds-size_5-of-12 slds-p-right_small"></div>
-                </template>
                     <div class="slds-size_1-of-12 slds-p-left_large slds-p-bottom_x-small">
                         <template if:true={showRequiredCheckbox}>
                             <lightning-input aria-label={labelGeAssistiveRequireField}

--- a/src/lwc/geTemplateBuilderFormField/geTemplateBuilderFormField.js
+++ b/src/lwc/geTemplateBuilderFormField/geTemplateBuilderFormField.js
@@ -106,6 +106,14 @@ export default class geTemplateBuilderFormField extends LightningElement {
         }
     }
 
+    get renderedWidgetClass() {
+        if (this.isWidget) {
+            return 'slds-size_10-of-12 slds-p-right_small';
+        } else {
+            return 'slds-size_5-of-12 slds-p-right_small';
+        }
+    }
+
     get name() {
         if (this.field.elementType === WIDGET) {
             return this.field.componentName;

--- a/src/lwc/geTemplateBuilderWidget/geTemplateBuilderWidget.html
+++ b/src/lwc/geTemplateBuilderWidget/geTemplateBuilderWidget.html
@@ -1,21 +1,23 @@
 <template>
-    <div class="slds-grid slds-wrap">
-        <div class="slds-size_1-of-1 slds-p-bottom_xx-small">
-            <label class="slds-text-body_regular widget-label">{uiTitle}</label>
-        </div>
-        <div class="slds-size_1-of-1 slds-p-left_small">
-            <template if:true={isAllocations}>
-                <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonGeneralAccountUnit}</p>
-                <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonAmount}</p>
-                <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonPercent}</p>
-            </template>
-
-            <template if:true={isTokenizeCard}>
-                <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonCreditNumber}</p>
-                <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonCardType}</p>
-                <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonMMYY}</p>
-                <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonCVV}</p>
-            </template>
-        </div>
-    </div>
+    <lightning-layout>
+        <lightning-layout-item size="12" class="slds-p-left_small">
+            <lightning-layout>
+                <template if:true={isAllocations}>
+                    <lightning-layout-item size="12">
+                        <label class="slds-text-body_regular widget-label slds-p-bottom_xx-small">{uiTitle}</label>
+                        <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonGeneralAccountUnit}</p>
+                        <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonAmount}</p>
+                        <p class="slds-text-body_regular widget-text">{CUSTOM_LABELS.commonPercent}</p>
+                    </lightning-layout-item>
+                </template>
+                <template if:true={isTokenizeCard}>
+                    <lightning-layout-item size="12">
+                        <p class="slds-text-body_regular slds-text-title_bold widget-text">
+                            {CUSTOM_LABELS.geTextFieldBundlePaymentMethod }
+                        </p>
+                    </lightning-layout-item>
+                </template>
+            </lightning-layout>
+        </lightning-layout-item>
+    </lightning-layout>
 </template>

--- a/src/package.xml
+++ b/src/package.xml
@@ -2471,6 +2471,7 @@
         <members>geTabFormFields</members>
         <members>geTabTemplateInfo</members>
         <members>geTextChargingCard</members>
+        <members>geTextFieldBundlePaymentMethod</members>
         <members>geTextListViewItemCount</members>
         <members>geTextListViewItemsCount</members>
         <members>geTextListViewSortedBy</members>


### PR DESCRIPTION
# Critical Changes

# Changes
Text will now display in the elevate widget in the template builder to let the admin know they should add the payment method field to the template if it's not already there.

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
