### PR TITLE
Add Elevate information widget to flexipage

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -142,6 +142,14 @@ tasks:
             path: unpackaged/config/rd2_post_config
             namespace_inject: $project_config.project__package__namespace
 
+    deploy_rd2_elevate_config:
+        description: Deploys updates to enable Elevate for Enhanced Recurring Donations
+        class_path: cumulusci.tasks.salesforce.Deploy
+        group: NPSP
+        options:
+            path: unpackaged/config/rd2_elevate_post_config
+            namespace_inject: $project_config.project__package__namespace
+
     deploy_reports:
         description: Deploys reports & dashboards
         class_path: cumulusci.tasks.salesforce.Deploy

--- a/unpackaged/config/rd2_elevate_post_config/flexipages/NPSP_Recurring_Donation.flexipage
+++ b/unpackaged/config/rd2_elevate_post_config/flexipages/NPSP_Recurring_Donation.flexipage
@@ -104,6 +104,9 @@
             </componentInstanceProperties>
             <componentName>%%%NAMESPACE_OR_C%%%:rdScheduleVisualizer</componentName>
         </componentInstances>
+        <componentInstances>
+            <componentName>%%%NAMESPACE_OR_C%%%:rd2ElevateInformation</componentName>
+        </componentInstances>
         <name>sidebar</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/unpackaged/config/rd2_elevate_post_config/package.xml
+++ b/unpackaged/config/rd2_elevate_post_config/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>NPSP_Recurring_Donation</members>
+        <name>FlexiPage</name>
+    </types>
+    <version>48.0</version>
+</Package>

--- a/unpackaged/config/rd2_post_config/flexipages/NPSP_Recurring_Donation.flexipage
+++ b/unpackaged/config/rd2_post_config/flexipages/NPSP_Recurring_Donation.flexipage
@@ -104,6 +104,9 @@
             </componentInstanceProperties>
             <componentName>%%%NAMESPACE_OR_C%%%:rdScheduleVisualizer</componentName>
         </componentInstances>
+        <componentInstances>
+            <componentName>%%%NAMESPACE_OR_C%%%:rd2ElevateInformation</componentName>
+        </componentInstances>
         <name>sidebar</name>
         <type>Region</type>
     </flexiPageRegions>


### PR DESCRIPTION
This is intended to fill a gap in our ability to automate Elevate testing.  The goal is to provide a fully automated way to configure the Recurring Donations flexipage with the Elevate Information widget installed.
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
