### PR TITLE
Change package name, retrieve missing component

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -2,8 +2,7 @@ minimum_cumulusci_version: 3.23.0
 project:
     name: Cumulus
     package:
-        name: Cumulus
-        name_managed: Nonprofit Success Pack
+        name: Nonprofit Success Pack
         namespace: npsp
         api_version: 48.0
         install_class: STG_InstallScript

--- a/src/globalValueSetTranslations/Payment_ACH_Code-iw.globalValueSetTranslation
+++ b/src/globalValueSetTranslations/Payment_ACH_Code-iw.globalValueSetTranslation
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSetTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <valueTranslation>
+        <masterLabel>Accounts Receivable Conversion (ARC)</masterLabel>
+        <translation><!-- Accounts Receivable Conversion (ARC) --></translation>
+    </valueTranslation>
+    <valueTranslation>
+        <masterLabel>Back Office Conversion (BOC)</masterLabel>
+        <translation><!-- Back Office Conversion (BOC) --></translation>
+    </valueTranslation>
+    <valueTranslation>
+        <masterLabel>Cash Concentration or Disbursement (CCD)</masterLabel>
+        <translation><!-- Cash Concentration or Disbursement (CCD) --></translation>
+    </valueTranslation>
+    <valueTranslation>
+        <masterLabel>Prearranged Payment and Deposit Entry (PPD)</masterLabel>
+        <translation><!-- Prearranged Payment and Deposit Entry (PPD) --></translation>
+    </valueTranslation>
+    <valueTranslation>
+        <masterLabel>Telephone-initiated Entry (TEL)</masterLabel>
+        <translation><!-- Telephone-initiated Entry (TEL) --></translation>
+    </valueTranslation>
+    <valueTranslation>
+        <masterLabel>Web-initiated Entry (WEB)</masterLabel>
+        <translation><!-- Web-initiated Entry (WEB) --></translation>
+    </valueTranslation>
+</GlobalValueSetTranslation>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Cumulus</fullName>
+    <fullName>Nonprofit Success Pack</fullName>
     <types>
         <members>ACCT_AccountMerge_TDTM</members>
         <members>ACCT_AccountMerge_TEST</members>
@@ -4117,6 +4117,7 @@
         <members>Payment_ACH_Code-de</members>
         <members>Payment_ACH_Code-es</members>
         <members>Payment_ACH_Code-fr</members>
+        <members>Payment_ACH_Code-iw</members>
         <members>Payment_ACH_Code-ja</members>
         <members>Payment_ACH_Code-nl_NL</members>
         <name>GlobalValueSetTranslation</name>


### PR DESCRIPTION
This PR corrects an old configuration issue with NPSP. See https://salesforce.quip.com/2XraA90OZCii for details.

# Critical Changes

- NPSP changed a CumulusCI configuration related to the internal package name used in development automation. This change has no impact on customers and only impacts developers. If you are a partner or developer and are maintaining a persistent org that includes an unmanaged deployment of NPSP, you will need to update that org for the best experience deploying new versions of NPSP in unmanaged form.
  - Navigate to Package Manager in Setup.
  - Locate the package called Cumulus and edit the package.
  - Change the package name to "Nonprofit Success Pack".
  - Save the package.

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
