### PR TITLE
Customizable Rollups: Update queries to use Skew Mode flag

### DIFF
--- a/src/classes/CRLP_Batch_Base_NonSkew.cls
+++ b/src/classes/CRLP_Batch_Base_NonSkew.cls
@@ -65,7 +65,7 @@ public abstract class CRLP_Batch_Base_NonSkew extends CRLP_Batch_Base {
      * at some point when an Opportunity was inserted/updated, but maybe that Opportunity was deleted or the
      * reference changed.
      * The objective of this method is to identify one or more fields on the Summary object that help identify
-     * if the rerord "ever" had rollups to it, even if there are no detail records currently to roll up. This
+     * if the record "ever" had rollups to it, even if there are no detail records currently to roll up. This
      * allows the rollup process to clear the rollups in the summary record if the last remaining detail record
      * is no longer eligible for rolling up (such as it was deleted).
     */

--- a/src/classes/CRLP_Query_SEL.cls
+++ b/src/classes/CRLP_Query_SEL.cls
@@ -84,7 +84,7 @@ public inherited sharing class CRLP_Query_SEL {
         Set<String> queryFields = new Set<String>{'Id'};
         if (resultObject == Account.SObjectType || resultObject == Contact.SObjectType) {
             // Add field specifying skew mode
-            queryFields.add(UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c'));
+            queryFields.add(UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c'));
         }
         for (DescribeFieldResult dfr : allFieldsToQuery) {
             queryFields.add(dfr.getName());

--- a/src/classes/CRLP_Query_SEL.cls
+++ b/src/classes/CRLP_Query_SEL.cls
@@ -84,7 +84,7 @@ public inherited sharing class CRLP_Query_SEL {
         Set<String> queryFields = new Set<String>{'Id'};
         if (resultObject == Account.SObjectType || resultObject == Contact.SObjectType) {
             // Add field specifying skew mode
-            queryFields.add(UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c'));
+            queryFields.add(UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c'));
         }
         for (DescribeFieldResult dfr : allFieldsToQuery) {
             queryFields.add(dfr.getName());

--- a/src/classes/CRLP_RollupBatch_SVC.cls
+++ b/src/classes/CRLP_RollupBatch_SVC.cls
@@ -64,49 +64,16 @@ public class CRLP_RollupBatch_SVC {
         String queryFilter = '';
         Integer maxRelatedOppsForNonLDVMode = CRLP_Rollup_SVC.getMaxRelatedOppsForNonSkewMode();
 
-        // If the Summary Object is the Account, then filter on Accounts that have at least a single
-        // Opportunity attached. This is helpful to reduce the overall query size.
-        // To handle a scenario where an attached Opportunity was deleted, but the record not recalculated
-        // also include any records where the TotalGifts or TotalMemberships fields are not zero.
-        // If the field is null, a query with "< #" will not work. "= null" must be explicitly included in the query.
         if (jobType == CRLP_RollupProcessingOptions.RollupType.ContactHardCredit ||
-                jobType == CRLP_RollupProcessingOptions.RollupType.AccountHardCredit) {
+            jobType == CRLP_RollupProcessingOptions.RollupType.AccountHardCredit ||
+            jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit ||
+            CRLP_Rollup_SVC.isOppContactRoleSoftCreditRollup(jobType)
+        ) {
 
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = ' (' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c = null OR ' + parentRelationshipField +
-                    'npo02__NumberOfClosedOpps__c < ' + maxRelatedOppsForNonLDVMode + ') ' +
-                    'AND (' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c = null OR ' + parentRelationshipField +
-                    'npo02__NumberOfMembershipOpps__c < ' + maxRelatedOppsForNonLDVMode + ') ' +
-                    'AND ' + parentRelationshipField +
-                    UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false';
+                queryFilter = '(' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
             } else {
-                queryFilter = '(' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c >= ' + maxRelatedOppsForNonLDVMode +
-                    ' OR ' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c >= ' + maxRelatedOppsForNonLDVMode +
-                    ' OR ' + parentRelationshipField +
-                    UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
-            }
-
-        } else if (jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
-
-            String softCreditField = parentRelationshipField + UTIL_Namespace.StrAllNSPrefix('Number_of_Soft_Credits__c');
-            if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '((' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')' +
-                    ' AND ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
-            } else {
-                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode +
-                    ' OR ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
-            }
-
-        } else if (CRLP_Rollup_SVC.isOppContactRoleSoftCreditRollup(jobType)) {
-            // TODO -- How to get Accounts that require using this method for Soft Credits??
-            // For now just use the NumberOfClosedOpportunities field as a proxy for the number of SoftCredits
-            String softCreditField = parentRelationshipField + 'npo02__NumberOfClosedOpps__c';
-            if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '((' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')' +
-                    ' AND ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
-            } else {
-                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode +
-                    ' OR ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
+                queryFilter = '(' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (jobType == CRLP_RollupProcessingOptions.RollupType.GAU) {

--- a/src/classes/CRLP_RollupBatch_SVC.cls
+++ b/src/classes/CRLP_RollupBatch_SVC.cls
@@ -78,12 +78,12 @@ public class CRLP_RollupBatch_SVC {
                     'AND (' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c = null OR ' + parentRelationshipField +
                     'npo02__NumberOfMembershipOpps__c < ' + maxRelatedOppsForNonLDVMode + ') ' +
                     'AND ' + parentRelationshipField +
-                    UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false';
+                    UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false';
             } else {
                 queryFilter = '(' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c >= ' + maxRelatedOppsForNonLDVMode +
                     ' OR ' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c >= ' + maxRelatedOppsForNonLDVMode +
                     ' OR ' + parentRelationshipField +
-                    UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
+                    UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
@@ -91,10 +91,10 @@ public class CRLP_RollupBatch_SVC {
             String softCreditField = parentRelationshipField + UTIL_Namespace.StrAllNSPrefix('Number_of_Soft_Credits__c');
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
                 queryFilter = '((' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')' +
-                    ' AND ' + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
+                    ' AND ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
             } else {
                 queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode +
-                    ' OR ' + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
+                    ' OR ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (CRLP_Rollup_SVC.isOppContactRoleSoftCreditRollup(jobType)) {
@@ -103,10 +103,10 @@ public class CRLP_RollupBatch_SVC {
             String softCreditField = parentRelationshipField + 'npo02__NumberOfClosedOpps__c';
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
                 queryFilter = '((' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')' +
-                    ' AND ' + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
+                    ' AND ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
             } else {
                 queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode +
-                    ' OR ' + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
+                    ' OR ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (jobType == CRLP_RollupProcessingOptions.RollupType.GAU) {
@@ -139,7 +139,7 @@ public class CRLP_RollupBatch_SVC {
                 jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
             String objName = recordId.getSobjectType().getDescribe().getName();
             String soql = 'SELECT Id FROM ' + objName + ' WHERE Id = :recordID AND ('
-                + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c')
+                + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c')
                 + ' = true';
             String filter = getSkewWhereClause(jobType, CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             if (!String.isEmpty(filter)) {

--- a/src/classes/CRLP_RollupBatch_SVC.cls
+++ b/src/classes/CRLP_RollupBatch_SVC.cls
@@ -73,22 +73,28 @@ public class CRLP_RollupBatch_SVC {
                 jobType == CRLP_RollupProcessingOptions.RollupType.AccountHardCredit) {
 
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '(' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c = null OR ' + parentRelationshipField +
+                queryFilter = ' (' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c = null OR ' + parentRelationshipField +
                     'npo02__NumberOfClosedOpps__c < ' + maxRelatedOppsForNonLDVMode + ') ' +
                     'AND (' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c = null OR ' + parentRelationshipField +
-                    'npo02__NumberOfMembershipOpps__c < ' + maxRelatedOppsForNonLDVMode + ')';
+                    'npo02__NumberOfMembershipOpps__c < ' + maxRelatedOppsForNonLDVMode + ') ' +
+                    'AND ' + parentRelationshipField +
+                    UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false';
             } else {
                 queryFilter = '(' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c >= ' + maxRelatedOppsForNonLDVMode +
-                        ' OR ' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c >= ' + maxRelatedOppsForNonLDVMode + ')';
+                    ' OR ' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c >= ' + maxRelatedOppsForNonLDVMode +
+                    ' OR ' + parentRelationshipField +
+                    UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
 
             String softCreditField = parentRelationshipField + UTIL_Namespace.StrAllNSPrefix('Number_of_Soft_Credits__c');
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '(' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')';
+                queryFilter = '((' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')' +
+                    ' AND ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
             } else {
-                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode + ')';
+                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode +
+                    ' OR ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (CRLP_Rollup_SVC.isOppContactRoleSoftCreditRollup(jobType)) {
@@ -96,9 +102,11 @@ public class CRLP_RollupBatch_SVC {
             // For now just use the NumberOfClosedOpportunities field as a proxy for the number of SoftCredits
             String softCreditField = parentRelationshipField + 'npo02__NumberOfClosedOpps__c';
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '(' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')';
+                queryFilter = '((' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')' +
+                    ' AND ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
             } else {
-                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode + ')';
+                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode +
+                    ' OR ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (jobType == CRLP_RollupProcessingOptions.RollupType.GAU) {

--- a/src/classes/CRLP_RollupBatch_SVC.cls
+++ b/src/classes/CRLP_RollupBatch_SVC.cls
@@ -78,12 +78,12 @@ public class CRLP_RollupBatch_SVC {
                     'AND (' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c = null OR ' + parentRelationshipField +
                     'npo02__NumberOfMembershipOpps__c < ' + maxRelatedOppsForNonLDVMode + ') ' +
                     'AND ' + parentRelationshipField +
-                    UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false';
+                    UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false';
             } else {
                 queryFilter = '(' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c >= ' + maxRelatedOppsForNonLDVMode +
                     ' OR ' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c >= ' + maxRelatedOppsForNonLDVMode +
                     ' OR ' + parentRelationshipField +
-                    UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
+                    UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
@@ -91,10 +91,10 @@ public class CRLP_RollupBatch_SVC {
             String softCreditField = parentRelationshipField + UTIL_Namespace.StrAllNSPrefix('Number_of_Soft_Credits__c');
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
                 queryFilter = '((' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')' +
-                    ' AND ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
+                    ' AND ' + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
             } else {
                 queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode +
-                    ' OR ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
+                    ' OR ' + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (CRLP_Rollup_SVC.isOppContactRoleSoftCreditRollup(jobType)) {
@@ -103,10 +103,10 @@ public class CRLP_RollupBatch_SVC {
             String softCreditField = parentRelationshipField + 'npo02__NumberOfClosedOpps__c';
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
                 queryFilter = '((' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')' +
-                    ' AND ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
+                    ' AND ' + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
             } else {
                 queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode +
-                    ' OR ' + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
+                    ' OR ' + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
 
         } else if (jobType == CRLP_RollupProcessingOptions.RollupType.GAU) {
@@ -139,7 +139,7 @@ public class CRLP_RollupBatch_SVC {
                 jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
             String objName = recordId.getSobjectType().getDescribe().getName();
             String soql = 'SELECT Id FROM ' + objName + ' WHERE Id = :recordID AND ('
-                + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c')
+                + UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c')
                 + ' = true';
             String filter = getSkewWhereClause(jobType, CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             if (!String.isEmpty(filter)) {

--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -47,6 +47,17 @@ public inherited sharing class CRLP_RollupProcessor {
     /** @description Support filtering the specific types of Rollup definitions that will be processed */
     private CRLP_RollupProcessingOptions.RollupTypeFilter rollupTypesToProcess = CRLP_RollupProcessingOptions.RollupTypeFilter.All;
 
+    /** @description Retrieve Skew Mode Threshold value once per session */
+    @TestVisible
+    private static Integer maxRelatedOppsForNonLDVMode {
+        get {
+            if (maxRelatedOppsForNonLDVMode == null) {
+                maxRelatedOppsForNonLDVMode = CRLP_Rollup_SVC.getMaxRelatedOppsForNonSkewMode();
+            }
+            return maxRelatedOppsForNonLDVMode;
+        } set;
+    }
+
     /** @description Optional processing options for the rollup operation */
     @TestVisible
     private CRLP_RollupProcessingOptions.ProcessingOptions options {
@@ -519,10 +530,9 @@ public inherited sharing class CRLP_RollupProcessor {
         // Determine if the updated SObject record is different than the parent.
         Boolean needsUpdate = CRLP_Rollup_SVC.resultsNeedUpdate(parent, updatedRecord, rollupDefs);
 
-        // Unconditionally set force skew flag if parent is Account/Contact and running in skew mode
-        if (mode == CRLP_RollupProcessingOptions.BatchJobMode.SkewMode && this.useForceSkewModeField && !isForceSkewModeTrue) {
-            updatedRecord.put(this.qualifiedSkewField, true);
-            needsUpdate = true;
+        // Ensure skew mode is set when threshold indicates it should be
+        if (useForceSkewModeField && !isForceSkewModeTrue) {
+            needsUpdate = needsSkewModeOverrideSet(updatedRecord, needsUpdate);
         }
 
         if (!needsUpdate) {
@@ -541,6 +551,25 @@ public inherited sharing class CRLP_RollupProcessor {
             this.qualifiedSkewField = UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c');
             this.useForceSkewModeField = (parentObjType == Account.SObjectType || parentObjType == Contact.SObjectType);
         }
+    }
+
+    /**
+     * @description Set needsUpdate and CustomizableRollups_UseSkewMode__c true if >= Skew Mode Threshold
+     * @param updatedRecord Update SObject record for rollup totals
+     * @param needsUpdate Boolean indicating whether or not record requires update
+     * @return Boolean
+     */
+    private Boolean needsSkewModeOverrideSet(SObject updatedRecord, Boolean needsUpdate) {
+        if (((Decimal) updatedRecord.get('npo02__NumberOfClosedOpps__c') >= maxRelatedOppsForNonLDVMode ||
+            (Decimal) updatedRecord.get('npo02__NumberOfMembershipOpps__c') >= maxRelatedOppsForNonLDVMode) ||
+            (updatedRecord.getSObjectType() == Contact.SObjectType) &&
+            (Decimal) updatedRecord.get('Number_of_Soft_Credits__c') >= maxRelatedOppsForNonLDVMode)
+        {
+            updatedRecord.put('CustomizableRollups_UseSkewMode__c', true);
+            needsUpdate = true;
+        }
+
+        return needsUpdate;
     }
 
     /**

--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -538,7 +538,7 @@ public inherited sharing class CRLP_RollupProcessor {
      */
     private void initForceSkewModeValues(SObjectType parentObjType) {
         if (this.qualifiedSkewField == null) {
-            this.qualifiedSkewField = UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c');
+            this.qualifiedSkewField = UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c');
             this.useForceSkewModeField = (parentObjType == Account.SObjectType || parentObjType == Contact.SObjectType);
         }
     }

--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -538,7 +538,7 @@ public inherited sharing class CRLP_RollupProcessor {
      */
     private void initForceSkewModeValues(SObjectType parentObjType) {
         if (this.qualifiedSkewField == null) {
-            this.qualifiedSkewField = UTIL_Namespace.StrAllNSPrefix('CustomizableRollups_UseSkewMode__c');
+            this.qualifiedSkewField = UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c');
             this.useForceSkewModeField = (parentObjType == Account.SObjectType || parentObjType == Contact.SObjectType);
         }
     }


### PR DESCRIPTION
We updated Customizable Rollups to use the Account and Contact Skew Mode flag for all Customizable Rollup jobs except GAU and Recurring Donations.
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
