### PR TITLE
Gift Entry - Fixed Get Template Record keyword + Opportunity Page element finding

### DIFF
--- a/robot/Cumulus/resources/BatchGiftEntryPageObject.py
+++ b/robot/Cumulus/resources/BatchGiftEntryPageObject.py
@@ -14,7 +14,7 @@ class BatchGiftEntryListPage(BaseNPSPPage, ListingPage):
         """To go to Batch Gift Entry List View page"""
         url_template = "{root}/lightning/n/{object}"
         name = self._object_name
-        namespace= self.cumulusci.get_namespace_prefix("Nonprofit Success Pack") or self.cumulusci.get_namespace_prefix("Cumulus Managed Feature Test")
+        namespace= self.cumulusci.get_namespace_prefix("Nonprofit Success Pack") or self.cumulusci.get_namespace_prefix("Nonprofit Success Pack Managed Feature Test")
         object_name = "{}{}".format(namespace, name)
         url = url_template.format(root=self.cumulusci.org.lightning_base_url, object=object_name)
         self.selenium.go_to(url)

--- a/robot/Cumulus/resources/DataImportPageObject.py
+++ b/robot/Cumulus/resources/DataImportPageObject.py
@@ -14,7 +14,7 @@ class DataImportPage(BaseNPSPPage, ListingPage):
         when running NPSP tests in a different repo"""
         url_template = "{root}/lightning/o/{object}/list"
         name = self._object_name
-        namespace= self.cumulusci.get_namespace_prefix("Nonprofit Success Pack") or self.cumulusci.get_namespace_prefix("Cumulus Managed Feature Test")
+        namespace= self.cumulusci.get_namespace_prefix("Nonprofit Success Pack") or self.cumulusci.get_namespace_prefix("Nonprofit Success Pack Managed Feature Test")
         object_name = "{}{}".format(namespace, name)
         url = url_template.format(root=self.cumulusci.org.lightning_base_url, object=object_name)
         self.selenium.go_to(url)

--- a/robot/Cumulus/resources/GiftEntryPageObject.py
+++ b/robot/Cumulus/resources/GiftEntryPageObject.py
@@ -111,7 +111,8 @@ class GiftEntryLandingPage(BaseNPSPPage, BasePage):
             Expects url format like: [a-zA-Z0-9]{15,18}
         """
         id=self.get_template_record_id(template)
-        self.salesforce.store_session_record("Form_Template__c",id)
+        namespace = self.cumulusci.get_namespace_prefix("Nonprofit Success Pack")
+        self.salesforce.store_session_record(namespace + "Form_Template__c",id)
 
 
 @pageobject("Template", "GE_Gift_Entry")

--- a/robot/Cumulus/resources/GiftEntryPageObject.py
+++ b/robot/Cumulus/resources/GiftEntryPageObject.py
@@ -20,7 +20,7 @@ class GiftEntryLandingPage(BaseNPSPPage, BasePage):
         otherwise waits until page contains batches table"""
         url_template = "{root}/lightning/n/{object}"
         name = self._object_name
-        namespace= self.cumulusci.get_namespace_prefix("Nonprofit Success Pack") or self.cumulusci.get_namespace_prefix("Cumulus Managed Feature Test")
+        namespace= self.cumulusci.get_namespace_prefix("Nonprofit Success Pack") or self.cumulusci.get_namespace_prefix("Nonprofit Success Pack Managed Feature Test")
         object_name = "{}{}".format(namespace, name)
         url = url_template.format(root=self.cumulusci.org.lightning_base_url, object=object_name)
         self.selenium.go_to(url)

--- a/robot/Cumulus/resources/GiftEntryPageObject.py
+++ b/robot/Cumulus/resources/GiftEntryPageObject.py
@@ -111,7 +111,7 @@ class GiftEntryLandingPage(BaseNPSPPage, BasePage):
             Expects url format like: [a-zA-Z0-9]{15,18}
         """
         id=self.get_template_record_id(template)
-        namespace = self.cumulusci.get_namespace_prefix("Nonprofit Success Pack")
+        namespace= self.cumulusci.get_namespace_prefix("Nonprofit Success Pack") or self.cumulusci.get_namespace_prefix("Nonprofit Success Pack Managed Feature Test")
         self.salesforce.store_session_record(namespace + "Form_Template__c",id)
 
 

--- a/robot/Cumulus/resources/NPSPSettingsPageObject.py
+++ b/robot/Cumulus/resources/NPSPSettingsPageObject.py
@@ -14,7 +14,7 @@ class NPSPSettingsPage(BaseNPSPPage, BasePage):
         """To go to NPSP Settings page"""
         url_template = "{root}/lightning/n/{object}"
         name = self._object_name
-        namespace= self.cumulusci.get_namespace_prefix("Nonprofit Success Pack") or self.cumulusci.get_namespace_prefix("Cumulus Managed Feature Test")
+        namespace= self.cumulusci.get_namespace_prefix("Nonprofit Success Pack") or self.cumulusci.get_namespace_prefix("Nonprofit Success Pack Managed Feature Test")
         object_name = "{}{}".format(namespace, name)
         url = url_template.format(root=self.cumulusci.org.lightning_base_url, object=object_name)
         self.selenium.go_to(url)

--- a/robot/Cumulus/resources/OpportunityPageObject.py
+++ b/robot/Cumulus/resources/OpportunityPageObject.py
@@ -17,8 +17,7 @@ class OpportunityPage(BaseNPSPPage, DetailPage):
         """
         self.selenium.wait_until_location_contains("/lightning/r/Opportunity/",timeout=60,message="Current page is not a Opportunity detail view")
         self.selenium.wait_until_page_contains("Donation Information")
-        locator = npsp_lex_locators['manage_hh_page']['more_actions_btn']
-        self.selenium.wait_until_element_is_visible(locator,60)
+        self.selenium.wait_until_page_contains("Delete")
 
     def ensure_opportunity_details_are_loaded(self,objectID, value):
         """ Navigate to the page with objectid mentioned

--- a/robot/Cumulus/tests/browser/gift_entry/error_validation_rename_fields.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/error_validation_rename_fields.robot
@@ -36,7 +36,7 @@ Validate Errors When Field Is Renamed
     ...                     status is dry run error. Rename the field to correct it and verify no errors or warnings are thrown on AM, object group,
     ...                     and template builder. Creates a batch and verifys field is back on form and on saving gift its status is dry run validated.
 
-    [tags]                              unstable                      feature:GE        W-8292840
+    [tags]                              feature:GE        W-8292840
     Go To Page                          Landing                       GE_Gift_Entry
     Click Link                          Templates
     Click Gift Entry Button             Create Template


### PR DESCRIPTION
# Critical Changes

- Fixes an issue where the keyword to delete form templates was not accounting for namespacing, and thus templates were not being deleted during cleanup. Fixed this to work in both namespaced and non-namespaced orgs.
- Fixes an issue where the 'Current Page Should Be' keyword was not finding page button elements on the Opportunity Details page.

# Changes

# Issues Closed

# Community Ideas Delivered

# New Metadata

# Deleted Metadata
