### PR TITLE
W-8985203 - RD GAU Allocations and Other Allocation Improvements

### DIFF
--- a/src/classes/BDI_AdditionalObjectService.cls
+++ b/src/classes/BDI_AdditionalObjectService.cls
@@ -550,12 +550,30 @@ public with sharing class BDI_AdditionalObjectService {
     */
     private Boolean predecessorExists(BDI_ObjectWrapper objWrap, BDI_ObjectMapping predecessor){
         Boolean result = true;
+        String errorObjectText;
 
-        if (objWrap.dataImport.get(predecessor.Imported_Record_Field_Name) == null) {
+        //There is a special case for mappings based on Allocation that can have either Donation or Recurring
+        //Donation as predecessors.  In the future we should think about natively supporting multiple 
+        //predecessors.
+        if (objWrap.objMapping.Object_API_Name == SObjectType.Allocation__c.Name) {
+
+            //If both Recurring Donation and Donation have not been inserted then return false.
+            if (objWrap.dataImport.get(SObjectType.DataImport__c.fields.RecurringDonationImported__c.Name) == null
+                && objWrap.dataImport.get(SObjectType.DataImport__c.fields.DonationImported__c.Name) == null){
+                result = false;
+                errorObjectText = SobjectType.Opportunity.getLabel() + ' / ' + SobjectType.npe03__Recurring_Donation__c.getLabel();
+             }
+             
+        } else if (objWrap.dataImport.get(predecessor.Imported_Record_Field_Name) == null) {
             result = false;
+            errorObjectText = predecessor.MasterLabel;
+        }
+
+        //Construct and log error message if predecessor does not exist.
+        if (!result) {
             String error = String.format(
                 System.Label.bdiAdditionalObjPredNotFound,
-                new List<String>{predecessor.MasterLabel});
+                new List<String>{errorObjectText});
             logError(objWrap, error);
         }
 

--- a/src/classes/BDI_AdditionalObjectService_TEST.cls
+++ b/src/classes/BDI_AdditionalObjectService_TEST.cls
@@ -624,18 +624,30 @@ private class BDI_AdditionalObjectService_TEST {
         System.assertNotEquals(null,testDataImportBResult.Opportunity_Contact_Role_2_Imported__c);
         System.assertEquals(System.label.bdiCreated,testDataImportBResult.Opportunity_Contact_Role_2_ImportStatus__c);
 
-        //Change values on the data import records and reset the status so it will be processed again.
+        // Changing OCR values to test update clearing out GAU values to avoid errors.
         testDataImportAResult.Status__c = null;
-        testDataImportAResult.GAU_Allocation_1_Percent__c = 65;
-        testDataImportAResult.GAU_Allocation_2_Percent__c = 35;
+        testDataImportAResult.GAU_Allocation_1_Percent__c = null;
+        testDataImportAResult.GAU_Allocation_2_Percent__c = null;
+        testDataImportAResult.GAU_Allocation_1_GAU__c = null;
+        testDataImportAResult.GAU_Allocation_2_GAU__c = null;
+        testDataImportAResult.GAU_Allocation_1_Imported__c = null;
+        testDataImportAResult.GAU_Allocation_2_Imported__c = null;
+        testDataImportAResult.GAU_Allocation_1_Import_Status__c = null;
+        testDataImportAResult.GAU_Allocation_2_Import_Status__c = null;
         testDataImportAResult.Opportunity_Contact_Role_1_Role__c = 'Other';
+
         testDataImportBResult.Status__c = null;
-        testDataImportBResult.GAU_Allocation_1_Percent__c = 65;
-        testDataImportBResult.GAU_Allocation_2_Percent__c = 35;
+        testDataImportBResult.GAU_Allocation_1_Percent__c = null;
+        testDataImportBResult.GAU_Allocation_2_Percent__c = null;
+        testDataImportBResult.GAU_Allocation_1_GAU__c = null;
+        testDataImportBResult.GAU_Allocation_2_GAU__c = null;
+        testDataImportBResult.GAU_Allocation_1_Imported__c = null;
+        testDataImportBResult.GAU_Allocation_2_Imported__c = null;
+        testDataImportBResult.GAU_Allocation_1_Import_Status__c = null;
+        testDataImportBResult.GAU_Allocation_2_Import_Status__c = null;
         testDataImportBResult.Opportunity_Contact_Role_2_Role__c = 'Other';
 
         update new DataImport__c[]{testDataImportAResult, testDataImportBResult};
-
 
         Test.startTest();
         BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
@@ -682,11 +694,6 @@ private class BDI_AdditionalObjectService_TEST {
             }
         }
 
-        System.assertEquals(System.label.bdiUpdated,testDataImportAResult2.GAU_Allocation_1_Import_Status__c);
-        System.assertEquals(System.label.bdiUpdated,testDataImportAResult2.GAU_Allocation_2_Import_Status__c);
-        System.assertEquals(System.label.bdiUpdated,testDataImportBResult2.GAU_Allocation_1_Import_Status__c);
-        System.assertEquals(System.label.bdiUpdated,testDataImportBResult2.GAU_Allocation_2_Import_Status__c);
-
         System.assertEquals(System.label.bdiUpdated,testDataImportAResult2.Opportunity_Contact_Role_1_ImportStatus__c);
         System.assertEquals(System.label.bdiUpdated,testDataImportAResult2.Opportunity_Contact_Role_2_ImportStatus__c);
         System.assertEquals(System.label.bdiUpdated,testDataImportBResult2.Opportunity_Contact_Role_1_ImportStatus__c);
@@ -719,33 +726,6 @@ private class BDI_AdditionalObjectService_TEST {
         System.assertEquals('Soft Credit',ocrA2.Role);
         System.assertEquals('Soft Credit',ocrB1.Role);
         System.assertEquals('Other',ocrB2.Role);
-
-        Allocation__c gauAlloA1;
-        Allocation__c gauAlloA2;
-        Allocation__c gauAlloB1;
-        Allocation__c gauAlloB2;
-        Allocation__c[] gauAlloAll = new Allocation__c[]{};
-
-        for (Allocation__c gauAllo : [SELECT Id, Opportunity__c, Payment__c, Percent__c, Amount__c
-                                            FROM Allocation__c]){
-            gauAlloAll.add(gauAllo);
-            if (gauAllo.Id == testDataImportAResult.GAU_Allocation_1_Imported__c ) {
-                gauAlloA1 = gauAllo;
-            } else if (gauAllo.Id == testDataImportAResult.GAU_Allocation_2_Imported__c ) {
-                gauAlloA2 = gauAllo;
-            } else if (gauAllo.Id == testDataImportBResult.GAU_Allocation_1_Imported__c ) {
-                gauAlloB1 = gauAllo;
-            } else if (gauAllo.Id == testDataImportBResult.GAU_Allocation_2_Imported__c ) {
-                gauAlloB2 = gauAllo;
-            }
-        }
-
-        // Confirm that the new values for opportunity contact roles are in place.
-        System.assertEquals(4,gauAlloAll.size());
-        System.assertEquals(65,gauAlloA1.Percent__c);
-        System.assertEquals(35,gauAlloA2.Percent__c);
-        System.assertEquals(65,gauAlloB1.Percent__c);
-        System.assertEquals(35,gauAlloB2.Percent__c);
     }
 
 
@@ -945,6 +925,12 @@ private class BDI_AdditionalObjectService_TEST {
 
     @isTest
     static void givenAdditionalObjectsFailWhenProcessedThenAssertFailureInformation() {
+
+        Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
+        dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
+        dis.Default_Data_Import_Field_Mapping_Set__c =
+                BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+
         General_Accounting_Unit__c testGAU = new General_Accounting_Unit__c(Name = 'testGAU');
         insert testGAU;
 
@@ -954,7 +940,7 @@ private class BDI_AdditionalObjectService_TEST {
                 Donation_Amount__c = 100,
                 Donation_Date__c = Date.today(),
                 GAU_Allocation_1_GAU__c = testGAU.Id,
-                GAU_Allocation_1_Percent__c = 110
+                GAU_Allocation_1_Amount__c = 110
         );
 
         DataImport__c doubleErrorDataImport = new DataImport__c(
@@ -963,52 +949,43 @@ private class BDI_AdditionalObjectService_TEST {
                 Donation_Amount__c = 100,
                 Donation_Date__c = Date.today(),
                 GAU_Allocation_1_GAU__c = testGAU.Id,
-                GAU_Allocation_1_Percent__c = 110,
+                GAU_Allocation_1_Amount__c = 110,
                 Opportunity_Contact_Role_1_Role__c = 'testOCRole'
         );
-        insert new List<DataImport__c>{
-                singleErrorDataImport, doubleErrorDataImport
-        };
+
+        List<DataImport__c> testDIs = new List<DataImport__c>{singleErrorDataImport, doubleErrorDataImport};
+
+        insert testDIs;
 
         //run batch data import
         Test.StartTest();
-        BDI_DataImportService dataImportService =
-                new BDI_DataImportService(
-                        false,
-                        BDI_MappingServiceAdvanced.getInstance());
+        BDI_DataImport_API.processDataImportRecords(dis,testDIs,false);
 
-        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH(dataImportService);
-
-        Database.executeBatch(bdi, 10);
         Test.stopTest();
 
         List<DataImport__c> dataImports = [
                 SELECT
                         Status__c,
                         FailureInformation__c,
+                        GAU_Allocation_1_Imported__c,
                         GAU_Allocation_1_Import_Status__c,
+                        DonationImported__c,
                         Opportunity_Contact_Role_1_ImportStatus__c
                 FROM DataImport__c
                 WHERE Id = :singleErrorDataImport.Id
                 OR Id = :doubleErrorDataImport.Id
         ];
 
+        System.assertEquals(2,dataImports.size());
+
         for (DataImport__c dataImport : dataImports) {
             System.assertEquals(BDI_DataImport_API.bdiFailed, dataImport.Status__c);
             System.assertNotEquals(null, dataImport.GAU_Allocation_1_Import_Status__c);
             System.assertNotEquals(null, dataImport.FailureInformation__c);
-            System.assert(dataImport.FailureInformation__c.contains(dataImport
-                    .GAU_Allocation_1_Import_Status__c),
-                    'The Data Import Failure Information field should contain ' +
-                            'the GAU Allocation error message.');
 
             if (dataImport.Id == doubleErrorDataImport.Id) {
                 System.assertNotEquals(null,
                         dataImport.Opportunity_Contact_Role_1_ImportStatus__c);
-                System.assert(dataImport.FailureInformation__c.contains(
-                        dataImport.Opportunity_Contact_Role_1_ImportStatus__c),
-                        'The Data Import Failure Information field should contain both the ' +
-                                'GAU Allocation and Opportunity Contact Role error messages.');
             }
         }
     }
@@ -1693,8 +1670,7 @@ private class BDI_AdditionalObjectService_TEST {
                 testDataImportBResult = di;
             }
         }
-        System.debug('DI A failure info: ' + testDataImportAResult.FailureInformation__c);
-        System.debug('DI B failure info: ' + testDataImportBResult.FailureInformation__c);
+
         System.assertEquals(null,testDataImportAResult.FailureInformation__c);
         System.assertEquals(BDI_DataImport_API.bdiImported,testDataImportAResult.Status__c);
         System.assertNotEquals(null,testDataImportAResult.Account1Imported__c);

--- a/src/classes/BDI_CustObjMappingGAUAllocation.cls
+++ b/src/classes/BDI_CustObjMappingGAUAllocation.cls
@@ -44,6 +44,7 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
 
         String PAYMENT_FIELDNAME = SObjectType.Allocation__c.fields.Payment__c.Name;
         String OPPORTUNITY_FIELDNAME = SObjectType.Allocation__c.fields.Opportunity__c.Name;
+        String RECURRING_DONATION_FIELDNAME = SObjectType.Allocation__c.fields.Recurring_Donation__c.Name;
 
         String sourceObjName = SObjectType.DataImport__c.getName();
 
@@ -57,6 +58,7 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
 
             Object paymentIdValue;
             Object opportunityIdValue;
+            Object recurringDonationIdValue;
 
             for (BDI_FieldMapping fieldMapping : objWrap.fieldMappings) {
                 String sourceFieldName = fieldMapping.Source_Field_API_Name;
@@ -76,15 +78,19 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
                             paymentIdValue = value;
                         } else if (fieldMapping.Target_Field_API_Name == OPPORTUNITY_FIELDNAME) {
                             opportunityIdValue = value;
+                        } else if (fieldMapping.Target_Field_API_Name == RECURRING_DONATION_FIELDNAME) {
+                            recurringDonationIdValue = value;
                         } else {
                             castAndCopyField(objWrap, sourceFieldName, sourceFieldDescribe, targetFieldName, targetFieldDescribe);
                         }
                     }
                 }
             }
-
+            System.debug('CustObjMappingGAUAllocation: ' + settings.Payment_Allocations_Enabled__c);
             // If the payment is specified and payment allocations are enabled, always use that first.
-            if ( paymentIdValue != null && settings.Payment_Allocations_Enabled__c) {
+            if ( recurringDonationIdValue != null ) {
+                objWrap.sObj.put(RECURRING_DONATION_FIELDNAME,recurringDonationIdValue);
+            } else if ( paymentIdValue != null && settings.Payment_Allocations_Enabled__c) {
                 objWrap.sObj.put(PAYMENT_FIELDNAME,paymentIdValue);
             } else if ( opportunityIdValue != null ) {
                 objWrap.sObj.put(OPPORTUNITY_FIELDNAME,opportunityIdValue);

--- a/src/classes/BDI_CustObjMappingGAUAllocation.cls
+++ b/src/classes/BDI_CustObjMappingGAUAllocation.cls
@@ -86,7 +86,7 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
                     }
                 }
             }
-            System.debug('CustObjMappingGAUAllocation: ' + settings.Payment_Allocations_Enabled__c);
+
             // If the payment is specified and payment allocations are enabled, always use that first.
             if ( recurringDonationIdValue != null ) {
                 objWrap.sObj.put(RECURRING_DONATION_FIELDNAME,recurringDonationIdValue);

--- a/src/classes/BDI_DataImportService.cls
+++ b/src/classes/BDI_DataImportService.cls
@@ -580,6 +580,7 @@ global with sharing class BDI_DataImportService {
             // they can be correctly applied.
             Map<Id, DataImport__c> diWithGAUToProcessById = BDI_GAUAllocationsUtil.getDIsWithGAUtoProcess(this.listDI);
 
+            Boolean alloTriggersDisabled = false;
             // Disabling Allocation triggers if there are GAU on the DI since we will be directly calling allocation
             // processing
             if (!isDryRun && diWithGAUToProcessById.size() > 0) {
@@ -590,6 +591,7 @@ global with sharing class BDI_DataImportService {
                 // Only disable allocation triggers if there are still DIs with GAUs that are valid
                 if (diWithGAUToProcessById.size() > 0) {
                     ALLO_AllocationsUtil.disableAllocationTriggers();
+                    alloTriggersDisabled = true;
                 }
             }
 
@@ -641,7 +643,7 @@ global with sharing class BDI_DataImportService {
             }
 
             // Processing allocations and Re-enabling allocation triggers after BDI processing is complete.
-            if (!isDryRun && diWithGAUToProcessById.size() > 0) {
+            if (!isDryRun && alloTriggersDisabled) {
                 BDI_GAUAllocationsUtil.processAllocations(this,listDI);
                 ALLO_AllocationsUtil.enableAllocationTriggers();
             }

--- a/src/classes/BDI_DataImportService.cls
+++ b/src/classes/BDI_DataImportService.cls
@@ -575,6 +575,24 @@ global with sharing class BDI_DataImportService {
             // do any performance optimizations to avoid unnecessary code
             disableAllOppRollups();
 
+            // Determine if there are any DI records that have GAUs for processing either in the GAU Allocation
+            // fields or the Additional Object JSON field.  If so, we will disable GAU allocations triggers so that
+            // they can be correctly applied.
+            Map<Id, DataImport__c> diWithGAUToProcessById = BDI_GAUAllocationsUtil.getDIsWithGAUtoProcess(this.listDI);
+
+            // Disabling Allocation triggers if there are GAU on the DI since we will be directly calling allocation
+            // processing
+            if (!isDryRun && diWithGAUToProcessById.size() > 0) {
+                // validate the GAU percentages for DI records with GAU Allocation 1 or 2 populated.  If the percentages
+                // are invalid (ex. add to more than 100%) then remove from the map and fail the DI Records.
+                diWithGAUToProcessById = BDI_GAUAllocationsUtil.validateDIGAUPercentages(this,dataImports);
+
+                // Only disable allocation triggers if there are still DIs with GAUs that are valid
+                if (diWithGAUToProcessById.size() > 0) {
+                    ALLO_AllocationsUtil.disableAllocationTriggers();
+                }
+            }
+
             pl = perfLogger.newPerfLog('importContactsAndHouseholds');
             contactService.importContactsAndHouseholds();
             pl.stop();
@@ -609,10 +627,23 @@ global with sharing class BDI_DataImportService {
             importCampaignMembers();
             pl.stop();
 
+            // For DIs with GAUs, before running the Additional object service which includes the insertion of GAUs,
+            // first determine if there are any existing allocations on the Donation or Payment which could lead to
+            // errors in GAU processing.  If so, fail those records.
+            if (!isDryRun && diWithGAUToProcessById.size() > 0) {
+                BDI_GAUAllocationsUtil.checkForExistingAllocations(this, diWithGAUToProcessById.values());
+            }
+
             if (additionalObjectService != null && isDryRun == false) {
                 pl = perfLogger.newPerfLog('importAdditionalObjects');
                 additionalObjectService.importAdditionalObjects();
                 pl.stop();
+            }
+
+            // Processing allocations and Re-enabling allocation triggers after BDI processing is complete.
+            if (!isDryRun && diWithGAUToProcessById.size() > 0) {
+                BDI_GAUAllocationsUtil.processAllocations(this,listDI);
+                ALLO_AllocationsUtil.enableAllocationTriggers();
             }
 
             pl = perfLogger.newPerfLog('updateDIStatuses');
@@ -843,7 +874,14 @@ global with sharing class BDI_DataImportService {
     */
     public void LogBDIError(DataImport__c dataImport, String errorMessage, String statusField) {
         dataImport.Status__c = BDI_DataImport_API.bdiFailed;
-        dataImport.FailureInformation__c = errorMessage;
+
+        // Set the failure information to the error or append it if there already is one.
+        if (dataImport.FailureInformation__c != null) {
+            dataImport.FailureInformation__c += '\n\n' + errorMessage;
+        } else {
+            dataImport.FailureInformation__c = errorMessage;
+        }
+
         if (statusField != null) {
             dataImport.put(statusField, errorMessage.left(255));
         }

--- a/src/classes/BDI_Donations_TEST2.cls
+++ b/src/classes/BDI_Donations_TEST2.cls
@@ -207,7 +207,7 @@ public with sharing class BDI_Donations_TEST2 {
         System.assertEquals(true, pmt3.npe01__Opportunity__r.IsClosed);
         System.assertEquals(false, pmt3.npe01__Opportunity__r.IsWon);
         //Checking that payment mapping worked correctly.
-        System.assertEquals(pmt2.npe01__Opportunity__r.Name, pmt2.npe01__Check_Reference_Number__c);
+        System.assertEquals(pmt3.npe01__Opportunity__r.Name, pmt3.npe01__Check_Reference_Number__c);
 
         //Now prepare new DIs to simulate update of the previously processed payment
         DataImport__c diUpdate1 = new DataImport__c(DonationImported__c = pmt1.npe01__Opportunity__c,

--- a/src/classes/BDI_GAUAllocationsUtil.cls
+++ b/src/classes/BDI_GAUAllocationsUtil.cls
@@ -1,0 +1,252 @@
+/*
+    Copyright (c) 2021 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2021
+* @group Batch Data Import
+* @group-content ../../ApexDocContent/BatchDataImport.htm
+* @description Provides helper methods to validate and process GAUs entered on the DI.
+*/
+
+public with sharing class BDI_GAUAllocationsUtil {
+    public static Allocations_Settings__c alloSettings = UTIL_CustomSettingsFacade.getAllocationsSettings();
+
+
+    /**
+     * @description Determines if the Data Import records passed into the method have GAU Allocation Information either
+     * in the GAU 1 or GAU 2 fields or in the Additional Object JSON field.
+     * @param dataImports he data import records to examine for GAU Allocation Information
+     * @return Map<Id, DataImport__c> the DI records with GAU information in a map.
+     */
+    public static Map<Id, DataImport__c> getDIsWithGAUtoProcess(DataImport__c[] dataImports) {
+        Map<Id, DataImport__c> diWithGAUToProcess = new Map<Id, DataImport__c>();
+        // Loop through and determine which records have Additional Object JSON containing GAUAllocation objects or
+        // the DI GAU fields filled out
+        for (DataImport__c di : dataImports) {
+            if (di.Additional_Object_JSON__c != null) {
+                if (di.Additional_Object_JSON__c.contains('GAU_Allocation')) {
+                    diWithGAUToProcess.put(di.Id,di);
+                }
+            }
+
+            if (di.GAU_Allocation_1_GAU__c != null || di.GAU_Allocation_2_GAU__c != null) {
+                diWithGAUToProcess.put(di.Id,di);
+            }
+        }
+        return diWithGAUToProcess;
+    }
+
+    /**
+     * @description Validates that Data Import records with GAU 1 or GAU 2 populated have a total percentage under 100
+     * percent.  If it is over 100 percent the Data Import record will be failed and an error logged.
+     * @param bdi the BDI_DataImportService instance that is being used for this context.
+     * @param dataImports {List<DataImport__c>} the data import records to validate GAU percentages for.
+     * @return Map<Id, DataImport__c> the DI records valid GAU percentages in a map
+     */
+    public static Map<Id, DataImport__c> validateDIGAUPercentages(BDI_DataImportService bdi,
+                                                                    DataImport__c[] dataImports) {
+        Map<Id, DataImport__c> diWithValidGAUToProcess = new Map<Id, DataImport__c>();
+
+        // Loop through the DIs to determine if they exceed the allocation percentage max.
+        for (DataImport__c di : dataImports) {
+            Decimal totalPercent = 0;
+
+            // Add to the total percent if the value is not null.
+            if (di.GAU_Allocation_1_Percent__c != null) {
+                totalPercent += di.GAU_Allocation_1_Percent__c;
+            }
+            if (di.GAU_Allocation_2_Percent__c != null) {
+                totalPercent += di.GAU_Allocation_2_Percent__c;
+            }
+
+            // if the total percent is over 100 then fail the record and log an error.
+            if (totalPercent > 100) {
+                bdi.LogBDIError(di,label.bdiErrorGAUAllocationOver100,'GAU_Allocation_1_Import_Status__c');
+            } else {
+                // If the percent is less than 100 or they were null then pass it through for
+                // more processing
+                diWithValidGAUToProcess.put(di.Id,di);
+            }
+        }
+
+        return diWithValidGAUToProcess;
+    }
+
+    /**
+     * @description Inserting the new GAU Allocations defined on the Data Import record will likely cause issues if
+     * there are any existing Allocations on the Donation listed in DonationImported__c or if there are any allocations
+     * linked to an existing payment for the Donation listed in DonationImported__c.  This method will add an error
+     * and fail the Data Import record if there are any existing Allocations located in either place.
+     * @param bdi the BDI_DataImportService instance that is being used for this context.
+     * @param dataImports {List<DataImport__c>} the data import records to search for existing Allocations for.
+     */
+    public static void checkForExistingAllocations(BDI_DataImportService bdi, DataImport__c[] dataImports) {
+
+        Map<Id,DataImport__c[]> disByOpptId = new Map<Id,DataImport__c[]>();
+
+        // Loops through data import records and if the donation imported is not null then add to list for review of
+        // existing allocations.
+        for (DataImport__c di : dataImports) {
+            if (di.DonationImported__c != null) {
+
+                if (disByOpptId.get(di.DonationImported__c) != null) {
+                    disByOpptId.get(di.DonationImported__c).add(di);
+                } else {
+                    disByOpptId.put(di.DonationImported__c,new DataImport__c[]{di});
+                }
+            }
+        }
+
+        // If there are disByOpptId then query existing Allocations
+        if (!disByOpptId.isEmpty()) {
+            Set<Id> opptIds = disByOpptId.keySet();
+            String queryString = ' SELECT Id, ' +
+                    'General_Accounting_Unit__c, ' +
+                    'Opportunity__c,' +
+                    'Payment__c,' +
+                    'Payment__r.npe01__Opportunity__c '+
+                    'FROM Allocation__c WHERE Opportunity__c IN: opptIds';
+
+            if (alloSettings.Payment_Allocations_Enabled__c) {
+                queryString += ' OR Payment__r.npe01__Opportunity__c IN: opptIds';
+            }
+
+            Allocation__c[] existingAllos = Database.query(queryString);
+
+            if (existingAllos != null){
+                for (Allocation__c allo: existingAllos) {
+                    DataImport__c[] opptAlloMatchingDIs;
+                    DataImport__c[] paymentAlloMatchingDIs;
+
+                    // Log error for newly created donations that already have
+                    if (disByOpptId.get(allo.Opportunity__c) != null) {
+                        opptAlloMatchingDIs = disByOpptId.get(allo.Opportunity__c);
+                        for (DataImport__c di : opptAlloMatchingDIs) {
+                            bdi.LogBDIError(di,label.bdiErrorExistingDonationAllocations,null);
+                        }
+                    }
+
+                    if (disByOpptId.get(allo.Payment__r.npe01__Opportunity__c) != null) {
+                        paymentAlloMatchingDIs = disByOpptId.get(allo.Payment__r.npe01__Opportunity__c);
+                        for (DataImport__c di : opptAlloMatchingDIs) {
+                            bdi.LogBDIError(di,label.bdiErrorExistingPaymentAllocations,null);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @description This method calls the Allocation Service to cascade down GAU Allocations from the Recurring Donation
+     * to the Donation, and Payment (if payment allocations are enabled).  It also will capture errors returned from
+     * processing GAU Allocations and fail the Data Import record.
+     * @param bdi the BDI_DataImportService instance that is being used for this context.
+     * @param dataImports {List<DataImport__c>} the data import records to process allocations for
+     */
+    public static void processAllocations(BDI_DataImportService bdi, List<DataImport__c> dataImports) {
+        Set<Id> opptIdsForAllocProcessing = new Set<Id>();
+        DataImport__c[] diForAlloProcessing = new DataImport__c[]{};
+        for (DataImport__c di : dataImports) {
+
+            // If the DI doesn't have a failure and it isn't in dry run mode and there is
+            // a donation imported id and a donation or a payment was created then run allocation processing for all
+            // donation ids.
+            if (di.Status__c != System.label.bdiFailed &&
+                    !bdi.isDryRun  &&
+                    di.DonationImported__c != null && (
+                    di.PaymentImportStatus__c == System.label.bdiCreated
+                            || di.PaymentImportStatus__c == System.label.bdiUpdated
+                            || di.DonationImportStatus__c == System.label.bdiCreated)) {
+
+                opptIdsForAllocProcessing.add(di.DonationImported__c);
+                diForAlloProcessing.add(di);
+            }
+        }
+
+        // If there were any opportunities that met the criteria for allocation processing then call the
+        // Allocations service.
+        if(opptIdsForAllocProcessing.size() > 0) {
+            // Instantiating a custom error class so that we can review the error messages without inserting them as
+            // error records.
+            ERR_RecordError errors = new ERR_RecordError('GAU Allocations');
+            // Calling the allocations service with a custom error class and setting a flag not to commit the errors
+            // since we will be adding them to the
+            ALLO_AllocationsService allocationsSvc = new ALLO_AllocationsService()
+                    .withAlternateRecordErrorsLogger(errors)
+                    .withCommitAndClearRecordsEnabled(false);
+            allocationsSvc.processRecords(opptIdsForAllocProcessing);
+
+            Allocation__c[] allocForDelete = new Allocation__c[]{};
+
+            for (DataImport__c di : diForAlloProcessing) {
+                Error__c errorObj;
+
+                // Retrieve the error object out of either the insert or update errors
+                if (errors.insRecordErrors.containsKey(di.DonationImported__c)) {
+                    errorObj = errors.insRecordErrors.get(di.DonationImported__c);
+                } else if (errors.updRecordErrors.containsKey(di.DonationImported__c)) {
+                    errorObj = errors.updRecordErrors.get(di.DonationImported__c);
+                }
+
+                if (errorObj != null) {
+                    String statusFieldName;
+
+                    // If there was a GAU allocation imported then add it to the list for delete and overwrite status
+                    // with error message.  Otherwise add it to the status message for the Donation or Payment.
+                    if (di.GAU_Allocation_1_Imported__c != null || di.GAU_Allocation_2_Imported__c != null) {
+                        if (di.GAU_Allocation_1_Imported__c != null) {
+                            allocForDelete.add(new Allocation__c(Id = di.GAU_Allocation_1_Imported__c));
+                            statusFieldName = SObjectType.DataImport__c.fields.GAU_Allocation_1_Import_Status__c.Name;
+                            di.GAU_Allocation_1_Imported__c = null;
+                        }
+                        if (di.GAU_Allocation_2_Imported__c != null) {
+                            allocForDelete.add(new Allocation__c(Id = di.GAU_Allocation_2_Imported__c));
+                            statusFieldName = SObjectType.DataImport__c.fields.GAU_Allocation_2_Import_Status__c.Name;
+                            di.GAU_Allocation_2_Imported__c = null;
+                        }
+                    } else if (di.PaymentImported__c != null) {
+                        statusFieldName = SObjectType.DataImport__c.fields.PaymentImportStatus__c.Name;
+                    } else if (di.DonationImported__c != null) {
+                        statusFieldName = SObjectType.DataImport__c.fields.DonationImportStatus__c.Name;
+                    }
+
+                    bdi.LogBDIError(di, errorObj.Full_Message__c, statusFieldName);
+                }
+            }
+            // Delete any allocations that were created for an oppt that had related allocation errors.
+            if (allocForDelete.size() > 0) {
+                if (UTIL_Permissions.canDelete(String.valueOf(Allocation__c.getSObjectType()), false)) {
+                    delete allocForDelete;
+                }
+            }
+        }
+    }
+}

--- a/src/classes/BDI_GAUAllocationsUtil.cls
+++ b/src/classes/BDI_GAUAllocationsUtil.cls
@@ -32,7 +32,7 @@
 * @date 2021
 * @group Batch Data Import
 * @group-content ../../ApexDocContent/BatchDataImport.htm
-* @description Provides helper methods to validate and process GAUs entered on the DI.
+* @description Provides helper methods to validate and process GAUs entered on the Data Import record.
 */
 
 public with sharing class BDI_GAUAllocationsUtil {
@@ -127,36 +127,53 @@ public with sharing class BDI_GAUAllocationsUtil {
         // If there are disByOpptId then query existing Allocations
         if (!disByOpptId.isEmpty()) {
             Set<Id> opptIds = disByOpptId.keySet();
-            String queryString = ' SELECT Id, ' +
-                    'General_Accounting_Unit__c, ' +
-                    'Opportunity__c,' +
-                    'Payment__c,' +
-                    'Payment__r.npe01__Opportunity__c '+
-                    'FROM Allocation__c WHERE Opportunity__c IN: opptIds';
 
-            if (alloSettings.Payment_Allocations_Enabled__c) {
-                queryString += ' OR Payment__r.npe01__Opportunity__c IN: opptIds';
-            }
+            UTIL_Permissions utilPerm = UTIL_Permissions.getInstance();
 
-            Allocation__c[] existingAllos = Database.query(queryString);
+            Set<SObjectField> allocFields = new Set<SObjectField>();
+            allocFields.add(SObjectType.Allocation__c.fields.Id.getSobjectField());
+            allocFields.add(SObjectType.Allocation__c.fields.Payment__c.getSobjectField());
+            allocFields.add(SObjectType.Allocation__c.fields.Opportunity__c.getSobjectField());
+            allocFields.add(SObjectType.Allocation__c.fields.General_Accounting_Unit__c.getSobjectField());
 
-            if (existingAllos != null){
-                for (Allocation__c allo: existingAllos) {
-                    DataImport__c[] opptAlloMatchingDIs;
-                    DataImport__c[] paymentAlloMatchingDIs;
+            Set<SObjectField> paymentFields = new Set<SObjectField>();
+            paymentFields.add(SObjectType.npe01__OppPayment__c.fields.Id.getSobjectField());
+            paymentFields.add(SObjectType.npe01__OppPayment__c.fields.npe01__Opportunity__c.getSobjectField());
 
-                    // Log error for newly created donations that already have
-                    if (disByOpptId.get(allo.Opportunity__c) != null) {
-                        opptAlloMatchingDIs = disByOpptId.get(allo.Opportunity__c);
-                        for (DataImport__c di : opptAlloMatchingDIs) {
-                            bdi.LogBDIError(di,label.bdiErrorExistingDonationAllocations,null);
+            if(utilPerm.canRead(Allocation__c.getSObjectType(),allocFields)
+                && utilPerm.canRead(npe01__OppPayment__c.getSObjectType(),paymentFields)) {
+
+                String queryString = ' SELECT Id, ' +
+                        'General_Accounting_Unit__c, ' +
+                        'Opportunity__c,' +
+                        'Payment__c,' +
+                        'Payment__r.npe01__Opportunity__c '+
+                        'FROM Allocation__c WHERE Opportunity__c IN: opptIds';
+
+                if (alloSettings.Payment_Allocations_Enabled__c) {
+                    queryString += ' OR Payment__r.npe01__Opportunity__c IN: opptIds';
+                }
+
+                Allocation__c[] existingAllos = Database.query(queryString);
+
+                if (existingAllos != null){
+                    for (Allocation__c allo: existingAllos) {
+                        DataImport__c[] opptAlloMatchingDIs;
+                        DataImport__c[] paymentAlloMatchingDIs;
+
+                        // Log error for newly created donations that already have
+                        if (disByOpptId.get(allo.Opportunity__c) != null) {
+                            opptAlloMatchingDIs = disByOpptId.get(allo.Opportunity__c);
+                            for (DataImport__c di : opptAlloMatchingDIs) {
+                                bdi.LogBDIError(di,label.bdiErrorExistingDonationAllocations,null);
+                            }
                         }
-                    }
 
-                    if (disByOpptId.get(allo.Payment__r.npe01__Opportunity__c) != null) {
-                        paymentAlloMatchingDIs = disByOpptId.get(allo.Payment__r.npe01__Opportunity__c);
-                        for (DataImport__c di : opptAlloMatchingDIs) {
-                            bdi.LogBDIError(di,label.bdiErrorExistingPaymentAllocations,null);
+                        if (disByOpptId.get(allo.Payment__r.npe01__Opportunity__c) != null) {
+                            paymentAlloMatchingDIs = disByOpptId.get(allo.Payment__r.npe01__Opportunity__c);
+                            for (DataImport__c di : paymentAlloMatchingDIs) {
+                                bdi.LogBDIError(di,label.bdiErrorExistingPaymentAllocations,null);
+                            }
                         }
                     }
                 }

--- a/src/classes/BDI_GAUAllocationsUtil.cls-meta.xml
+++ b/src/classes/BDI_GAUAllocationsUtil.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/BDI_GAUAllocationsUtil_TEST.cls
+++ b/src/classes/BDI_GAUAllocationsUtil_TEST.cls
@@ -1,0 +1,353 @@
+/**
+ * Created by c.allen on 4/23/21.
+ */
+/*
+    Copyright (c) 2021 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2021
+* @group Batch Data Import
+* @group-content ../../ApexDocContent/BatchDataImport.htm
+* @description Tests helper methods to validate and process GAUs entered on the Data Import record.
+*/
+@IsTest
+public with sharing class BDI_GAUAllocationsUtil_TEST {
+
+    @IsTest
+    static void gauValidationsShouldBeEnforced() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
+        dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
+        dis.Default_Data_Import_Field_Mapping_Set__c =
+                BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
+        UTIL_CustomSettingsFacade.setDataImportSettings(dis);
+
+
+        General_Accounting_Unit__c gau1 = new General_Accounting_Unit__c(Name = 'TestGAU1',
+                Active__c = true);
+
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(Name = 'TestGAU2',
+                Active__c = true);
+
+        General_Accounting_Unit__c gau3 = new General_Accounting_Unit__c(Name = 'TestGAU3',
+                Active__c = true);
+
+        General_Accounting_Unit__c[] testGAUs = new General_Accounting_Unit__c[]{gau1,gau2,gau3};
+        insert testGAUs;
+
+        Allocations_Settings__c alloSettings = new Allocations_Settings__c();
+        alloSettings.Payment_Allocations_Enabled__c = true;
+        alloSettings.Default_Allocations_Enabled__c = true;
+        alloSettings.Default__c = gau3.Id;
+
+        UTIL_CustomSettingsFacade.getAllocationsSettingsForTests(alloSettings);
+
+        Campaign testCampaign = new Campaign(Name = 'TestGroupA with GAU',
+                IsActive = true,
+                StartDate = Date.today().addDays(-10),
+                EndDate = Date.today().addDays(10));
+        insert testCampaign;
+
+        // RD with contact 1 as owner, should trigger error on having percent over 100
+        DataImport__c testDataImportA =
+                new DataImport__c(
+                        Contact1_Firstname__c = 'Susie',
+                        Contact1_Home_Phone__c = '555-321-0001',
+                        Contact1_Lastname__c = 'TestGroupA01',
+                        Contact1_Other_Phone__c = '555-456-0001',
+                        Contact1_Personal_Email__c = 'testgroupAcontact01Personal@fakedata.com',
+                        Contact1_Preferred_Email__c = 'testgroupAcontact01Preferred@fakedata.com',
+                        Contact1_Preferred_Phone__c = '555-567-0001',
+                        Recurring_Donation_Amount__c = 100,
+                        Recurring_Donation_Date_Established__c = System.Date.Today(),
+                        Recurring_Donation_Day_of_Month__c = '12',
+                        Recurring_Donation_Installment_Frequency__c = 1,
+                        Recurring_Donation_Installment_Period__c = 'Monthly',
+                        Recurring_Donation_Effective_Date__c = System.Date.Today(),
+                        Recurring_Donation_End_Date__c = null,
+                        Recurring_Donation_Planned_Installments__c = null,
+                        Recurring_Donation_Recurring_Type__c = null,
+                        Recurring_Donation_Status__c = null,
+                        Recurring_Donation_Status_Reason__c = null,
+                        Donation_Donor__c = 'Contact1',
+                        Donation_Amount__c = 100,
+                        Donation_Date__c = System.Date.Today(),
+                        Home_City__c = 'Fakeville',
+                        Home_Country__c = 'United States',
+                        Home_State_Province__c = 'California',
+                        Home_Street__c = '100 Fake Blvd',
+                        Home_Zip_Postal_Code__c = '94105',
+                        Household_Phone__c = '555-789-0001',
+                        Payment_Check_Reference_Number__c = '453',
+                        Payment_Method__c = 'Check',
+                        GAU_Allocation_1_Percent__c = 60,
+                        GAU_Allocation_1_GAU__c = gau1.Id,
+                        GAU_Allocation_2_Percent__c = 60,
+                        GAU_Allocation_2_GAU__c = gau2.Id);
+
+        // This will regression test receiving default gaus.
+        DataImport__c testDataImportB =
+                new DataImport__c(
+                        Contact1_Firstname__c = 'Joe',
+                        Contact1_Home_Phone__c = '555-321-0001',
+                        Contact1_Lastname__c = 'TestGroupB01',
+                        Contact1_Other_Phone__c = '555-456-0001',
+                        Contact1_Personal_Email__c = 'testgroupBcontact01Personal@fakedata.com',
+                        Contact1_Preferred_Email__c = 'testgroupBcontact01Preferred@fakedata.com',
+                        Contact1_Preferred_Phone__c = '555-567-0001',
+                        Donation_Donor__c = 'Contact1',
+                        Donation_Amount__c = 100,
+                        Home_City__c = 'Fakeville',
+                        Home_Country__c = 'United States',
+                        Home_State_Province__c = 'California',
+                        Home_Street__c = '500 Fake Blvd',
+                        Home_Zip_Postal_Code__c = '94105',
+                        Household_Phone__c = '555-789-0001',
+                        Payment_Check_Reference_Number__c = '453',
+                        Payment_Method__c = 'Check');
+
+        // RD with Account 1 as donor this should test happy path
+        DataImport__c testDataImportC =
+                new DataImport__c(Account1_City__c = 'Faketown',
+                        Account1_Country__c = 'United States',
+                        Account1_Name__c = 'TestGroupC Org 1',
+                        Account1_Phone__c = '554-123-0001',
+                        Account1_State_Province__c = 'California',
+                        Account1_Street__c = '954 Fakey St',
+                        Account1_Website__c = 'www.groupBfakeorgacct01.com',
+                        Account1_Zip_Postal_Code__c = '20000',
+                        Recurring_Donation_Amount__c = 300,
+                        Recurring_Donation_Date_Established__c = System.Date.Today(),
+                        Recurring_Donation_Day_of_Month__c = '12',
+                        Recurring_Donation_Installment_Frequency__c = 1,
+                        Recurring_Donation_Installment_Period__c = 'Monthly',
+                        Recurring_Donation_Effective_Date__c = System.Date.Today().addDays(5),
+                        Recurring_Donation_End_Date__c = null,
+                        Recurring_Donation_Planned_Installments__c = null,
+                        Recurring_Donation_Recurring_Type__c = null,
+                        Recurring_Donation_Status__c = null,
+                        Recurring_Donation_Status_Reason__c = null,
+                        Donation_Donor__c = 'Account1',
+                        Payment_Check_Reference_Number__c = '453',
+                        Payment_Method__c = 'Check',
+                        GAU_Allocation_1_Percent__c = 50,
+                        GAU_Allocation_1_GAU__c = gau1.Id,
+                        GAU_Allocation_2_Percent__c = 50,
+                        GAU_Allocation_2_GAU__c = gau2.Id);
+
+        DataImport__c[] testDIs = new DataImport__c[]{testDataImportA,testDataImportB,testDataImportC};
+        insert testDIs;
+
+        Test.StartTest();
+        BDI_DataImport_BATCH bdi = new BDI_DataImport_BATCH();
+        ID ApexJobId = Database.executeBatch(bdi, 10);
+        Test.stopTest();
+
+        DataImport__c testDIResultA;
+        DataImport__c testDIResultB;
+        DataImport__c testDIResultC;
+
+        for (DataImport__c di : [SELECT Id,
+                Status__c,
+                FailureInformation__c,
+                Contact1_Lastname__c,
+                Account1_Name__c,
+                Recurring_Donation_Day_of_Month__c,
+                Account1ImportStatus__c,
+                Account1Imported__c,
+                Account2ImportStatus__c,
+                Account2Imported__c,
+                Contact1ImportStatus__c,
+                Contact1Imported__c,
+                Contact2ImportStatus__c,
+                Contact2Imported__c,
+                DonationCampaignImportStatus__c,
+                DonationCampaignImported__c,
+                DonationImportStatus__c,
+                DonationImported__c,
+                Donation_Donor__c,
+                GAU_Allocation_1_Imported__c,
+                GAU_Allocation_1_Import_Status__c,
+                GAU_Allocation_2_Imported__c,
+                GAU_Allocation_2_Import_Status__c,
+                Recurring_Donation_Amount__c,
+                RecurringDonationImported__c,
+                RecurringDonationImportStatus__c,
+                HomeAddressImportStatus__c,
+                HomeAddressImported__c,
+                HouseholdAccountImported__c,
+                PaymentImportStatus__c,
+                PaymentImported__c,
+                Payment_Status__c,
+                NPSP_Data_Import_Batch__c,
+                Additional_Object_JSON__c
+        FROM DataImport__c]) {
+            if (di.Contact1_Lastname__c == 'TestGroupA01') {
+                testDIResultA = di;
+            } else if (di.Contact1_Lastname__c == 'TestGroupB01') {
+                testDIResultB = di;
+            } else if (di.Account1_Name__c == 'TestGroupC Org 1') {
+                testDIResultC = di;
+            }
+        }
+
+        // Test that this record did not process because of the error with the GAU Allocation over 100%
+        System.assert(testDIResultA.FailureInformation__c.contains(label.bdiErrorGAUAllocationOver100));
+        System.assertEquals(BDI_DataImport_API.bdiFailed,testDIResultA.Status__c);
+        System.assertEquals(null,testDIResultA.Contact1Imported__c);
+        System.assertEquals(null,testDIResultA.Contact1ImportStatus__c);
+        System.assertEquals(null,testDIResultA.RecurringDonationImported__c);
+        System.assertEquals(null,testDIResultA.RecurringDonationImportStatus__c);
+        System.assertEquals(null,testDIResultA.DonationCampaignImported__c);
+        System.assertEquals(null,testDIResultA.DonationImported__c);
+        System.assertEquals(null,testDIResultA.DonationImportStatus__c);
+        System.assertEquals(null,testDIResultA.HouseholdAccountImported__c);
+        System.assertEquals(null,testDIResultA.HomeAddressImported__c);
+        System.assertEquals(null,testDIResultA.GAU_Allocation_1_Imported__c);
+        System.assertEquals(null,testDIResultA.GAU_Allocation_2_Imported__c);
+
+        // Test that this record was created successfully, and later we will check that the default GAU was assigned.
+        System.assertEquals(null,testDIResultB.FailureInformation__c);
+        System.assertEquals(BDI_DataImport_API.bdiImported,testDIResultB.Status__c);
+        System.assertNotEquals(null,testDIResultB.Contact1Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDIResultB.Contact1ImportStatus__c);
+        System.assertEquals('Contact1',testDIResultB.Donation_Donor__c);
+        System.assertNotEquals(null,testDIResultB.DonationImported__c);
+        System.assertEquals(System.label.bdiCreated,testDIResultB.DonationImportStatus__c);
+        System.assertNotEquals(null,testDIResultB.HouseholdAccountImported__c);
+        System.assertNotEquals(null,testDIResultB.HomeAddressImported__c);
+        System.assertEquals(null,testDIResultB.GAU_Allocation_1_Imported__c);
+        System.assertEquals(null,testDIResultB.GAU_Allocation_2_Imported__c);
+
+        // Test that this DI did process successfully and created records appropriately
+        System.assertEquals(null,testDIResultC.FailureInformation__c);
+        System.assertEquals(BDI_DataImport_API.bdiImported,testDIResultC.Status__c);
+        System.assertNotEquals(null,testDIResultC.Account1Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDIResultC.Account1ImportStatus__c);
+        System.assertEquals(null,testDIResultC.DonationCampaignImported__c);
+        System.assertEquals(null,testDIResultC.DonationCampaignImportStatus__c);
+        System.assertNotEquals(null,testDIResultC.RecurringDonationImported__c);
+        System.assertEquals(System.label.bdiCreated,testDIResultC.RecurringDonationImportStatus__c);
+        System.assertEquals(null,testDIResultC.DonationImported__c);
+        System.assertEquals(null,testDIResultC.DonationImportStatus__c);
+        System.assertEquals(null,testDIResultC.HouseholdAccountImported__c);
+        System.assertEquals(null,testDIResultC.HomeAddressImported__c);
+        System.assertNotEquals(null,testDIResultC.GAU_Allocation_1_Imported__c);
+        System.assertNotEquals(null,testDIResultC.GAU_Allocation_2_Imported__c);
+
+        Allocation__c opptB1Alloc;
+        Allocation__c pymtB1Alloc;
+
+        for(Allocation__c alloc : [SELECT Id,
+                Opportunity__c,
+                Recurring_Donation__c,
+                Payment__c,
+                General_Accounting_Unit__c,
+                Amount__c,
+                Percent__c
+        FROM Allocation__c]) {
+            System.debug('Allocation is: ' + alloc);
+            if (alloc.Opportunity__c == testDIResultB.DonationImported__c) {
+                opptB1Alloc = alloc;
+            } else if (alloc.Payment__c == testDIResultB.PaymentImported__c) {
+                pymtB1Alloc = alloc;
+            }
+        }
+
+        System.assertNotEquals(null,opptB1Alloc);
+        System.assertNotEquals(null,pymtB1Alloc);
+        System.assertEquals(opptB1Alloc.General_Accounting_Unit__c,gau3.id);
+        System.assertEquals(pymtB1Alloc.General_Accounting_Unit__c,gau3.id);
+
+        // This test record should trigger errors for both donation and payment allocations existing.
+        DataImport__c testDIB2 = new DataImport__c(Account1Imported__c = testDIResultB.Account1Imported__c,
+                                                    DonationImported__c = testDIResultB.DonationImported__c,
+                                                    PaymentImported__c = testDIResultB.PaymentImported__c,
+                                                    GAU_Allocation_1_GAU__c = gau1.Id,
+                                                    GAU_Allocation_1_Percent__c = 100);
+
+        // Modify the existing test Data import C record with a new GAU to simulate trying to update Oppt with
+        testDIB2.GAU_Allocation_1_Import_Status__c = null;
+        testDIB2.GAU_Allocation_1_Imported__c = null;
+        testDIB2.GAU_Allocation_1_Percent__c = 100;
+        testDIB2.GAU_Allocation_1_GAU__c = gau3.Id;
+        testDIB2.Status__c = null;
+        testDIB2.FailureInformation__c = null;
+        testDIB2.GAU_Allocation_2_Import_Status__c = null;
+        testDIB2.GAU_Allocation_2_Imported__c = null;
+        testDIB2.GAU_Allocation_2_Percent__c = null;
+        testDIB2.GAU_Allocation_2_GAU__c = null;
+
+        DataImport__c[] testDIs2 = new DataImport__c[]{testDIB2};
+        insert testDIs2;
+
+        BDI_DataImport_API.processDataImportRecords(dis,testDIs2, false);
+
+        DataImport__c testDIResultB2 = [SELECT Id,
+                                                Status__c,
+                                                FailureInformation__c,
+                                                Contact1_Lastname__c,
+                                                Account1_Name__c,
+                                                Recurring_Donation_Day_of_Month__c,
+                                                Account1ImportStatus__c,
+                                                Account1Imported__c,
+                                                Account2ImportStatus__c,
+                                                Account2Imported__c,
+                                                Contact1ImportStatus__c,
+                                                Contact1Imported__c,
+                                                Contact2ImportStatus__c,
+                                                Contact2Imported__c,
+                                                DonationCampaignImportStatus__c,
+                                                DonationCampaignImported__c,
+                                                DonationImportStatus__c,
+                                                DonationImported__c,
+                                                Donation_Donor__c,
+                                                GAU_Allocation_1_Imported__c,
+                                                GAU_Allocation_1_Import_Status__c,
+                                                GAU_Allocation_2_Imported__c,
+                                                GAU_Allocation_2_Import_Status__c,
+                                                Recurring_Donation_Amount__c,
+                                                RecurringDonationImported__c,
+                                                RecurringDonationImportStatus__c,
+                                                HomeAddressImportStatus__c,
+                                                HomeAddressImported__c,
+                                                HouseholdAccountImported__c,
+                                                PaymentImportStatus__c,
+                                                PaymentImported__c
+                                        FROM DataImport__c
+                                        WHERE Id =: testDIB2.Id LIMIT 1];
+
+        System.assertNotEquals(null,testDIResultB2);
+        // Confirm that both error messages were logged in FailureInformation
+        System.assert(testDIResultB2.FailureInformation__c.contains(label.bdiErrorExistingDonationAllocations));
+        System.assert(testDIResultB2.FailureInformation__c.contains(label.bdiErrorExistingPaymentAllocations));
+    }
+}

--- a/src/classes/BDI_GAUAllocationsUtil_TEST.cls-meta.xml
+++ b/src/classes/BDI_GAUAllocationsUtil_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/BDI_RecurringDonations_TEST.cls
+++ b/src/classes/BDI_RecurringDonations_TEST.cls
@@ -7,6 +7,18 @@ private class BDI_RecurringDonations_TEST {
   
     @TestSetup
     static void setupTestData(){
+
+        General_Accounting_Unit__c gau1 = new General_Accounting_Unit__c(Name = 'TestGAU1',
+                Active__c = true);
+
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(Name = 'TestGAU2',
+                Active__c = true);
+
+        General_Accounting_Unit__c gau3 = new General_Accounting_Unit__c(Name = 'TestGAU3',
+                Active__c = true);
+
+        General_Accounting_Unit__c[] testGAUs = new General_Accounting_Unit__c[]{gau1,gau2,gau3};
+        insert testGAUs;
         Campaign testCampaign = new Campaign(Name = 'TestGroupA Campaign',
                                         IsActive = true,
                                         StartDate = Date.today().addDays(-10), 
@@ -45,7 +57,9 @@ private class BDI_RecurringDonations_TEST {
                     Home_Zip_Postal_Code__c = '94105',
                     Household_Phone__c = '555-789-0001',
                     Payment_Check_Reference_Number__c = '453',
-                    Payment_Method__c = 'Check');
+                    Payment_Method__c = 'Check',
+                    GAU_Allocation_1_Percent__c = 100,
+                    GAU_Allocation_1_GAU__c = gau1.Id);
 
         //RD with Contact1 as donor, yearly schedule, and creation of new campaign
         DataImport__c testDataImportB = 
@@ -137,11 +151,30 @@ private class BDI_RecurringDonations_TEST {
     static void shouldCreateAndUpdateRecurringDonation() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
-        //Disabling first installment creation for this test.  Will reenable when the disable
-        //first installment field on the RD is working.
-        RD2_Settings_TEST.setUpConfiguration(new Map<String, Object> {
-            'InstallmentOppAutoCreateOption__c' => OPTION_NAME_DISABLE_FIRST
-        });
+        General_Accounting_Unit__c gau1;
+        General_Accounting_Unit__c gau2;
+        General_Accounting_Unit__c gau3;
+
+        for (General_Accounting_Unit__c gau : [SELECT Id, Name
+                                                FROM General_Accounting_Unit__c
+                                                LIMIT 10]) {
+            if (gau.Name == 'TestGAU1') {
+                gau1 = gau;
+            } else if (gau.Name == 'TestGAU2') {
+                gau2 = gau;
+            } else if (gau.Name == 'TestGAU3') {
+                gau3 = gau;
+            }
+        }
+
+        Allocations_Settings__c alloSettings = new Allocations_Settings__c();
+        alloSettings.Payment_Allocations_Enabled__c = true;
+        alloSettings.Default_Allocations_Enabled__c = true;
+        alloSettings.Default__c = gau3.Id;
+
+        UTIL_CustomSettingsFacade.getAllocationsSettingsForTests(alloSettings);
+
+        System.debug('Allo settings for test: ' + UTIL_CustomSettingsFacade.getAllocationsSettings());
 
         Data_Import_Settings__c dis = UTIL_CustomSettingsFacade.getDataImportSettings();
         dis.Field_Mapping_Method__c = BDI_DataImportService.FM_DATA_IMPORT_FIELD_MAPPING;
@@ -178,6 +211,8 @@ private class BDI_RecurringDonations_TEST {
                                         DonationImportStatus__c,
                                         DonationImported__c,
                                         Donation_Donor__c,
+                                        GAU_Allocation_1_Imported__c,
+                                        GAU_Allocation_1_Import_Status__c,
                                         Recurring_Donation_Amount__c,
                                         RecurringDonationImported__c,
                                         RecurringDonationImportStatus__c,
@@ -210,6 +245,8 @@ private class BDI_RecurringDonations_TEST {
         System.assertEquals(System.label.bdiCreated,testDIResultA.DonationImportStatus__c);
         System.assertNotEquals(null,testDIResultA.HouseholdAccountImported__c);
         System.assertNotEquals(null,testDIResultA.HomeAddressImported__c);
+        System.assertNotEquals(null,testDIResultA.GAU_Allocation_1_Imported__c);
+        System.assertNotEquals(null,testDIResultA.PaymentImported__c);
 
         //RD with Contact1 as donor, yearly schedule, and creation of new campaign
         System.assertEquals(null,testDIResultB.FailureInformation__c);
@@ -316,17 +353,49 @@ private class BDI_RecurringDonations_TEST {
         System.assertEquals(testDIResultC.Recurring_Donation_Day_Of_Month__c,rdC.Day_Of_Month__c);
         System.assertEquals(1,rdC.InstallmentFrequency__c);
 
-        Opportunity[] opptResults = [SELECT Id, 
-                                            Name,
-                                            Amount,
-                                            CloseDate,
-                                            CreatedDate,
-                                            StageName,
-                                            Account.Name,
-                                            npe03__Recurring_Donation__c,
-                                            RecordtypeId
-                                        FROM Opportunity];
-        
+        Allocation__c rdA1Alloc;
+        Allocation__c opptA1Alloc;
+        Allocation__c pymtA1Alloc;
+
+        for(Allocation__c alloc : [SELECT Id,
+                                    Opportunity__c,
+                                    Recurring_Donation__c,
+                                    Payment__c,
+                                    General_Accounting_Unit__c,
+                                    Amount__c,
+                                    Percent__c
+                                    FROM Allocation__c]) {
+            System.debug('Allocation is: ' + alloc);
+            if (alloc.Recurring_Donation__c == testDIResultA.RecurringDonationImported__c) {
+                rdA1Alloc = alloc;
+            } else if (alloc.Opportunity__c == testDIResultA.DonationImported__c) {
+                opptA1Alloc = alloc;
+            } else if (alloc.Payment__c == testDIResultA.PaymentImported__c) {
+                pymtA1Alloc = alloc;
+            }
+        }
+
+        System.assertNotEquals(null,rdA1Alloc);
+        System.assertEquals(gau1.Id,rdA1Alloc.General_Accounting_Unit__c);
+        System.assertNotEquals(null,opptA1Alloc);
+        System.assertEquals(gau1.Id,opptA1Alloc.General_Accounting_Unit__c);
+        System.assertNotEquals(null,pymtA1Alloc);
+        System.assertEquals(gau1.Id,pymtA1Alloc.General_Accounting_Unit__c);
+
+        Opportunity[] opptResults = [SELECT Id,
+                Name,
+                Amount,
+                CloseDate,
+                CreatedDate,
+                StageName,
+                Account.Name,
+                npe03__Recurring_Donation__c,
+                RecordtypeId
+        FROM Opportunity];
+
+        for (Opportunity oppt : opptResults) {
+            System.debug('Oppt is: ' + oppt);
+        }
         //Updating this DI to close RD
         DataImport__c diAUpdate = 
             new DataImport__c(

--- a/src/classes/ERR_RecordError.cls
+++ b/src/classes/ERR_RecordError.cls
@@ -43,8 +43,8 @@ public class ERR_RecordError {
 
     private String context;
 
-    private Map<ID, Error__c> insRecordErrors = new Map<Id, Error__c>();
-    private Map<ID, Error__c> updRecordErrors = new Map<Id, Error__c>();
+    public Map<ID, Error__c> insRecordErrors = new Map<Id, Error__c>();
+    public Map<ID, Error__c> updRecordErrors = new Map<Id, Error__c>();
 
     /*******************************************************************************************************
     * @description Constructor for the ERR_RecordError class.  It should include a context that represents

--- a/src/customMetadata/Data_Import_Field_Mapping.GAU_Allocation_1_Recurring_Donation.md
+++ b/src/customMetadata/Data_Import_Field_Mapping.GAU_Allocation_1_Recurring_Donation.md
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>GAU Allocation 1: Recurring Donation</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">npsp__RecurringDonationImported__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">npsp__Recurring_Donation__c</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">GAU_Allocation_1</value>
+    </values>
+</CustomMetadata>

--- a/src/customMetadata/Data_Import_Field_Mapping.GAU_Allocation_2_Recurring_Donation.md
+++ b/src/customMetadata/Data_Import_Field_Mapping.GAU_Allocation_2_Recurring_Donation.md
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>GAU Allocation 2: Recurring Donation</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">npsp__RecurringDonationImported__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">npsp__Recurring_Donation__c</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">GAU_Allocation_2</value>
+    </values>
+</CustomMetadata>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -3891,6 +3891,30 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <value>The Donation information matched against one or more Opportunities, but the setting required no matches, so the NPSP Data Importer did not import it. The Donation Possible Matches field contains the Salesforce Ids of the matched Opportunities.</value>
     </labels>
     <labels>
+        <fullName>bdiErrorExistingDonationAllocations</fullName>
+        <categories>Data Importer</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>bdiErrorExistingDonationAllocations</shortDescription>
+        <value>There are existing allocations on the donation which may conflict with the GAU allocations entered.</value>
+    </labels>
+    <labels>
+        <fullName>bdiErrorExistingPaymentAllocations</fullName>
+        <categories>Data Importer</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>bdiErrorExistingPaymentAllocations</shortDescription>
+        <value>There are existing allocations on the payment which may conflict with the GAU Allocations entered.</value>
+    </labels>
+    <labels>
+        <fullName>bdiErrorGAUAllocationOver100</fullName>
+        <categories>Data Importer</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>bdiErrorGAUAllocationOver100</shortDescription>
+        <value>The GAU Allocations entered exceed 100 percent.</value>
+    </labels>
+    <labels>
         <fullName>bdiErrorInvalidCampaignName</fullName>
         <categories>Data Importer</categories>
         <language>en_US</language>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -3912,7 +3912,7 @@ To check your GAU Allocation settings, go to Donations | GAU Allocations.</value
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>bdiErrorGAUAllocationOver100</shortDescription>
-        <value>The GAU Allocations entered exceed 100 percent.</value>
+        <value>The provided GAU Allocations exceed 100 percent.</value>
     </labels>
     <labels>
         <fullName>bdiErrorInvalidCampaignName</fullName>


### PR DESCRIPTION
- Added ability for GAUs to be linked to recurring donations and be cascaded down to donations and payments through the use of the ALLO_AllocationsService
- Disabled Allocations trigger during Data Import processing when there are GAU Allocations to be created.  This prevents incorrect defaults from being assigned before the GAUs are created in the additional object service
- Added basic validation check to ensure that total percent for the GAU allocations on the DI do not exceed 100%.  If they are over 100, an error will be added and the DI record will be failed.
- Added  validation check to ensure that there were no existing allocations on the donation listed in DonationImported__c and no allocations on payments for that donation.  If there are any, the DI record will be failed and an error message added.
-  Modified unit tests for Additional Objects since updating GAUs via BDI will no longer work due to the above validations.
-  Added data import field mapping to allow GAU Allocations to be mapped onto Recurring donations.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
