### PR TITLE
Fix Status to State Mapping page invalid Deployment Id error

### DIFF
--- a/src/classes/RD2_StatusMappingSettings_CTRL.cls
+++ b/src/classes/RD2_StatusMappingSettings_CTRL.cls
@@ -415,6 +415,7 @@ public with sharing class RD2_StatusMappingSettings_CTRL {
                             // there are known scenarios that result in an invalid deployment id
                             // - metadata deployments older than 30 days can no longer be retrieved
                             // - sandbox created/refreshed from org with RD2 and a status to state mapping
+                            deployResult = null;
                         }
                     }
                 }

--- a/src/classes/RD2_StatusMappingSettings_CTRL.cls
+++ b/src/classes/RD2_StatusMappingSettings_CTRL.cls
@@ -116,6 +116,7 @@ public with sharing class RD2_StatusMappingSettings_CTRL {
     * The state values and labels are sourced from the RD Status field picklist field
     * since state values are already contained in the Status field
     * so there is no need to create new custom labels to hold the state labels.
+    @ @return Map<String, String>
     */
     private static Map<String, String> mapStateLabelByValue() {
         Map<String, String> stateLabelByValue = new Map<String, String>();
@@ -139,6 +140,7 @@ public with sharing class RD2_StatusMappingSettings_CTRL {
 
     /***
     * @description NPSP namespace: an empty string if unmanaged, or 'npsp' if managed
+    * @return String
     */
     public String getNamespace() {
         return UTIL_Namespace.getNamespace();
@@ -405,7 +407,15 @@ public with sharing class RD2_StatusMappingSettings_CTRL {
             get {
                 if (deployResult == null) {
                     if (String.isNotBlank(deploymentId)) {
-                        deployResult = CMT_MetadataAPI.getDeploymentResult(deploymentId);
+                        try {
+                            deployResult = CMT_MetadataAPI.getDeploymentResult(deploymentId);
+                        }
+                        catch (Exception e) {
+                            // deployResult should remain null if retrieval by deploymentId is unsuccessful
+                            // there are known scenarios that result in an invalid deployment id
+                            // - metadata deployments older than 30 days can no longer be retrieved
+                            // - sandbox created/refreshed from org with RD2 and a status to state mapping
+                        }
                     }
                 }
                 return deployResult;
@@ -432,6 +442,7 @@ public with sharing class RD2_StatusMappingSettings_CTRL {
 
         /**
          * @description Returns deployment Id
+         * @return String
          */
         public String getDeploymentId() {
             return deploymentId;
@@ -439,6 +450,7 @@ public with sharing class RD2_StatusMappingSettings_CTRL {
 
         /**
          * @description Checks if deployment exists for the specified deployment Id
+         * @return Boolean
          */
         public Boolean hasDeployResult() {
             return deployResult != null;
@@ -446,6 +458,7 @@ public with sharing class RD2_StatusMappingSettings_CTRL {
 
         /**
          * @description Checks if deployment is in progress
+         * @return Boolean
          */
         public Boolean isInProgress() {
             return hasDeployResult()
@@ -458,6 +471,7 @@ public with sharing class RD2_StatusMappingSettings_CTRL {
 
         /**
          * @description Checks if deployment succeeded
+         * @return Boolean
          */
         public Boolean isSuccess() {
             return hasDeployResult()
@@ -466,6 +480,7 @@ public with sharing class RD2_StatusMappingSettings_CTRL {
 
         /**
          * @description Returns deployment error message
+         * @return String
          */
         public String getDeployErrorMessage() {
             if (!hasDeployResult()

--- a/src/classes/RD2_StatusMappingSettings_TEST.cls
+++ b/src/classes/RD2_StatusMappingSettings_TEST.cls
@@ -216,6 +216,21 @@ private with sharing class RD2_StatusMappingSettings_TEST {
     }
 
     /**
+     * @description Verifies no exception is generated when attempt is made to retrieve
+     * deployment result with an invalid deployment Id.
+     */
+    @IsTest
+    private static void shouldNotThrowExceptionWhenDeploymentIdIsInvalid() {
+        final String invalidDeploymentId = 'invalidId';
+
+        RD2_StatusMappingSettings_CTRL.DeploymentHandler deploymentHandler =
+            new RD2_StatusMappingSettings_CTRL.DeploymentHandler(invalidDeploymentId);
+
+        System.assertEquals(null, deploymentHandler.deployResult,
+            'Null result is expected when DeploymentHandler attempts retrieval with invalid Deployment Id');
+    }
+
+    /**
      * @description Verifies deployment result is returned for the specified deployment Id
      */
     @IsTest


### PR DESCRIPTION
# Critical Changes

# Changes
 - We fixed an issue that could cause the Recurring Donations Status to State Mapping page to produce a 500 Server error.

# Issues Closed
Fixes #6007

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
