### PR TITLE
RD2: Adding Last Elevate Event Version to new RDs and checking version on Update

### DIFF
--- a/src/classes/RD2_ElevateIntegrationService.cls
+++ b/src/classes/RD2_ElevateIntegrationService.cls
@@ -87,10 +87,10 @@ public inherited sharing class RD2_ElevateIntegrationService {
     * @return Boolean
     */
     public static Boolean isElevateEvent(RD2_RecurringDonation rd, RD2_RecurringDonation oldRd) {
-        String elevateEvent = rd.getSObject().LastElevateEventPlayed__c;
+        Integer elevateEventVersion = Integer.valueOf(rd.getSObject().LastElevateVersionPlayed__c);
 
-        Boolean isElevateEventChanged = String.isNotBlank(elevateEvent)
-            && elevateEvent != oldRd.getSObject().LastElevateEventPlayed__c;
+        Boolean isElevateEventChanged = elevateEventVersion != null
+            && elevateEventVersion > oldRd.getSObject().LastElevateVersionPlayed__c;
 
         return isElevateEventChanged;
     }

--- a/src/classes/RD2_ElevateIntegrationService.cls
+++ b/src/classes/RD2_ElevateIntegrationService.cls
@@ -87,12 +87,21 @@ public inherited sharing class RD2_ElevateIntegrationService {
     * @return Boolean
     */
     public static Boolean isElevateEvent(RD2_RecurringDonation rd, RD2_RecurringDonation oldRd) {
-        Integer elevateEventVersion = Integer.valueOf(rd.getSObject().LastElevateVersionPlayed__c);
+        Integer newElevateEventVersion = returnElevateVersionAsInteger(rd);
+        Integer oldElevateEventVersion = returnElevateVersionAsInteger(oldRd);
 
-        Boolean isElevateEventChanged = elevateEventVersion != null
-            && elevateEventVersion > oldRd.getSObject().LastElevateVersionPlayed__c;
+        Boolean isElevateEventChanged = newElevateEventVersion > oldElevateEventVersion;
 
         return isElevateEventChanged;
+    }
+
+    /***
+    * @description Returns the Last Elevate Version Played as an Integer. If null, return -1
+    * @return Integer
+    */
+    private static Integer returnElevateVersionAsInteger (RD2_RecurringDonation rd){
+        return rd.getSObject().LastElevateVersionPlayed__c != null 
+            ? Integer.valueOf(rd.getSObject().LastElevateVersionPlayed__c) : -1;
     }
 
     /***

--- a/src/classes/RD2_ElevateIntegrationService_TEST.cls
+++ b/src/classes/RD2_ElevateIntegrationService_TEST.cls
@@ -632,10 +632,12 @@ public class RD2_ElevateIntegrationService_TEST {
 
         npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
             .withStatusClosed()
+            .withLastElevateVersionPlayed(2)
             .build();
-        npe03__Recurring_Donation__c oldRd = newRd.clone();
-        newRd.LastElevateVersionPlayed__c = 2;
-        oldRd.LastElevateVersionPlayed__c = 1;
+        npe03__Recurring_Donation__c oldRd = getElevateRecurringDonationBaseBuilder()
+            .withStatusClosed()
+            .withLastElevateVersionPlayed(1)
+            .build();
 
         System.assertEquals(
             true,
@@ -652,10 +654,11 @@ public class RD2_ElevateIntegrationService_TEST {
 
         npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
             .withStatusClosed()
+            .withLastElevateVersionPlayed(2)
             .build();
-        npe03__Recurring_Donation__c oldRd = newRd.clone();
-        newRd.LastElevateVersionPlayed__c = 2;
-        oldRd.LastElevateVersionPlayed__c = null;
+        npe03__Recurring_Donation__c oldRd = getElevateRecurringDonationBaseBuilder()
+            .withStatusClosed()
+            .build();
 
         System.assertEquals(
             true,
@@ -672,10 +675,9 @@ public class RD2_ElevateIntegrationService_TEST {
 
         npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
             .withStatusClosed()
+            .withLastElevateVersionPlayed(1)
             .build();
         npe03__Recurring_Donation__c oldRd = newRd.clone();
-        newRd.LastElevateVersionPlayed__c = 1;
-        oldRd.LastElevateVersionPlayed__c = 1;
 
         System.assertEquals(
             false,
@@ -693,9 +695,10 @@ public class RD2_ElevateIntegrationService_TEST {
         npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
             .withStatusClosed()
             .build();
-        npe03__Recurring_Donation__c oldRd = newRd.clone();
-        newRd.LastElevateVersionPlayed__c = null;
-        oldRd.LastElevateVersionPlayed__c = 1;
+        npe03__Recurring_Donation__c oldRd = getElevateRecurringDonationBaseBuilder()
+            .withStatusClosed()
+            .withLastElevateVersionPlayed(1)
+            .build();
 
         System.assertEquals(
             false,

--- a/src/classes/RD2_ElevateIntegrationService_TEST.cls
+++ b/src/classes/RD2_ElevateIntegrationService_TEST.cls
@@ -644,6 +644,26 @@ public class RD2_ElevateIntegrationService_TEST {
     }
 
     /***
+    * @description Should determine that event is from Elevate when Last Elevate Version Played changes
+    */
+    @isTest
+    private static void shouldIdentifyEventFromElevateWhenLastElevateEventPlayedChangeFromNull() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
+            .withStatusClosed()
+            .build();
+        npe03__Recurring_Donation__c oldRd = newRd.clone();
+        newRd.LastElevateVersionPlayed__c = 2;
+        oldRd.LastElevateVersionPlayed__c = null;
+
+        System.assertEquals(
+            true,
+            RD2_ElevateIntegrationService.isElevateEvent(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
+            'Should recognize the event is from Elevate');
+    }
+
+    /***
     * @description Should determine that event is not from Elevate when Last Elevate Version Played is unchanged
     */
     @isTest
@@ -655,6 +675,26 @@ public class RD2_ElevateIntegrationService_TEST {
             .build();
         npe03__Recurring_Donation__c oldRd = newRd.clone();
         newRd.LastElevateVersionPlayed__c = 1;
+        oldRd.LastElevateVersionPlayed__c = 1;
+
+        System.assertEquals(
+            false,
+            RD2_ElevateIntegrationService.isElevateEvent(new RD2_RecurringDonation(newRd), new RD2_RecurringDonation(oldRd)),
+            'Should recognize the event is not from Elevate');
+    }
+
+    /***
+    * @description Should determine that event is not from Elevate when Last Elevate Version Played is unchanged
+    */
+    @isTest
+    private static void shouldIdentifyEventNotFromElevateWhenLastElevateEventPlayedNull() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        npe03__Recurring_Donation__c newRd = getElevateRecurringDonationBaseBuilder()
+            .withStatusClosed()
+            .build();
+        npe03__Recurring_Donation__c oldRd = newRd.clone();
+        newRd.LastElevateVersionPlayed__c = null;
         oldRd.LastElevateVersionPlayed__c = 1;
 
         System.assertEquals(

--- a/src/classes/RD2_ElevateIntegrationService_TEST.cls
+++ b/src/classes/RD2_ElevateIntegrationService_TEST.cls
@@ -624,7 +624,7 @@ public class RD2_ElevateIntegrationService_TEST {
     }
 
     /***
-    * @description Should determine that event is from Elevate when Last Elevate Event Played changes
+    * @description Should determine that event is from Elevate when Last Elevate Version Played changes
     */
     @isTest
     private static void shouldIdentifyEventFromElevateWhenLastElevateEventPlayedChanged() {
@@ -634,8 +634,8 @@ public class RD2_ElevateIntegrationService_TEST {
             .withStatusClosed()
             .build();
         npe03__Recurring_Donation__c oldRd = newRd.clone();
-        newRd.LastElevateEventPlayed__c = 'event-v2';
-        oldRd.LastElevateEventPlayed__c = 'event-v1';
+        newRd.LastElevateVersionPlayed__c = 2;
+        oldRd.LastElevateVersionPlayed__c = 1;
 
         System.assertEquals(
             true,
@@ -644,7 +644,7 @@ public class RD2_ElevateIntegrationService_TEST {
     }
 
     /***
-    * @description Should determine that event is from Elevate when Last Elevate Event Played changes
+    * @description Should determine that event is not from Elevate when Last Elevate Version Played is unchanged
     */
     @isTest
     private static void shouldIdentifyEventNotFromElevateWhenLastElevateEventPlayedUnchanged() {
@@ -654,8 +654,8 @@ public class RD2_ElevateIntegrationService_TEST {
             .withStatusClosed()
             .build();
         npe03__Recurring_Donation__c oldRd = newRd.clone();
-        newRd.LastElevateEventPlayed__c = 'event-v1';
-        oldRd.LastElevateEventPlayed__c = 'event-v1';
+        newRd.LastElevateVersionPlayed__c = 1;
+        oldRd.LastElevateVersionPlayed__c = 1;
 
         System.assertEquals(
             false,

--- a/src/classes/RD2_EntryFormController_TEST.cls
+++ b/src/classes/RD2_EntryFormController_TEST.cls
@@ -43,6 +43,7 @@ private with sharing class RD2_EntryFormController_TEST {
     private static final String CARD_LAST_4 = '1234';
     private static final String CARD_EXPIRATION_MONTH = '11';
     private static final String CARD_EXPIRATION_YEAR = '2019';
+    private static final String EVENT_VERSION = '1';
 
     private static final TEST_SObjectGateway.RecurringDonationGateway rdGateway = new TEST_SObjectGateway.RecurringDonationGateway();
     private static final TEST_SObjectGateway.ErrorGateway errorGateway = new TEST_SObjectGateway.ErrorGateway();
@@ -240,6 +241,8 @@ private with sharing class RD2_EntryFormController_TEST {
         System.assertNotEquals(null, response, 'The Commitment response should be returned');
         System.assertEquals(UTIL_Http.STATUS_CODE_CREATED, response.statusCode,
             'The response status code should match: ' + response);
+        System.assert(response.body.contains('"version":"'+EVENT_VERSION+'"'),
+            'The response should include the version: ' + response);
     }
 
     /**
@@ -387,6 +390,7 @@ private with sharing class RD2_EntryFormController_TEST {
     private static String mockSuccessResponseBody() {
         return '{"id":"' + COMMITMENT_ID
             + '","status":"ACTIVE","statusReason":"COMMITMENT_CREATED"'
+            + ',"version":"' + EVENT_VERSION +'"'
             + ',"cardData":{"last4":"' + CARD_LAST_4
             + '","expirationMonth":"' + CARD_EXPIRATION_MONTH
             + '","expirationYear":"' + CARD_EXPIRATION_YEAR

--- a/src/classes/RD2_RecurringDonations_TDTM.cls
+++ b/src/classes/RD2_RecurringDonations_TDTM.cls
@@ -465,6 +465,7 @@ public class RD2_RecurringDonations_TDTM extends TDTM_Runnable {
 
             if (rd.isElevateRecord() && rd.isClosed() && !oldRd.isClosed()) {
 
+                // If the Event originated from Elevate, we do not want to send it to Elevate again
                 if (RD2_ElevateIntegrationService.isElevateEvent(rd, oldRd)) {
                     continue;
                 }

--- a/src/classes/TEST_RecurringDonationBuilder.cls
+++ b/src/classes/TEST_RecurringDonationBuilder.cls
@@ -575,6 +575,16 @@ public without sharing class TEST_RecurringDonationBuilder {
         return this;
     }
 
+    /***
+    * @description Set LastElevateVersionPlayed
+    * @param version Integer for the 'Last Elevate Version Played'
+    * @return TEST_RecurringDonationBuilder Builder instance
+    */
+    public TEST_RecurringDonationBuilder withLastElevateVersionPlayed(Integer version) {
+        valuesByFieldName.put('LastElevateVersionPlayed__c', version);
+        return this;
+    }
+
     /**
     * @description Configure the RD with the appropriate default values based on the mode
     */

--- a/src/lwc/rd2EntryForm/rd2EntryForm.js
+++ b/src/lwc/rd2EntryForm/rd2EntryForm.js
@@ -22,6 +22,7 @@ import FIELD_CARD_EXPIRY_MONTH from '@salesforce/schema/npe03__Recurring_Donatio
 import FIELD_CARD_EXPIRY_YEAR from '@salesforce/schema/npe03__Recurring_Donation__c.CardExpirationYear__c';
 import FIELD_INSTALLMENT_FREQUENCY from '@salesforce/schema/npe03__Recurring_Donation__c.InstallmentFrequency__c';
 import FIELD_NEXT_DONATION_DATE from '@salesforce/schema/npe03__Recurring_Donation__c.npe03__Next_Payment_Date__c';
+import FIELD_LAST_ELEVATE_VERSION from '@salesforce/schema/npe03__Recurring_Donation__c.LastElevateVersionPlayed__c';
 
 import currencyFieldLabel from '@salesforce/label/c.lblCurrency';
 import cancelButtonLabel from '@salesforce/label/c.stgBtnCancel';
@@ -596,6 +597,9 @@ export default class rd2EntryForm extends LightningElement {
             this.commitmentId = responseBody.id;
 
             allFields[FIELD_COMMITMENT_ID.fieldApiName] = this.commitmentId;
+
+            // Set the version so we can compare later and know when an update occurs
+            allFields[FIELD_LAST_ELEVATE_VERSION.fieldApiName] = responseBody.version;
         }
 
         if (cardData) {


### PR DESCRIPTION
We are now adding the Elevate Event Version to an Elevate RD when it is created, and comparing the Event version when updates are sent from Elevate.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
