### PR TITLE
Ensure proper permissions when accessing the "Refresh Opportunity Names" page in NPSP Settings

### DIFF
--- a/src/classes/STG_PanelOppNamingBatch_CTRL.cls
+++ b/src/classes/STG_PanelOppNamingBatch_CTRL.cls
@@ -1,10 +1,10 @@
 /*
     Copyright (c) 2015, Salesforce.org
     All rights reserved.
-    
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
-    
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -13,18 +13,18 @@
     * Neither the name of Salesforce.org nor the names of
       its contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
- 
+
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 */
 /**
@@ -36,30 +36,57 @@
 public with sharing class STG_PanelOppNamingBatch_CTRL extends STG_Panel {
 
     /*********************************************************************************************************
-    * @description The panel's constructor 
+    * @description The panel's constructor
     */
     public STG_PanelOppNamingBatch_CTRL() {
         isRunningBatch = false;
     }
 
     /*********************************************************************************************************
-    * @description Returns the string Id of the Households panel. 
+    * @description NPSP namespace: an empty string if unmanaged, or 'npsp' if managed
     */
-    public override string idPanel() { return 'idPanelOppNamingBatch'; }
+    public String getNamespace() {
+        String namespace = UTIL_Namespace.getNamespace();
+        if (String.isBlank(namespace)) return 'c';
+        return namespace;
+    }
 
     /*********************************************************************************************************
-    * @description Whether we are running the batch opportunity naming process 
+    * @description Returns the string Id of the Households panel.
     */
-    public boolean isRunningBatch { get; set; }
+    public override String idPanel() { return 'idPanelOppNamingBatch'; }
+
+    /*********************************************************************************************************
+    * @description Whether we are running the batch opportunity naming process
+    */
+    public Boolean isRunningBatch { get; set; }
 
     /*********************************************************************************************************
     * @description Action Method to run batch opportunity renaming.
-    * @return null 
+    * @return null
     */
     public PageReference runBatch() {
         isRunningBatch = true;
         OPP_OpportunityNaming_BATCH batch = new OPP_OpportunityNaming_BATCH();
-        id batchProcessId = database.executeBatch(batch, 200);
+        Id batchProcessId = Database.executeBatch(batch, 200);
         return null;
     }
+
+    /*********************************************************************************************************
+    * @description Check if the running user has update access to the Opportunity sObject and Read access to the
+    * Account and Contact objects
+    * @return Boolean
+    */
+    public Boolean getHasAccess() {
+        String oppObject = Schema.SObjectType.Opportunity.getName();
+        String acctObject = Schema.SObjectType.Account.getName();
+        String contactObject = Schema.SObjectType.Contact.getName();
+
+        return UTIL_Permissions.canRead(oppObject, false) &&
+                UTIL_Permissions.canUpdate(oppObject, false) &&
+                UTIL_Permissions.canRead(acctObject, false) &&
+                UTIL_Permissions.canRead(contactObject, false);
+    }
+
+
 }

--- a/src/classes/STG_PanelOppNamingBatch_CTRL.cls
+++ b/src/classes/STG_PanelOppNamingBatch_CTRL.cls
@@ -47,7 +47,9 @@ public with sharing class STG_PanelOppNamingBatch_CTRL extends STG_Panel {
     */
     public String getNamespace() {
         String namespace = UTIL_Namespace.getNamespace();
-        if (String.isBlank(namespace)) return 'c';
+        if (String.isBlank(namespace)) {
+            return 'c';
+        }
         return namespace;
     }
 
@@ -87,6 +89,4 @@ public with sharing class STG_PanelOppNamingBatch_CTRL extends STG_Panel {
                 UTIL_Permissions.canRead(acctObject, false) &&
                 UTIL_Permissions.canRead(contactObject, false);
     }
-
-
 }

--- a/src/classes/STG_PanelOppNamingBatch_CTRL_TEST.cls
+++ b/src/classes/STG_PanelOppNamingBatch_CTRL_TEST.cls
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Salesforce.org
+ *     All rights reserved.
+ *
+ *     Redistribution and use in source and binary forms, with or without
+ *     modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Salesforce.org nor the names of
+ *       its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *     "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *     FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *     COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *     INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *     BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *     LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *     POSSIBILITY OF SUCH DAMAGE.
+ */
+@isTest
+private class STG_PanelOppNamingBatch_CTRL_TEST {
+
+    /**
+     * @description Validate that the User has the proper permissions to the Opp/Account/Contact object
+     * during page load
+     */
+    @isTest
+    private static void shouldAllowAccessToUser() {
+        User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
+
+        System.runAs(adminUser) {
+            STG_PanelOppNamingBatch_CTRL controller = new STG_PanelOppNamingBatch_CTRL();
+            Boolean hasAccess = controller.getHasAccess();
+
+            System.assertEquals(true, hasAccess, 'The access check should return true if the user has update ' +
+                    'access to the Opportunity object');
+        }
+    }
+
+    /**
+     * @description Validate that the method returns false if User does not have Update permissions to the Opp object
+     */
+    @isTest
+    private static void shouldNotAllowAccessToReadOnlyUser() {
+        User standardUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.PROFILE_READ_ONLY);
+
+        System.runAs(standardUser) {
+            STG_PanelOppNamingBatch_CTRL controller = new STG_PanelOppNamingBatch_CTRL();
+            Boolean hasAccess = controller.getHasAccess();
+
+            System.assertEquals(false, hasAccess, 'The access check should return false if the user does NOT have ' +
+                    'update access to the Opportunity object');
+        }
+    }
+}

--- a/src/classes/STG_PanelOppNamingBatch_CTRL_TEST.cls-meta.xml
+++ b/src/classes/STG_PanelOppNamingBatch_CTRL_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/STG_PanelPaymentMapping_CTRL.cls
+++ b/src/classes/STG_PanelPaymentMapping_CTRL.cls
@@ -45,7 +45,9 @@ public with sharing class STG_PanelPaymentMapping_CTRL extends STG_Panel {
     */
     public String getNamespace() {
         String namespace = UTIL_Namespace.getNamespace();
-        if (String.isBlank(namespace)) return 'c';
+        if (String.isBlank(namespace)) {
+            return 'c';
+        }
         return namespace;
     }
 
@@ -102,7 +104,7 @@ public with sharing class STG_PanelPaymentMapping_CTRL extends STG_Panel {
             'npe01__Opportunity__c', 'npe01__Paid__c', 'npe01__Payment_Amount__c', 'npe01__Payment_Date__c',
             'npe01__Written_Off__c'};
         Map<String, Schema.SObjectField> targetTokenMap = Schema.SObjectType.npe01__OppPayment__c.fields.getMap().clone();
-       
+
         //pop out the known fields
         for (String fieldName : paymentsFieldsToExclude) {
             fieldName = fieldName.toLowerCase();

--- a/src/package.xml
+++ b/src/package.xml
@@ -520,6 +520,7 @@
         <members>STG_PanelOppBatch_CTRL</members>
         <members>STG_PanelOppCampaignMembers_CTRL</members>
         <members>STG_PanelOppNamingBatch_CTRL</members>
+        <members>STG_PanelOppNamingBatch_CTRL_TEST</members>
         <members>STG_PanelOppNaming_CTRL</members>
         <members>STG_PanelOppRollups_CTRL</members>
         <members>STG_PanelOpps_CTRL</members>

--- a/src/pages/STG_PanelOppNamingBatch.page
+++ b/src/pages/STG_PanelOppNamingBatch.page
@@ -1,19 +1,50 @@
 <apex:page controller="STG_PanelOppNamingBatch_CTRL" docType="html-5.0" standardStylesheets="false" >
+    <apex:includeLightning />
+
+    <script>
+        if ({!NOT(hasAccess)}) {
+            $Lightning.use("{!namespace}" + ":RD2_EnablementApp", function() {
+                $Lightning.createComponent("{!namespace}" + ":utilIllustration",
+                    {   title : "{!$Label.commonAdminPermissionErrorTitle}",
+                        message : "{!$Label.commonPermissionErrorMessage}",
+                        size: 'small',
+                        variant: 'no-access',
+                        illustrationClass: "slds-p-top_x-large slds-m-top_x-large"
+                    },
+                    "stgPanelOppNamingBatchIllustration",
+                    function () { }
+                );
+            });
+        }
+    </script>
+
     <apex:form id="form" styleClass="slds-m-around_x-large">
         <c:STG_PageHeader sectionLabel="{!$Label.stgNavBulkProcesses}" pageLabel="{!$Label.stgLabelOppNamingRefreshTitle}" />
-        <div class="slds-text-body_small slds-m-around_medium"><c:UTIL_HtmlOutput html="{!$Label.stgHelpBtnOppNaming}" /></div>
-        <c:UTIL_PageMessages />
-        <div class="slds-grid slds-grid_align-center slds-grid_vertical-align-center slds-p-around_large">
-            <apex:commandButton id="runOppNamingBatch" value="{!$Label.stgBtnRefreshOpportunityNames}" status="statusLoad" action="{!runBatch}" disabled="{!isRunningBatch}" immediate="true" rerender="form" styleClass="slds-button slds-button_small slds-button_neutral" />
-        </div>
-        <apex:outputPanel rendered="{!isRunningBatch}">
-            <c:UTIL_JobProgressLightning id="jobProgress"
-                eventTargetId="{!$Component.jobProgress}"
-                strBatchComponentLabel="{!$Label.stgLabelOppNamingRefreshTitle}"
-                cNumberOfJobs="1"
-                startPolling="True"
-                stopPollingOnComplete="True"
-                pollingDelay="1000"/>
+
+        <apex:outputPanel rendered="{!NOT(hasAccess)}">
+            <div id="stgPanelOppNamingBatchIllustration" />
+        </apex:outputPanel>
+
+        <apex:outputPanel rendered="{!hasAccess}">
+            <div class="slds-text-body_small slds-m-around_medium">
+                <c:UTIL_HtmlOutput html="{!$Label.stgHelpBtnOppNaming}" />
+            </div>
+            <c:UTIL_PageMessages />
+
+            <div class="slds-grid slds-grid_align-center slds-grid_vertical-align-center slds-p-around_large">
+                <apex:commandButton id="runOppNamingBatch" value="{!$Label.stgBtnRefreshOpportunityNames}" status="statusLoad" action="{!runBatch}" disabled="{!isRunningBatch}" immediate="true" rerender="form" styleClass="slds-button slds-button_small slds-button_neutral" />
+            </div>
+
+            <apex:outputPanel rendered="{!isRunningBatch}">
+                <c:UTIL_JobProgressLightning id="jobProgress"
+                    eventTargetId="{!$Component.jobProgress}"
+                    strBatchComponentLabel="{!$Label.stgLabelOppNamingRefreshTitle}"
+                    cNumberOfJobs="1"
+                    startPolling="True"
+                    stopPollingOnComplete="True"
+                    pollingDelay="1000"/>
+            </apex:outputPanel>
         </apex:outputPanel>
     </apex:form>
+
 </apex:page>


### PR DESCRIPTION
# Critical Changes

- In order to use the "Refresh Opportunity Names" page in NPSP Settings, the User must have Update access to the Opportunity object as well as Read access to both the Account and Contact objects.

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
