### PR TITLE
Fix Opportunity naming after Enhanced RD edit/pause

### DIFF
--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls
@@ -67,7 +67,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
         } else if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
             upsertContactRolesAfterInsert((list<Opportunity>) newlist);
             try {
-                updateOpportunityNames((list<Opportunity>) newList);            	
+                updateOpportunityNames((list<Opportunity>) newList);            
             } catch (Exception ex) {
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.OPP);
             }
@@ -327,7 +327,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
     private void updateOpportunityNames(list<Opportunity> listOpps) {
         //name opportunities
         Map<Id,Opportunity> mapOppNaming = new Map<Id,Opportunity>(OPP_OpportunityNaming.getOppNamesAfterInsert(listOpps));
-        	
+        
         //update existing dmlWrapper objects with opp name to avoid errors updating the same opportunity twice
         for (sObject dmlObj : dmlWrapper.objectsToUpdate) {
             Id objId = (Id) dmlObj.get('id');
@@ -336,7 +336,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
                 mapOppNaming.remove(objId);
             }
         }
-        	
+        
         for (Opportunity opp : listOpps) {
             //add renamed opportunities that weren't updated as part of the contact roles fixing
             if (mapOppNaming.containsKey(opp.Id) && mapOppNaming.get(opp.id).Name != opp.Name) {

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls
@@ -66,11 +66,13 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
 
         } else if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
             upsertContactRolesAfterInsert((list<Opportunity>) newlist);
-            updateOpportunityNames((list<Opportunity>) newList);
-
+            try {
+                updateOpportunityNames((list<Opportunity>) newList);
+            } catch (Exception ex) {
+                ERR_Handler.processError(ex, ERR_Handler_API.Context.OPP);
+            }
         } else if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
             upsertContactRolesAfterUpdate((list<Opportunity>) newlist, (list<Opportunity>) oldlist);
-            updateOpportunityNames((list<Opportunity>) newList);
         }
 
         // we can't defer the dml.  too many of our other opp related triggers depend on the ocr's being saved.
@@ -323,29 +325,23 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
     * @param listOpps List of opportunities from trigger.new
     ********************************************************************************************************/
     private void updateOpportunityNames(list<Opportunity> listOpps) {
-        try {
-            //name opportunities
-            Map<Id,Opportunity> mapOppNaming = new Map<Id,Opportunity>(OPP_OpportunityNaming.getOppNamesAfterInsert(listOpps));
+        //name opportunities
+        Map<Id,Opportunity> mapOppNaming = new Map<Id,Opportunity>(OPP_OpportunityNaming.getOppNamesAfterInsert(listOpps));
 
-            //update existing dmlWrapper objects with opp name to avoid errors updating the same opportunity twice
-            for (sObject dmlObj : dmlWrapper.objectsToUpdate) {
-                Id objId = (Id) dmlObj.get('id');
-                if (mapOppNaming.containsKey(objId)) {
-                    dmlObj.put('Name', mapOppNaming.get(objId).Name);
-                    mapOppNaming.remove(objId);
-                }
+        //update existing dmlWrapper objects with opp name to avoid errors updating the same opportunity twice
+        for (sObject dmlObj : dmlWrapper.objectsToUpdate) {
+            Id objId = (Id) dmlObj.get('id');
+            if (mapOppNaming.containsKey(objId)) {
+                dmlObj.put('Name', mapOppNaming.get(objId).Name);
+                mapOppNaming.remove(objId);
             }
+        }
 
-            for (Opportunity opp : listOpps) {
-                //add renamed opportunities that weren't updated as part of the contact roles fixing
-                if (mapOppNaming.containsKey(opp.Id) && mapOppNaming.get(opp.id).Name != opp.Name) {
-                    System.debug('Opportunity name after Contact Roles name update - ' + mapOppNaming.get(opp.id).Name);
-                    dmlWrapper.objectsToUpdate.add((sObject) mapOppNaming.get(opp.id));
-                }
+        for (Opportunity opp : listOpps) {
+            //add renamed opportunities that weren't updated as part of the contact roles fixing
+            if (mapOppNaming.containsKey(opp.Id) && mapOppNaming.get(opp.id).Name != opp.Name) {
+                dmlWrapper.objectsToUpdate.add((sObject) mapOppNaming.get(opp.id));
             }
-
-        } catch (Exception ex) {
-            ERR_Handler.processError(ex, ERR_Handler_API.Context.OPP);
         }
     }
 

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls
@@ -67,7 +67,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
         } else if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
             upsertContactRolesAfterInsert((list<Opportunity>) newlist);
             try {
-                updateOpportunityNames((list<Opportunity>) newList);
+                updateOpportunityNames((list<Opportunity>) newList);            	
             } catch (Exception ex) {
                 ERR_Handler.processError(ex, ERR_Handler_API.Context.OPP);
             }
@@ -327,7 +327,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
     private void updateOpportunityNames(list<Opportunity> listOpps) {
         //name opportunities
         Map<Id,Opportunity> mapOppNaming = new Map<Id,Opportunity>(OPP_OpportunityNaming.getOppNamesAfterInsert(listOpps));
-
+        	
         //update existing dmlWrapper objects with opp name to avoid errors updating the same opportunity twice
         for (sObject dmlObj : dmlWrapper.objectsToUpdate) {
             Id objId = (Id) dmlObj.get('id');
@@ -336,7 +336,7 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
                 mapOppNaming.remove(objId);
             }
         }
-
+        	
         for (Opportunity opp : listOpps) {
             //add renamed opportunities that weren't updated as part of the contact roles fixing
             if (mapOppNaming.containsKey(opp.Id) && mapOppNaming.get(opp.id).Name != opp.Name) {

--- a/src/classes/OPP_OpportunityContactRoles_TDTM.cls
+++ b/src/classes/OPP_OpportunityContactRoles_TDTM.cls
@@ -66,13 +66,11 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
 
         } else if (triggerAction == TDTM_Runnable.Action.AfterInsert) {
             upsertContactRolesAfterInsert((list<Opportunity>) newlist);
-            try {
-                updateOpportunityNames((list<Opportunity>) newList);            
-            } catch (Exception ex) {
-                ERR_Handler.processError(ex, ERR_Handler_API.Context.OPP);
-            }
+            updateOpportunityNames((list<Opportunity>) newList);
+
         } else if (triggerAction == TDTM_Runnable.Action.AfterUpdate) {
             upsertContactRolesAfterUpdate((list<Opportunity>) newlist, (list<Opportunity>) oldlist);
+            updateOpportunityNames((list<Opportunity>) newList);
         }
 
         // we can't defer the dml.  too many of our other opp related triggers depend on the ocr's being saved.
@@ -325,23 +323,29 @@ public without sharing class OPP_OpportunityContactRoles_TDTM extends TDTM_Runna
     * @param listOpps List of opportunities from trigger.new
     ********************************************************************************************************/
     private void updateOpportunityNames(list<Opportunity> listOpps) {
-        //name opportunities
-        Map<Id,Opportunity> mapOppNaming = new Map<Id,Opportunity>(OPP_OpportunityNaming.getOppNamesAfterInsert(listOpps));
-        
-        //update existing dmlWrapper objects with opp name to avoid errors updating the same opportunity twice
-        for (sObject dmlObj : dmlWrapper.objectsToUpdate) {
-            Id objId = (Id) dmlObj.get('id');
-            if (mapOppNaming.containsKey(objId)) {
-                dmlObj.put('Name', mapOppNaming.get(objId).Name);
-                mapOppNaming.remove(objId);
+        try {
+            //name opportunities
+            Map<Id,Opportunity> mapOppNaming = new Map<Id,Opportunity>(OPP_OpportunityNaming.getOppNamesAfterInsert(listOpps));
+
+            //update existing dmlWrapper objects with opp name to avoid errors updating the same opportunity twice
+            for (sObject dmlObj : dmlWrapper.objectsToUpdate) {
+                Id objId = (Id) dmlObj.get('id');
+                if (mapOppNaming.containsKey(objId)) {
+                    dmlObj.put('Name', mapOppNaming.get(objId).Name);
+                    mapOppNaming.remove(objId);
+                }
             }
-        }
-        
-        for (Opportunity opp : listOpps) {
-            //add renamed opportunities that weren't updated as part of the contact roles fixing
-            if (mapOppNaming.containsKey(opp.Id) && mapOppNaming.get(opp.id).Name != opp.Name) {
-                dmlWrapper.objectsToUpdate.add((sObject) mapOppNaming.get(opp.id));
+
+            for (Opportunity opp : listOpps) {
+                //add renamed opportunities that weren't updated as part of the contact roles fixing
+                if (mapOppNaming.containsKey(opp.Id) && mapOppNaming.get(opp.id).Name != opp.Name) {
+                    System.debug('Opportunity name after Contact Roles name update - ' + mapOppNaming.get(opp.id).Name);
+                    dmlWrapper.objectsToUpdate.add((sObject) mapOppNaming.get(opp.id));
+                }
             }
+
+        } catch (Exception ex) {
+            ERR_Handler.processError(ex, ERR_Handler_API.Context.OPP);
         }
     }
 


### PR DESCRIPTION
# Critical Changes

# Changes
We fixed an issue with Opportunity naming after edit or pause of an Enhanced Recurring Donation.

# Issues Closed
Fixes #5896

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
