### PR TITLE
Remove code that unchecks "force skew mode"

### DIFF
--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -522,11 +522,6 @@ public inherited sharing class CRLP_RollupProcessor {
         if (mode == CRLP_RollupProcessingOptions.BatchJobMode.SkewMode && this.useForceSkewModeField && !isForceSkewModeTrue) {
             updatedRecord.put(this.qualifiedSkewField, true);
             needsUpdate = true;
-
-        // Reset any flags erroneously set for NonSkewMode records
-        } else if (mode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode && this.useForceSkewModeField && isForceSkewModeTrue) {
-            updatedRecord.put(this.qualifiedSkewField, false);
-            needsUpdate = true;
         }
 
         if (!needsUpdate) {

--- a/src/classes/CRLP_RollupProcessor_TEST.cls
+++ b/src/classes/CRLP_RollupProcessor_TEST.cls
@@ -539,8 +539,8 @@ private class CRLP_RollupProcessor_TEST {
         account.CustomizableRollups_UseSkewMode__c = true;
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
-                .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
-                .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
 
         Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
 
@@ -560,8 +560,29 @@ private class CRLP_RollupProcessor_TEST {
         account.CustomizableRollups_UseSkewMode__c = false;
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
-                .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
-                .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
+
+        Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
+
+        System.assertEquals(null, updatedAcct,
+            'Account should not be updated if running in non skew mode.');
+    }
+
+    /**
+     * @description Verify that skew mode flag is not updated if running in non skew mode.  Test only validates
+     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
+     */
+    @IsTest
+    static void shouldNotSetSkewModeFlagFalseWhenInNonSkewMode() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+
+        Account account = buildMockAccount();
+        account.CustomizableRollups_UseSkewMode__c = true;
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
 
         Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
 


### PR DESCRIPTION
We removed code that resets the "Customizable Rollups: Force Skew Mode" field to false when running in NonSkew mode during Customizable Rollup processing.
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
