### PR TITLE
Removing the number from Opportunities created by Open Enhanced Recurring Donations

### DIFF
--- a/src/classes/RD2_OpportunityService.cls
+++ b/src/classes/RD2_OpportunityService.cls
@@ -205,7 +205,7 @@ public with sharing class RD2_OpportunityService {
 
         customFieldMapper.populateOpportunityFields(opp, rd);
 
-        opp.Name = buildOpportunityName(rd.npe03__Donor_Name__c, opp);
+        opp.Name = buildOpportunityName(rd, opp);
 
         return opp;
     }
@@ -214,12 +214,15 @@ public with sharing class RD2_OpportunityService {
     * @description Constructs the opportunity name in a specific format.
     * @return String The Opportunity Name
     */
-    private String buildOpportunityName(String donorName, Opportunity opp) {
-        return
-            donorName + ' '
-                + System.Label.npe03.RecurringDonationPrefix
-                + ' (' + opp.Recurring_Donation_Installment_Number__c +  ') '
-                + opp.CloseDate.format();
+    private String buildOpportunityName(npe03__Recurring_Donation__c rd, Opportunity opp) {
+        String oppName = rd.npe03__Donor_Name__c + ' '
+            + System.Label.npe03.RecurringDonationPrefix;
+
+        if (new RD2_RecurringDonation(rd).isFixedLength()) {
+            oppName += ' (' + opp.Recurring_Donation_Installment_Number__c +  ')';
+        }
+        oppName += ' ' + opp.CloseDate.format();        
+        return oppName;
     }
 
     /***
@@ -349,7 +352,7 @@ public with sharing class RD2_OpportunityService {
         isChanged = syncOppWithInstallment(opp, installment) || isChanged;
 
         if (isChanged) {
-            opp.Name = buildOpportunityName(rd.npe03__Donor_Name__c, opp);
+            opp.Name = buildOpportunityName(rd, opp);
             return opp;
         }
         return null;

--- a/src/classes/RD2_OpportunityService_TEST.cls
+++ b/src/classes/RD2_OpportunityService_TEST.cls
@@ -157,6 +157,31 @@ private with sharing class RD2_OpportunityService_TEST {
     }
 
     /***
+     * @description Verifies an Opportunity name has the specialized format when
+     * Opportunity naming is not configured in NPSP Settings
+     */
+    @isTest
+    private static void shouldCreateOppsWithCorrectNameWhenRdIsOpen() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        setUpConfiguration();
+
+        Test.startTest();
+        npe03__Recurring_Donation__c rd = createRecurringDonation();
+        rd.RecurringType__c = RD2_Constants.RECURRING_TYPE_OPEN;
+        update rd;
+        Test.stopTest();
+
+        Date secondCloseDate = CLOSE_DATE.addMonths(1);
+
+        List<Opportunity> opps = oppGateway.getRecords(rd);
+
+        System.assertEquals(1, opps.size(), 'One Installment Opp should be created on RD insert: ' + opps);
+        Opportunity opp1 = opps[0];
+        System.assertEquals(getExpectedOppName(rd, CLOSE_DATE), opp1.Name, 'Opportunity Name should match');
+    }
+
+    /***
      * @description Verifies an Opportunity name is set as configured in NPSP Settings Opportunity naming
      */
     @isTest
@@ -1405,11 +1430,14 @@ private with sharing class RD2_OpportunityService_TEST {
     * @return String Expected Opportunity name
     */
     public static String getExpectedOppName(npe03__Recurring_Donation__c rd, Date closeDate) {
-        return
-            rd.npe03__Donor_Name__c +  ' ' +
-            System.Label.npe03.RecurringDonationPrefix + ' (' +
-            (rd.npe03__Total_Paid_Installments__c != null ? rd.npe03__Total_Paid_Installments__c + 1 : 1) + ') ' +
-            closeDate.format();
+        String oppName = rd.npe03__Donor_Name__c + ' '
+            + System.Label.npe03.RecurringDonationPrefix;
+
+        if (new RD2_RecurringDonation(rd).isFixedLength()) {
+            oppName += ' (' + (rd.npe03__Total_Paid_Installments__c != null ? rd.npe03__Total_Paid_Installments__c + 1 : 1) +  ')';
+        }
+        oppName += ' ' + closeDate.format();
+        return oppName;
     }
 
     /***

--- a/src/classes/RD2_OpportunityService_TEST.cls
+++ b/src/classes/RD2_OpportunityService_TEST.cls
@@ -158,7 +158,7 @@ private with sharing class RD2_OpportunityService_TEST {
 
     /***
      * @description Verifies an Opportunity name has the specialized format when
-     * Opportunity naming is not configured in NPSP Settings
+     * the associated Recurring Donation is Open
      */
     @isTest
     private static void shouldCreateOppsWithCorrectNameWhenRdIsOpen() {
@@ -172,10 +172,7 @@ private with sharing class RD2_OpportunityService_TEST {
         update rd;
         Test.stopTest();
 
-        Date secondCloseDate = CLOSE_DATE.addMonths(1);
-
         List<Opportunity> opps = oppGateway.getRecords(rd);
-
         System.assertEquals(1, opps.size(), 'One Installment Opp should be created on RD insert: ' + opps);
         Opportunity opp1 = opps[0];
         System.assertEquals(getExpectedOppName(rd, CLOSE_DATE), opp1.Name, 'Opportunity Name should match');


### PR DESCRIPTION
# Critical Changes

# Changes

- We're removing the number from Installment Names for Open-ended Recurring Donations.

# Issues Closed

Fixes #5512 

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
