### PR TITLE
Use minimum access profile in UTIL_Profile when available

### DIFF
--- a/src/classes/AN_AutoNumberService_TEST.cls
+++ b/src/classes/AN_AutoNumberService_TEST.cls
@@ -195,7 +195,7 @@ private class AN_AutoNumberService_TEST {
         utility.setupAutoNumber(true,
                 'ABCZZZ-{000}', 100, true);
 
-        System.runAs(UTIL_UnitTestData_TEST.createUser('Standard User')) {
+        System.runAs(UTIL_UnitTestData_TEST.createUser(UTIL_Profile.PROFILE_STANDARD_USER)) {
             System.assertEquals(false, Schema.SObjectType.DataImportBatch__c.fields
                     .Batch_Number__c.isAccessible(),
                     'This Standard User created for the test should not have read access ' +

--- a/src/classes/UTIL_Permissions_TEST.cls
+++ b/src/classes/UTIL_Permissions_TEST.cls
@@ -63,7 +63,7 @@ public with sharing class UTIL_Permissions_TEST {
                 UTIL_Permissions.canCreate(standardObjectName);
             } catch (Exception ex) {
                 System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException,
-                    'Minimum access user should not have create access to standard/custom object.');
+                    'Minimum access user should not have create access to standard object.');
             }
         }
     }
@@ -83,7 +83,7 @@ public with sharing class UTIL_Permissions_TEST {
                 UTIL_Permissions.canRead(standardObjectName);
             } catch (Exception ex) {
                 System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException,
-                    'Minimum access user should not have read access to standard/custom object.');
+                    'Minimum access user should not have read access to standard.');
             }
         }
     }
@@ -102,7 +102,8 @@ public with sharing class UTIL_Permissions_TEST {
             try {
                 UTIL_Permissions.canUpdate(standardObjectName);
             } catch (Exception ex) {
-                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException,
+                    'Minimum access user should not have edit access to standard.');
             }
         }
     }
@@ -122,7 +123,7 @@ public with sharing class UTIL_Permissions_TEST {
                 UTIL_Permissions.canDelete(standardObjectName);
             } catch (Exception ex) {
                 System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException,
-                    'Minimum access user should not have delete access to standard/custom object.');
+                    'Minimum access user should not have delete access to standard.');
             }
         }
     }

--- a/src/classes/UTIL_Permissions_TEST.cls
+++ b/src/classes/UTIL_Permissions_TEST.cls
@@ -157,6 +157,38 @@ public with sharing class UTIL_Permissions_TEST {
     }
 
     @isTest
+    static void shouldReturnFalseForUserWithoutCreateAccessToFieldByString() {
+        System.runAs(getReadOnlyUser()) {
+            System.assert(!UTIL_Permissions.canCreate(standardObjectName, standardFieldName, false),
+                'Minimum access user should not have create access to standard field.');
+        }
+    }
+
+    @isTest
+    static void shouldReturnFalseForUserWithoutReadAccessToCustomFieldByString() {
+        System.runAs(getReadOnlyUser()) {
+            System.assert(!UTIL_Permissions.canRead(customObjectName, customFieldName, false),
+                'Minimum access user should not have read access to custom field.');
+        }
+    }
+
+    @isTest
+    static void shouldReturnFalseForUserWithoutUpdateAccessToFieldByString() {
+        System.runAs(getReadOnlyUser()) {
+            System.assert(!UTIL_Permissions.canUpdate(standardObjectName, standardFieldName, false),
+                'Minimum access user should not have update access to standard field.');
+        }
+    }
+
+    @isTest
+    static void shouldReturnFalseForUserWithoutDeleteAccessToCustomFieldByString() {
+        System.runAs(getReadOnlyUser()) {
+            System.assert(!UTIL_Permissions.canUpdate(customObjectName, customFieldName, false),
+                'Minimum access user should not have delete access to custom field.');
+        }
+    }
+
+    @isTest
     static void shouldReturnTrueForUserWithoutCreateAccessAfterPermissionAssignment() {
         User readOnlyUser = UTIL_UnitTestData_TEST.createUser(UTIL_Profile.PROFILE_READ_ONLY);
         User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);

--- a/src/classes/UTIL_Permissions_TEST.cls
+++ b/src/classes/UTIL_Permissions_TEST.cls
@@ -47,6 +47,145 @@ public with sharing class UTIL_Permissions_TEST {
     private static String standardObjectName = 'Contact';
     private static String standardFieldName = 'FirstName';
 
+
+    @isTest
+    static void shouldReturnTrueForUserWithCreateAccessToObjectByString() {
+        System.runAs(getSysAdmin()) {
+            System.assert(UTIL_Permissions.canCreate(standardObjectName),
+                'Privileged user should have create access to standard object.');
+        }
+    }
+
+    @isTest
+    static void shouldThrowExceptionForUserWithoutCreateAccessToObjectByString() {
+        System.runAs(getReadOnlyUser()) {
+            try {
+                UTIL_Permissions.canCreate(standardObjectName);
+            } catch (Exception ex) {
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException,
+                    'Minimum access user should not have create access to standard/custom object.');
+            }
+        }
+    }
+
+    @isTest
+    static void shouldReturnTrueForUserWithReadAccessToObjectByString() {
+        System.runAs(getSysAdmin()) {
+            System.assert(UTIL_Permissions.canRead(standardObjectName),
+                'Privileged user should have read access to standard object.');
+        }
+    }
+
+    @isTest
+    static void shouldThrowExceptionForUserWithoutReadAccessToObjectByString() {
+        System.runAs(getReadOnlyUser()) {
+            try {
+                UTIL_Permissions.canRead(standardObjectName);
+            } catch (Exception ex) {
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException,
+                    'Minimum access user should not have read access to standard/custom object.');
+            }
+        }
+    }
+
+    @isTest
+    static void shouldReturnTrueForUserWithEditAccessToObjectByString() {
+        System.runAs(getSysAdmin()) {
+            System.assert(UTIL_Permissions.canUpdate(standardObjectName),
+                'Privileged user should have update access to standard object.');
+        }
+    }
+
+    @isTest
+    static void shouldThrowExceptionForUserWithoutEditAccessToObjectByString() {
+        System.runAs(getReadOnlyUser()) {
+            try {
+                UTIL_Permissions.canUpdate(standardObjectName);
+            } catch (Exception ex) {
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException);
+            }
+        }
+    }
+
+    @isTest
+    static void shouldReturnTrueForUserWithDeleteAccessToObjectByString() {
+        System.runAs(getSysAdmin()) {
+            System.assert(UTIL_Permissions.canDelete(standardObjectName),
+                'Privileged user should have delete access to standard object.');
+        }
+    }
+
+    @isTest
+    static void shouldThrowExceptionForUserWithoutDeleteAccessToObjectByString() {
+        System.runAs(getReadOnlyUser()) {
+            try {
+                UTIL_Permissions.canDelete(standardObjectName);
+            } catch (Exception ex) {
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException,
+                    'Minimum access user should not have delete access to standard/custom object.');
+            }
+        }
+    }
+
+    @isTest
+    static void shouldReturnTrueForUserWithDeleteAccessToSObjectType() {
+        System.runAs(getSysAdmin()) {
+            UTIL_Permissions utilPermissions = UTIL_Permissions.getInstance();
+            System.assert(utilPermissions.canDelete(Contact.SObjectType),
+                'Privileged user should have delete access to standard object.');
+        }
+    }
+
+    @isTest
+    static void shouldReturnTrueForUserWithCreateAccessToFieldByDescribeFieldResult() {
+        System.runAs(getSysAdmin()) {
+            System.assert(UTIL_Permissions.canCreate(Contact.LastName.getDescribe()),
+                'Privileged user should have create access to standard field.');
+        }
+    }
+
+    @isTest
+    static void shouldThrowExceptionForUserWithoutCreateAccessToFieldByDescribeFieldResult() {
+        System.runAs(getReadOnlyUser()) {
+            try {
+                UTIL_Permissions.canCreate(Contact.LastName.getDescribe());
+            } catch (Exception ex) {
+                System.assert(ex instanceof UTIL_Permissions.InsufficientPermissionException,
+                    'Minimum access user should not have create access to standard field.');
+            }
+        }
+    }
+
+    @isTest
+    static void shouldReturnTrueForUserWithoutCreateAccessAfterPermissionAssignment() {
+        User readOnlyUser = UTIL_UnitTestData_TEST.createUser(UTIL_Profile.PROFILE_READ_ONLY);
+        User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
+        System.runas(adminUser) {
+            Boolean canCreate = true;
+            Boolean canRead = true;
+            Boolean canUpdate = false;
+            Boolean canDelete = false;
+            Boolean canViewAllRecords = false;
+
+            Id permissionSetId = createPermissionSet(
+                standardObjectName,
+                canCreate,
+                canRead,
+                canUpdate,
+                canDelete,
+                canViewAllRecords);
+
+            assignPermissionSet(permissionSetId, readOnlyUser.Id);
+        }
+
+        Test.startTest();
+        System.runas(readOnlyUser) {
+            System.assert(UTIL_Permissions.canCreate(standardObjectName),
+                'Minimum access user should have create access after being assigned permission set.');
+        }
+        Test.stopTest();
+    }
+
     @isTest
     static void readOnlyUserCannotReadCustomObjectException() {
         Boolean exceptionCaught = false;
@@ -77,21 +216,6 @@ public with sharing class UTIL_Permissions_TEST {
         }
 
         System.assert(exceptionCaught);
-    }
-
-    @isTest
-    static void readOnlyUserObjectCheckNoException() {
-        System.runAs(getReadOnlyUser()) {
-            System.assert(!UTIL_Permissions.canRead(customObjectName, false));
-            System.assert(!UTIL_Permissions.canCreate(customObjectName, false));
-            System.assert(!UTIL_Permissions.canUpdate(customObjectName, false));
-            System.assert(!UTIL_Permissions.canDelete(customObjectName, false));
-            System.assert(!UTIL_Permissions.canCreate(standardObjectName, false));
-            System.assert(!UTIL_Permissions.canUpdate(standardObjectName, false));
-            System.assert(!UTIL_Permissions.canDelete(standardObjectName, false));
-            // this one is positive!
-            System.assert(UTIL_Permissions.canRead(standardObjectName, false));
-        }
     }
 
     @isTest
@@ -157,30 +281,6 @@ public with sharing class UTIL_Permissions_TEST {
     }
 
     @isTest
-    static void readOnlyUserFieldCheckNoException() {
-        System.runAs(getReadOnlyUser()) {
-            DescribeFieldResult customFieldResult =
-                UTIL_Describe.getFieldDescribe(customObjectName, customFieldName);
-            DescribeFieldResult standardFieldResult =
-                UTIL_Describe.getFieldDescribe(standardObjectName, standardFieldName);
-
-            System.assert(!UTIL_Permissions.canRead(customObjectName, customFieldName, false));
-            System.assert(!UTIL_Permissions.canCreate(customObjectName, customFieldName, false));
-            System.assert(!UTIL_Permissions.canUpdate(customObjectName, customFieldName, false));
-            System.assert(!UTIL_Permissions.canCreate(standardObjectName, standardFieldName, false));
-            System.assert(!UTIL_Permissions.canUpdate(standardObjectName, standardFieldName, false));
-            System.assert(!UTIL_Permissions.canCreate(customFieldResult, false));
-            System.assert(!UTIL_Permissions.canUpdate(customFieldResult, false));
-            System.assert(!UTIL_Permissions.canCreate(standardFieldResult, false));
-            System.assert(!UTIL_Permissions.canUpdate(standardFieldResult, false));
-
-            // these two are positive!
-            System.assert(UTIL_Permissions.canRead(standardObjectName, standardFieldName, false));
-            System.assert(UTIL_Permissions.canRead(standardFieldResult, false));
-        }
-    }
-
-    @isTest
     static void sysAdminCanUpdateCustomFieldException() {
         Boolean exceptionCaught = false;
 
@@ -237,6 +337,47 @@ public with sharing class UTIL_Permissions_TEST {
             System.assert(perms.canRead(customSObjType, new Set<SObjectField>{ customSObjField }), 'Admin user should have read access to the custom object/field.');
             System.assert(perms.canUpdate(customSObjType, new Set<SObjectField>{ customSObjField }), 'Admin user should have read access to the custom object/field.');
         }
+    }
+
+    /***
+    * @description Inserts a permission set for a provided object
+    */
+    private static Id createPermissionSet(
+        String objectName,
+        Boolean canCreate,
+        Boolean canRead,
+        Boolean canUpdate,
+        Boolean canDelete,
+        Boolean canViewAllRecords) {
+
+        PermissionSet permissionSet = new PermissionSet(
+            Name = 'PermissionTest',
+            Label = 'PermissionTest'
+        );
+
+        insert permissionSet;
+
+        insert new ObjectPermissions (
+            SObjectType = objectName,
+            ParentId = permissionSet.id,
+            PermissionsCreate = canCreate,
+            PermissionsRead = canRead,
+            PermissionsEdit = canUpdate,
+            PermissionsDelete = canDelete,
+            PermissionsViewAllRecords = canViewAllRecords
+        );
+
+        return permissionSet.Id;
+    }
+
+    /***
+    * @description Assigns permission set to user by id
+    */
+    private static void assignPermissionSet(Id permissionSetId, Id userId) {
+        insert new PermissionSetAssignment(
+            AssigneeId = userId,
+            PermissionSetId = permissionSetId
+        );
     }
 
     /***

--- a/src/classes/UTIL_Permissions_TEST.cls
+++ b/src/classes/UTIL_Permissions_TEST.cls
@@ -189,36 +189,6 @@ public with sharing class UTIL_Permissions_TEST {
     }
 
     @isTest
-    static void shouldReturnTrueForUserWithoutCreateAccessAfterPermissionAssignment() {
-        User readOnlyUser = UTIL_UnitTestData_TEST.createUser(UTIL_Profile.PROFILE_READ_ONLY);
-        User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
-        System.runas(adminUser) {
-            Boolean canCreate = true;
-            Boolean canRead = true;
-            Boolean canUpdate = false;
-            Boolean canDelete = false;
-            Boolean canViewAllRecords = false;
-
-            Id permissionSetId = createPermissionSet(
-                standardObjectName,
-                canCreate,
-                canRead,
-                canUpdate,
-                canDelete,
-                canViewAllRecords);
-
-            assignPermissionSet(permissionSetId, readOnlyUser.Id);
-        }
-
-        Test.startTest();
-        System.runas(readOnlyUser) {
-            System.assert(UTIL_Permissions.canCreate(standardObjectName),
-                'Minimum access user should have create access after being assigned permission set.');
-        }
-        Test.stopTest();
-    }
-
-    @isTest
     static void readOnlyUserCannotReadCustomObjectException() {
         Boolean exceptionCaught = false;
 
@@ -369,47 +339,6 @@ public with sharing class UTIL_Permissions_TEST {
             System.assert(perms.canRead(customSObjType, new Set<SObjectField>{ customSObjField }), 'Admin user should have read access to the custom object/field.');
             System.assert(perms.canUpdate(customSObjType, new Set<SObjectField>{ customSObjField }), 'Admin user should have read access to the custom object/field.');
         }
-    }
-
-    /***
-    * @description Inserts a permission set for a provided object
-    */
-    private static Id createPermissionSet(
-        String objectName,
-        Boolean canCreate,
-        Boolean canRead,
-        Boolean canUpdate,
-        Boolean canDelete,
-        Boolean canViewAllRecords) {
-
-        PermissionSet permissionSet = new PermissionSet(
-            Name = 'PermissionTest',
-            Label = 'PermissionTest'
-        );
-
-        insert permissionSet;
-
-        insert new ObjectPermissions (
-            SObjectType = objectName,
-            ParentId = permissionSet.id,
-            PermissionsCreate = canCreate,
-            PermissionsRead = canRead,
-            PermissionsEdit = canUpdate,
-            PermissionsDelete = canDelete,
-            PermissionsViewAllRecords = canViewAllRecords
-        );
-
-        return permissionSet.Id;
-    }
-
-    /***
-    * @description Assigns permission set to user by id
-    */
-    private static void assignPermissionSet(Id permissionSetId, Id userId) {
-        insert new PermissionSetAssignment(
-            AssigneeId = userId,
-            PermissionSetId = permissionSetId
-        );
     }
 
     /***

--- a/src/classes/UTIL_Profile.cls
+++ b/src/classes/UTIL_Profile.cls
@@ -89,7 +89,10 @@ public class UTIL_Profile {
     /** @description True if the Read Only profile exists in the org */
     private static Boolean hasReadOnlyProfile;
 
-    /** @description Read Only Profile Name */
+    /*********************************************************************************************************
+    * @description Read Only Profile Name
+    * Returns PROFILE_MINIMUM_ACCESS if 'Read Only' profile isn't found.
+    */
     public static final String PROFILE_READ_ONLY {
         get {
             String readOnly = 'Read Only';
@@ -118,9 +121,8 @@ public class UTIL_Profile {
 
             if (hasReadOnlyProfile == true) {
                 return readOnly;
-            } else {
-                return PROFILE_MINIMUM_ACCESS;
             }
+            return PROFILE_MINIMUM_ACCESS;
         }
     }
 

--- a/src/classes/UTIL_Profile.cls
+++ b/src/classes/UTIL_Profile.cls
@@ -86,6 +86,9 @@ public class UTIL_Profile {
     /** @description Minimum Access - Salesforce Profile Name */
     public static final String PROFILE_MINIMUM_ACCESS = 'Minimum Access - Salesforce';
 
+    /** @description True if the Read Only profile exists in the org */
+    private static Boolean hasReadOnlyProfile;
+
     /** @description Read Only Profile Name */
     public static final String PROFILE_READ_ONLY {
         get {
@@ -120,9 +123,6 @@ public class UTIL_Profile {
             }
         }
     }
-
-    /** @description True if the Read Only profile exists in the org */
-    private static Boolean hasReadOnlyProfile;
 
     /*********************************************************************************************************
     * @description Checks for any Profile records with the provided Name

--- a/src/classes/UTIL_Profile.cls
+++ b/src/classes/UTIL_Profile.cls
@@ -83,27 +83,57 @@ public class UTIL_Profile {
         }
     }
 
+    /** @description Minimum Access - Salesforce Profile Name */
+    public static final String PROFILE_MINIMUM_ACCESS = 'Minimum Access - Salesforce';
+
     /** @description Read Only Profile Name */
     public static final String PROFILE_READ_ONLY {
         get {
+            String readOnly = 'Read Only';
+
             switch on (UserInfo.getLanguage()) {
                 when 'es' {
-                    return 'Sólo lectura';
+                    readOnly = 'Sólo lectura';
                 }
                 when 'de' {
-                    return 'Standardbenutzer';
+                    readOnly = 'Standardbenutzer';
                 }
                 when 'ja' {
-                    return '参照のみ';
+                    readOnly = '参照のみ';
                 }
                 when 'fr' {
-                    return 'Lecture seule';
+                    readOnly = 'Lecture seule';
                 }
                 when 'NL_nl' {
-                    return 'Alleen-lezen';
+                    readOnly = 'Alleen-lezen';
                 }
             }
-            return 'Read Only';
+
+            if (hasReadOnlyProfile == null) {
+                hasReadOnlyProfile = hasProfile(readOnly);
+            }
+
+            if (hasReadOnlyProfile == true) {
+                return readOnly;
+            } else {
+                return PROFILE_MINIMUM_ACCESS;
+            }
+        }
+    }
+
+    /** @description True if the Read Only profile exists in the org */
+    private static Boolean hasReadOnlyProfile;
+
+    /*********************************************************************************************************
+    * @description Checks for any Profile records with the provided Name
+    * @return BOOLEAN True if query returns at least 1 profile record by the provided Name exists
+    */
+    private static Boolean hasProfile(String profileName) {
+        Integer profileRecordCount = [SELECT count() FROM Profile WHERE Name = :profileName];
+        if (profileRecordCount != null && profileRecordCount > 0) {
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/src/classes/UTIL_Profile.cls
+++ b/src/classes/UTIL_Profile.cls
@@ -132,9 +132,8 @@ public class UTIL_Profile {
         Integer profileRecordCount = [SELECT count() FROM Profile WHERE Name = :profileName];
         if (profileRecordCount != null && profileRecordCount > 0) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
     /** @description static instance of the current class (UTIL_Profile). It is used as the instance in a Singleton context */


### PR DESCRIPTION
We made changes to prevent unit test failures once the 'Read Only' profile is removed from our persistent orgs.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
