### PR TITLE
add multicurrency to query call to fix breaking unit test 

### DIFF
--- a/src/classes/AllocationParent.cls
+++ b/src/classes/AllocationParent.cls
@@ -141,6 +141,7 @@ public inherited sharing class AllocationParent {
         String queryString = soql
             .withFrom(objectType)
             .withSelectFields(fields)
+            .withMultiCurrencyField()
             .withWhere('Id = :id')
             .withLimit(1)
             .build();


### PR DESCRIPTION
Resolve failing unit tests in the multicurrency beta build by introducing the "withMultiCurrencyField()" call to the query in AllocationParent

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
