### PR TITLE
Customizable Rollups: Update queries to use Skew Mode flag

### DIFF
--- a/src/classes/CRLP_RollupBatch_SVC.cls
+++ b/src/classes/CRLP_RollupBatch_SVC.cls
@@ -60,51 +60,19 @@ public class CRLP_RollupBatch_SVC {
      * @return A portion of a WHERE clause without WHERE or AND; or an empty string
      */
     public static String getSkewWhereClause(CRLP_RollupProcessingOptions.RollupType jobType, CRLP_RollupProcessingOptions.BatchJobMode jobMode,
-            String parentRelationshipField) {
+        String parentRelationshipField) {
         String queryFilter = '';
         Integer maxRelatedOppsForNonLDVMode = CRLP_Rollup_SVC.getMaxRelatedOppsForNonSkewMode();
 
-        // If the Summary Object is the Account, then filter on Accounts that have at least a single
-        // Opportunity attached. This is helpful to reduce the overall query size.
-        // To handle a scenario where an attached Opportunity was deleted, but the record not recalculated
-        // also include any records where the TotalGifts or TotalMemberships fields are not zero.
-        // If the field is null, a query with "< #" will not work. "= null" must be explicitly included in the query.
-        if (jobType == CRLP_RollupProcessingOptions.RollupType.ContactHardCredit ||
-                jobType == CRLP_RollupProcessingOptions.RollupType.AccountHardCredit) {
+        if (jobType != CRLP_RollupProcessingOptions.RollupType.GAU &&
+            jobType != CRLP_RollupProcessingOptions.RollupType.RecurringDonations
+            ) {
 
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '(' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c = null OR ' + parentRelationshipField +
-                    'npo02__NumberOfClosedOpps__c < ' + maxRelatedOppsForNonLDVMode + ') ' +
-                    'AND (' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c = null OR ' + parentRelationshipField +
-                    'npo02__NumberOfMembershipOpps__c < ' + maxRelatedOppsForNonLDVMode + ')';
+                queryFilter = '(' + parentRelationshipField + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
             } else {
-                queryFilter = '(' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c >= ' + maxRelatedOppsForNonLDVMode +
-                        ' OR ' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c >= ' + maxRelatedOppsForNonLDVMode + ')';
+                queryFilter = '(' + parentRelationshipField + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
-
-        } else if (jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
-
-            String softCreditField = parentRelationshipField + UTIL_Namespace.StrAllNSPrefix('Number_of_Soft_Credits__c');
-            if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '(' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')';
-            } else {
-                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode + ')';
-            }
-
-        } else if (jobType == CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit ||
-            jobType == CRLP_RollupProcessingOptions.RollupType.AccountSoftCredit) {
-
-            // TODO -- How to get Accounts that require using this method for Soft Credits??
-            // For now just use the NumberOfClosedOpportunities field as a proxy for the number of SoftCredits
-            String softCreditField = parentRelationshipField + 'npo02__NumberOfClosedOpps__c';
-            if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '(' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')';
-            } else {
-                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode + ')';
-            }
-
-        } else if (jobType == CRLP_RollupProcessingOptions.RollupType.GAU) {
-            // no extra filter on this type since we're always processing all GAU's using the skew method
 
         } else if (jobType == CRLP_RollupProcessingOptions.RollupType.RecurringDonations) {
 
@@ -131,15 +99,10 @@ public class CRLP_RollupBatch_SVC {
             jobType != CRLP_RollupProcessingOptions.RollupType.RecurringDonations)
         {
             String objName = recordId.getSobjectType().getDescribe().getName();
-            String soql = 'SELECT Id FROM ' + objName + ' WHERE Id = :recordID AND ('
-                + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c')
-                + ' = true';
+            String soql = 'SELECT Id FROM ' + objName + ' WHERE Id = :recordID ';
             String filter = getSkewWhereClause(jobType, CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             if (!String.isEmpty(filter)) {
-                soql += ' OR ' + filter + ')';
-            }
-            else {
-                soql += ')';
+                soql += ' AND ' + filter;
             }
             List<SObject> cntObj = database.query(soql);
             return cntObj.size() == 1;

--- a/src/classes/CRLP_RollupBatch_SVC.cls
+++ b/src/classes/CRLP_RollupBatch_SVC.cls
@@ -104,8 +104,8 @@ public class CRLP_RollupBatch_SVC {
             if (!String.isEmpty(filter)) {
                 soql += ' AND ' + filter;
             }
-            List<SObject> cntObj = database.query(soql);
-            return cntObj.size() == 1;
+            List<SObject> rollupSummaryObjects = database.query(soql);
+            return rollupSummaryObjects.size() == 1;
         }
         return true;
     }

--- a/src/classes/CRLP_RollupBatch_TEST.cls
+++ b/src/classes/CRLP_RollupBatch_TEST.cls
@@ -42,8 +42,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c',
-            'npo02__NumberOfMembershipOpps__c', 2, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -52,8 +51,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c',
-            'npo02__NumberOfMembershipOpps__c', 2, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -62,8 +60,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c',
-            'npo02__NumberOfMembershipOpps__c', 2, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -72,8 +69,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c',
-            'npo02__NumberOfMembershipOpps__c', 2, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -82,7 +78,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'Number_of_Soft_Credits__c', 1, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -91,7 +87,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'Number_of_Soft_Credits__c', 1, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -100,7 +96,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c', 1, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -109,7 +105,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c', 1, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -118,7 +114,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c', 1, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -127,7 +123,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c', 1, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -173,5 +169,14 @@ private class CRLP_RollupBatch_TEST {
         if (count > 1) {
             System.assert(whereClause.contains(apiName2), 'Expected field ' + apiName2 + ' missing from skew mode where clause');
         }
+    }
+
+    private static void assertSkewModeBoolean(String whereClause, Boolean isSkewMode)
+    {
+        final String apiName = 'CustomizableRollups_UseSkewMode__c';
+
+        System.assert(whereClause.contains(apiName), 'Expected field ' + apiName + ' missing from skew mode where clause');
+        System.assert(whereClause.contains(String.valueOf(isSkewMode)), 'Expected Boolean value ' + isSkewMode +
+            ' missing from skew mode where clause');
     }
 }

--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -500,7 +500,7 @@ public inherited sharing class CRLP_RollupProcessor {
 
         CRLP_VRollupHandler handler = initHandlerClass(parent);
 
-        List<CRLP_Rollup> rollupDefs = doFinalRollup(handler, parentId);
+        List<CRLP_Rollup> rollupsToCalculate = doFinalRollup(handler, parentId);
         if (options.doSummaryObjectComparison == false) {
             return null;
         }
@@ -509,7 +509,7 @@ public inherited sharing class CRLP_RollupProcessor {
         SObject updatedRecord = handler.getPopulatedSObject();
 
         // Determine if the updated SObject record is different than the parent.
-        Boolean needsUpdate = CRLP_Rollup_SVC.resultsNeedUpdate(parent, updatedRecord, rollupDefs);
+        Boolean needsUpdate = CRLP_Rollup_SVC.resultsNeedUpdate(parent, updatedRecord, rollupsToCalculate);
 
         // Check whether skew mode threshold has been exceeded
         initForceSkewModeValues(parent.getSObjectType());

--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -113,8 +113,6 @@ public inherited sharing class CRLP_RollupProcessor {
 
     private SObjectType summaryObjectType;
 
-    private Boolean useForceSkewModeField;
-
     /** *************************************************************************************************************
     * @description Constructor
     */
@@ -511,10 +509,11 @@ public inherited sharing class CRLP_RollupProcessor {
         Boolean needsUpdate = CRLP_Rollup_SVC.resultsNeedUpdate(parent, updatedRecord, rollupsToCalculate);
 
         initForceSkewModeValues(parent);
-        needsUpdate = isSkewModeNeeded(updatedRecord) || needsUpdate;
+        if (isSkewModeNeeded(updatedRecord)) {
+            updatedRecord.put(this.qualifiedSkewField, true);
 
-        if (!needsUpdate) {
-            updatedRecord = null;
+        } else if (!needsUpdate) {
+            return null;
         }
 
         return updatedRecord;
@@ -528,7 +527,6 @@ public inherited sharing class CRLP_RollupProcessor {
         if (this.qualifiedSkewField == null) {
             this.qualifiedSkewField = UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c');
             this.summaryObjectType = parent.getSObjectType();
-            this.useForceSkewModeField = (this.summaryObjectType == Account.SObjectType || this.summaryObjectType == Contact.SObjectType);
         }
     }
 
@@ -545,7 +543,6 @@ public inherited sharing class CRLP_RollupProcessor {
         }
 
         if (isRollupFieldAtThreshold(updatedRecord)) {
-            updatedRecord.put(this.qualifiedSkewField, true);
             return true;
         }
         return false;

--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -498,13 +498,6 @@ public inherited sharing class CRLP_RollupProcessor {
         // has changed or not.
         Id parentId = parent.Id;
 
-        // Determine status of force skew mode field
-        initForceSkewModeValues(parent.getSObjectType());
-        Boolean isForceSkewModeTrue = false;
-        if (this.useForceSkewModeField && parent.isSet(this.qualifiedSkewField)) {
-            isForceSkewModeTrue = (Boolean) parent.get(this.qualifiedSkewField);
-        }
-
         CRLP_VRollupHandler handler = initHandlerClass(parent);
 
         List<CRLP_Rollup> rollupDefs = doFinalRollup(handler, parentId);
@@ -518,10 +511,10 @@ public inherited sharing class CRLP_RollupProcessor {
         // Determine if the updated SObject record is different than the parent.
         Boolean needsUpdate = CRLP_Rollup_SVC.resultsNeedUpdate(parent, updatedRecord, rollupDefs);
 
-        // Unconditionally set force skew flag if parent is Account/Contact and running in skew mode
-        if (mode == CRLP_RollupProcessingOptions.BatchJobMode.SkewMode && this.useForceSkewModeField && !isForceSkewModeTrue) {
-            updatedRecord.put(this.qualifiedSkewField, true);
-            needsUpdate = true;
+        // Check whether skew mode threshold has been exceeded
+        initForceSkewModeValues(parent.getSObjectType());
+        if (mode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode && this.useForceSkewModeField) {
+            needsUpdate = isSkewModeNeeded(updatedRecord) || needsUpdate;
         }
 
         if (!needsUpdate) {
@@ -540,6 +533,30 @@ public inherited sharing class CRLP_RollupProcessor {
             this.qualifiedSkewField = UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c');
             this.useForceSkewModeField = (parentObjType == Account.SObjectType || parentObjType == Contact.SObjectType);
         }
+    }
+
+    private Boolean isSkewModeNeeded(SObject updatedRecord) {
+        if (isRollupFieldAtThreshold(updatedRecord)) {
+            updatedRecord.put(this.qualifiedSkewField, true);
+            return true;
+        }
+        return false;
+    }
+
+    private Boolean isRollupFieldAtThreshold(SObject summaryObject) {
+        Integer maxRelatedOppsForNonLDVMode = CRLP_Rollup_SVC.getMaxRelatedOppsForNonSkewMode();
+
+        if ((Decimal) summaryObject.get('npo02__NumberOfClosedOpps__c') >= maxRelatedOppsForNonLDVMode ||
+            (Decimal) summaryObject.get('npo02__NumberOfMembershipOpps__c') >= maxRelatedOppsForNonLDVMode) {
+            return true;
+
+        } else if (summaryObject.getSObjectType() == Contact.getSObjectType() &&
+            (Decimal) summaryObject.get(UTIL_Namespace.StrAllNSPrefix('Number_of_Soft_Credits__c'))
+                >= maxRelatedOppsForNonLDVMode) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -111,9 +111,8 @@ public inherited sharing class CRLP_RollupProcessor {
      */
     private String qualifiedSkewField;
 
-    /**
-     * @description Boolean set true if parent record should use the force skew mode field on Account & Contact
-     */
+    private SObjectType summaryObjectType;
+
     private Boolean useForceSkewModeField;
 
     /** *************************************************************************************************************
@@ -511,11 +510,8 @@ public inherited sharing class CRLP_RollupProcessor {
         // Determine if the updated SObject record is different than the parent.
         Boolean needsUpdate = CRLP_Rollup_SVC.resultsNeedUpdate(parent, updatedRecord, rollupsToCalculate);
 
-        // Check whether skew mode threshold has been exceeded
-        initForceSkewModeValues(parent.getSObjectType());
-        if (mode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode && this.useForceSkewModeField) {
-            needsUpdate = isSkewModeNeeded(updatedRecord) || needsUpdate;
-        }
+        initForceSkewModeValues(parent);
+        needsUpdate = isSkewModeNeeded(updatedRecord) || needsUpdate;
 
         if (!needsUpdate) {
             updatedRecord = null;
@@ -526,16 +522,28 @@ public inherited sharing class CRLP_RollupProcessor {
 
     /**
      * @description Set variables associated with handling force skew mode checkbox on Account and Contact
-     * @param parentObjType Base SObject type for the dynamically generated query
+     * @param parent Base SObject for the dynamically generated query
      */
-    private void initForceSkewModeValues(SObjectType parentObjType) {
+    private void initForceSkewModeValues(SObject parent) {
         if (this.qualifiedSkewField == null) {
             this.qualifiedSkewField = UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c');
-            this.useForceSkewModeField = (parentObjType == Account.SObjectType || parentObjType == Contact.SObjectType);
+            this.summaryObjectType = parent.getSObjectType();
+            this.useForceSkewModeField = (this.summaryObjectType == Account.SObjectType || this.summaryObjectType == Contact.SObjectType);
         }
     }
 
+    /**
+     * @description Determine whether skew mode is needed in the future for this job
+     * @param updatedRecord Base SObject for the dynamically generated query
+     * @return Boolean
+     */
     private Boolean isSkewModeNeeded(SObject updatedRecord) {
+        if ((this.summaryObjectType != Account.SObjectType && this.summaryObjectType != Contact.SObjectType)
+            || mode == CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
+        {
+            return false;
+        }
+
         if (isRollupFieldAtThreshold(updatedRecord)) {
             updatedRecord.put(this.qualifiedSkewField, true);
             return true;
@@ -543,6 +551,11 @@ public inherited sharing class CRLP_RollupProcessor {
         return false;
     }
 
+    /**
+     * @description Determine whether calculated rollups have arrived at threshold value.
+     * @param summaryObject Updated SObject reflecting rollup calculations
+     * @return Boolean
+     */
     private Boolean isRollupFieldAtThreshold(SObject summaryObject) {
         Integer maxRelatedOppsForNonLDVMode = CRLP_Rollup_SVC.getMaxRelatedOppsForNonSkewMode();
 
@@ -550,7 +563,7 @@ public inherited sharing class CRLP_RollupProcessor {
             (Decimal) summaryObject.get('npo02__NumberOfMembershipOpps__c') >= maxRelatedOppsForNonLDVMode) {
             return true;
 
-        } else if (summaryObject.getSObjectType() == Contact.getSObjectType() &&
+        } else if (this.summaryObjectType == Contact.SObjectType &&
             (Decimal) summaryObject.get(UTIL_Namespace.StrAllNSPrefix('Number_of_Soft_Credits__c'))
                 >= maxRelatedOppsForNonLDVMode) {
             return true;

--- a/src/classes/CRLP_RollupProcessor_TEST.cls
+++ b/src/classes/CRLP_RollupProcessor_TEST.cls
@@ -507,87 +507,135 @@ private class CRLP_RollupProcessor_TEST {
     }
 
     /**
-     * @description Verify that skew mode flag is set true when running in skew mode. Test only validates
-     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
+     * @description Verify that skew mode flag is not updated when running in skew mode.
      */
     @IsTest
-    static void shouldSetSkewModeFlagTrueWhenSkewModeFlagIsFalse() {
+    static void shouldNotSetSkewModeFlagWhenInSkewMode() {
         CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
-
-        Account account = buildMockAccount();
-        account.CustomizableRollups_UseSkewMode__c = false;
-
-        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
-                .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
-                .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
-
-        Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
-
-        System.assertEquals(true, updatedAcct.CustomizableRollups_UseSkewMode__c,
-            'CustomizableRollups_UseSkewMode__c should be set true if currently false and running in skew mode.');
-    }
-
-    /**
-     * @description Verify that skew mode flag is not updated if already set true.  Test only validates
-     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
-     */
-    @IsTest
-    static void shouldNotUpdateUpdateRecordWhenSkewModeFlagIsAlreadyTrue() {
-        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
-
-        Account account = buildMockAccount();
-        account.CustomizableRollups_UseSkewMode__c = true;
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
             .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
             .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
 
+        Account account = buildMockAccount();
         Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
 
         System.assertEquals(null, updatedAcct,
-            'Account should not be updated if CustomizableRollups_UseSkewMode__c is already true.');
+            'Account should not be updated when in skew mode.');
     }
 
-    /**
-     * @description Verify that skew mode flag is not updated if running in non skew mode.  Test only validates
-     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
-     */
     @IsTest
-    static void shouldNotSetSkewModeFlagTrueWhenInNonSkewMode() {
+    static void shouldNotSetSkewModeFlagWhenInNonSkewModeWithNoUpdate() {
         CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 1)
+        );
 
         Account account = buildMockAccount();
-        account.CustomizableRollups_UseSkewMode__c = false;
+        Contact contact = buildMockContact(account.Id);
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
             .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
-            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit);
+        Contact updatedContact = (Contact) processor.completeRollupForSingleSummaryRecord(contact);
 
-        Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
-
-        System.assertEquals(null, updatedAcct,
-            'Account should not be updated if running in non skew mode.');
+        System.assertEquals(null, updatedContact,
+            'CustomizableRollups_UseSkewMode__c should not be set if no update and under threshold.');
     }
 
-    /**
-     * @description Verify that skew mode flag is not updated if running in non skew mode.  Test only validates
-     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
-     */
     @IsTest
-    static void shouldNotSetSkewModeFlagFalseWhenInNonSkewMode() {
+    static void shouldNotSetSkewModeFlagWhenInNonSkewModeAndBelowOpportunityThreshold() {
         CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 2)
+        );
 
         Account account = buildMockAccount();
-        account.CustomizableRollups_UseSkewMode__c = true;
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
             .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
-            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
-
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit)
+            .withDetailRecords(new List<SObject>{opp});
         Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
 
-        System.assertEquals(null, updatedAcct,
-            'Account should not be updated if running in non skew mode.');
+        System.assertEquals(false, updatedAcct.CustomizableRollups_UseSkewMode__c,
+            'CustomizableRollups_UseSkewMode__c should not be set if at threshold and running in nonskew mode.');
+    }
+
+    @IsTest
+    static void shouldNotSetSkewModeFlagWhenInNonSkewModeAndBelowSoftCreditThreshold() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 2)
+        );
+
+        Account account = buildMockAccount();
+        Contact contact = buildMockContact(account.Id);
+
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
+        OpportunityContactRole ocr = buildMockContactRoles(opp, new List<Contact>{ contact })[0];
+
+        List<Partial_Soft_Credit__c> pscRecords = new List<Partial_Soft_Credit__c>{
+            buildMockPartialSoftCredit(opp, ocr, contact, opp.Amount)
+        };
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit)
+            .withDetailRecords(pscRecords);
+        Contact updatedContact = (Contact) processor.completeRollupForSingleSummaryRecord(contact);
+        System.debug(updatedContact);
+
+        System.assertEquals(false, updatedContact.CustomizableRollups_UseSkewMode__c,
+            'CustomizableRollups_UseSkewMode__c should be false if below threshold and running in nonskew mode.');
+    }
+
+    @IsTest
+    static void shoulSetSkewModeFlagWhenInNonSkewModeAndAtOpportunityThreshold() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 1)
+        );
+
+        Account account = buildMockAccount();
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit)
+            .withDetailRecords(new List<SObject>{opp});
+        Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
+
+        System.assertEquals(true, updatedAcct.CustomizableRollups_UseSkewMode__c,
+            'CustomizableRollups_UseSkewMode__c should be set if at threshold and running in nonskew mode.');
+    }
+
+    @IsTest
+    static void shouldSetSkewModeFlagWhenInNonSkewModeAndAtSoftCreditThreshold() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 1)
+        );
+
+        Account account = buildMockAccount();
+        Contact contact = buildMockContact(account.Id);
+
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
+        OpportunityContactRole ocr = buildMockContactRoles(opp, new List<Contact>{ contact })[0];
+
+        List<Partial_Soft_Credit__c> pscRecords = new List<Partial_Soft_Credit__c>{
+            buildMockPartialSoftCredit(opp, ocr, contact, opp.Amount)
+        };
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit)
+            .withDetailRecords(pscRecords);
+        Contact updatedContact = (Contact) processor.completeRollupForSingleSummaryRecord(contact);
+
+        System.assertEquals(true, updatedContact.CustomizableRollups_UseSkewMode__c,
+            'CustomizableRollups_UseSkewMode__c should be true if at threshold and running in nonskew mode.');
     }
 
     // **************************** HELPER METHODS ****************************
@@ -620,7 +668,9 @@ private class CRLP_RollupProcessor_TEST {
             Id = UTIL_UnitTestData_TEST.mockId(Account.SObjectType),
             Name = 'TestAccount',
             npo02__TotalOppAmount__c = null,
-            npo02__NumberOfClosedOpps__c = null
+            npo02__NumberOfClosedOpps__c = null,
+            npo02__NumberOfMembershipOpps__c = null,
+            CustomizableRollups_UseSkewMode__c = null
         );
     }
 
@@ -630,17 +680,25 @@ private class CRLP_RollupProcessor_TEST {
             AccountId = acctId,
             LastName = 'TestContact',
             Number_of_Soft_Credits__c = null,
-            npo02__Soft_Credit_Total__c = null
+            npo02__Soft_Credit_Total__c = null,
+            npo02__NumberOfClosedOpps__c = null,
+            npo02__NumberOfMembershipOpps__c = null,
+            CustomizableRollups_UseSkewMode__c = null
         );
+    }
+
+    private static Opportunity buildMockOpportunity(Id accountId, Double amt) {
+        return (buildMockOpportunity(accountId, null, amt));
     }
 
     /**
      * @description Instantiate a single mock Opportunity that will not be inserted
      */
-    private static Opportunity buildMockOpportunity(Id accountId, Double amt) {
+    private static Opportunity buildMockOpportunity(Id accountId, Id primaryContactId, Double amt) {
         return new Opportunity(
             Id = UTIL_UnitTestData_TEST.mockId(Opportunity.SObjectType),
             AccountId = accountId,
+            Primary_Contact__c = primaryContactId,
             Amount = amt,
             CloseDate = Date.today(),
             StageName = UTIL_UnitTestData_TEST.getClosedWonStage()


### PR DESCRIPTION
We updated our Customizable Rollup queries to use the Skew Mode flag on Account and Contact to determine whether or not to use Skew Mode for most Customizable Rollups jobs.
# Critical Changes

# Changes
 - When Force Skew Mode is selected on an Account or Contact, Customizable Rollups uses Skew Mode to roll up data for those records.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
