### PR TITLE
W-9251993 - Fixing where DI GAU allocations are placed

### DIFF
--- a/robot/Cumulus/resources/locators_51.py
+++ b/robot/Cumulus/resources/locators_51.py
@@ -98,7 +98,7 @@ npsp_lex_locators={
     'name':'//tbody/tr/th/span/a',
     'select_name':'//tbody//a[text()= "{}"]',
     'opportunities_dropdown':"css:a.slds-button.slds-button--icon-border-filled",
-    'locate_dropdown':'//tbody/tr[{}]/td/span//div/a/lightning-icon',
+    'locate_dropdown':'//tbody/tr[{}]/td/span//div/a',
     'locating_delete_dropdown':'//tbody//a[text()= "{}"]/../../following-sibling::td/span//div/a/lightning-icon',
     'related_name':'//tbody/tr/td/a[contains(@class,"forceOutputLookup")]',
     'rel_loc_dd':'//tbody/tr[{}]/td[4]//lightning-primitive-icon',

--- a/robot/Cumulus/tests/browser/gift_entry/lookup_related_fields_validation_for_payment.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/lookup_related_fields_validation_for_payment.robot
@@ -19,6 +19,7 @@ Suite Teardown  Run Keywords
 Setup Test Data
     [Documentation]       Create contact, opportunity, get current date and npsp
     ...                   generate random names for template and batch.
+    [Tags]                unstable       feature:GE
 
     &{CONTACT} =          API Create Contact       FirstName=${faker.first_name()}    LastName=${faker.last_name()}
     Set suite variable    &{CONTACT}

--- a/robot/Cumulus/tests/browser/gift_entry/verify_mapped_fields_tmpbldr.robot
+++ b/robot/Cumulus/tests/browser/gift_entry/verify_mapped_fields_tmpbldr.robot
@@ -27,7 +27,7 @@ Verify Mapped Field Is Available For Batch Template
     [Documentation]                         Create a custom field on opportunity and npsp data import objects. Create advanced mapping to these fields.
     ...                                     Verify that the mapped field is available for selection while creating a new template and once selected, its avialble on newly created batch gift form
     ...                                     Remove field from template, delete mapping and verify that the new field is not avaialable for selection while creating template.
-    [tags]                                  feature:GE                    W-039562
+    [tags]                                  unstable     feature:GE                    W-039562
     #Create field mapping
     Click Configure Advanced Mapping
     View Field Mappings Of The Object       Opportunity

--- a/src/classes/BDI_CustObjMappingGAUAllocation.cls
+++ b/src/classes/BDI_CustObjMappingGAUAllocation.cls
@@ -40,8 +40,6 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
 
     public override BDI_ObjectWrapper[] populateObjects(BDI_ObjectWrapper[] objWraps) {
 
-        Allocations_Settings__c settings = UTIL_CustomSettingsFacade.getAllocationsSettings();
-
         String PAYMENT_FIELDNAME = SObjectType.Allocation__c.fields.Payment__c.Name;
         String OPPORTUNITY_FIELDNAME = SObjectType.Allocation__c.fields.Opportunity__c.Name;
         String RECURRING_DONATION_FIELDNAME = SObjectType.Allocation__c.fields.Recurring_Donation__c.Name;
@@ -56,7 +54,6 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
                 objWrap.sObj.put('Id', objWrap.existingSObjectId);
             }
 
-            Object paymentIdValue;
             Object opportunityIdValue;
             Object recurringDonationIdValue;
 
@@ -75,7 +72,8 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
                     if (objWrap.sObj.Id == null || targetFieldDescribe.isUpdateable()) {
                         // If the target field mapping is one of the key parent objects, then extract the values for later logic
                         if (fieldMapping.Target_Field_API_Name == PAYMENT_FIELDNAME) {
-                            paymentIdValue = value;
+                            // Skip payment lookup since we will not directly link a GAU Allocation to Payment
+                            continue;
                         } else if (fieldMapping.Target_Field_API_Name == OPPORTUNITY_FIELDNAME) {
                             opportunityIdValue = value;
                         } else if (fieldMapping.Target_Field_API_Name == RECURRING_DONATION_FIELDNAME) {
@@ -88,10 +86,9 @@ public with sharing class BDI_CustObjMappingGAUAllocation extends BDI_ObjectMapp
             }
 
             // If the payment is specified and payment allocations are enabled, always use that first.
-            if ( recurringDonationIdValue != null ) {
+            if ( recurringDonationIdValue != null
+                    && objWrap.dataImport.RecurringDonationImportStatus__c == Label.bdiCreated ) {
                 objWrap.sObj.put(RECURRING_DONATION_FIELDNAME,recurringDonationIdValue);
-            } else if ( paymentIdValue != null && settings.Payment_Allocations_Enabled__c) {
-                objWrap.sObj.put(PAYMENT_FIELDNAME,paymentIdValue);
             } else if ( opportunityIdValue != null ) {
                 objWrap.sObj.put(OPPORTUNITY_FIELDNAME,opportunityIdValue);
             }

--- a/src/classes/BDI_GAUAllocationsUtil_TEST.cls
+++ b/src/classes/BDI_GAUAllocationsUtil_TEST.cls
@@ -1,6 +1,3 @@
-/**
- * Created by c.allen on 4/23/21.
- */
 /*
     Copyright (c) 2021 Salesforce.org
     All rights reserved.
@@ -163,7 +160,32 @@ public with sharing class BDI_GAUAllocationsUtil_TEST {
                         GAU_Allocation_2_Percent__c = 50,
                         GAU_Allocation_2_GAU__c = gau2.Id);
 
-        DataImport__c[] testDIs = new DataImport__c[]{testDataImportA,testDataImportB,testDataImportC};
+        // This will test mixing Default GAUs with partially allocated DI GAUs
+        DataImport__c testDataImportD =
+                new DataImport__c(
+                        Contact1_Firstname__c = 'Jake',
+                        Contact1_Home_Phone__c = '555-321-0034',
+                        Contact1_Lastname__c = 'TestGroupD01',
+                        Contact1_Other_Phone__c = '555-456-0034',
+                        Contact1_Personal_Email__c = 'testgroupDcontact01Personal@fakedata.com',
+                        Contact1_Preferred_Phone__c = '555-567-0034',
+                        Donation_Donor__c = 'Contact1',
+                        Donation_Amount__c = 100,
+                        Home_City__c = 'Fakeville',
+                        Home_Country__c = 'United States',
+                        Home_State_Province__c = 'California',
+                        Home_Street__c = '600 Faked Blvd',
+                        Home_Zip_Postal_Code__c = '94105',
+                        Household_Phone__c = '555-789-0034',
+                        Payment_Check_Reference_Number__c = '452',
+                        Payment_Method__c = 'Check',
+                        GAU_Allocation_1_Percent__c = 50,
+                        GAU_Allocation_1_GAU__c = gau1.Id);
+
+        DataImport__c[] testDIs = new DataImport__c[]{testDataImportA,
+                                                        testDataImportB,
+                                                        testDataImportC,
+                                                        testDataImportD};
         insert testDIs;
 
         Test.StartTest();
@@ -174,6 +196,7 @@ public with sharing class BDI_GAUAllocationsUtil_TEST {
         DataImport__c testDIResultA;
         DataImport__c testDIResultB;
         DataImport__c testDIResultC;
+        DataImport__c testDIResultD;
 
         for (DataImport__c di : [SELECT Id,
                 Status__c,
@@ -210,12 +233,14 @@ public with sharing class BDI_GAUAllocationsUtil_TEST {
                 NPSP_Data_Import_Batch__c,
                 Additional_Object_JSON__c
         FROM DataImport__c]) {
-            if (di.Contact1_Lastname__c == 'TestGroupA01') {
+            if (di.Id == testDataImportA.Id) {
                 testDIResultA = di;
-            } else if (di.Contact1_Lastname__c == 'TestGroupB01') {
+            } else if (di.Id == testDataImportB.Id) {
                 testDIResultB = di;
-            } else if (di.Account1_Name__c == 'TestGroupC Org 1') {
+            } else if (di.Id == testDataImportC.Id) {
                 testDIResultC = di;
+            } else if (di.Id == testDataImportD.Id) {
+                testDIResultD = di;
             }
         }
 
@@ -263,8 +288,24 @@ public with sharing class BDI_GAUAllocationsUtil_TEST {
         System.assertNotEquals(null,testDIResultC.GAU_Allocation_1_Imported__c);
         System.assertNotEquals(null,testDIResultC.GAU_Allocation_2_Imported__c);
 
+        // Test that this record was created successfully, and the partial GAU allocation was created
+        System.assertEquals(null,testDIResultD.FailureInformation__c);
+        System.assertEquals(BDI_DataImport_API.bdiImported,testDIResultD.Status__c);
+        System.assertNotEquals(null,testDIResultD.Contact1Imported__c);
+        System.assertEquals(System.label.bdiCreated,testDIResultD.Contact1ImportStatus__c);
+        System.assertEquals('Contact1',testDIResultD.Donation_Donor__c);
+        System.assertNotEquals(null,testDIResultD.DonationImported__c);
+        System.assertEquals(System.label.bdiCreated,testDIResultD.DonationImportStatus__c);
+        System.assertNotEquals(null,testDIResultD.HouseholdAccountImported__c);
+        System.assertNotEquals(null,testDIResultD.HomeAddressImported__c);
+        System.assertNotEquals(null,testDIResultD.GAU_Allocation_1_Imported__c);
+
         Allocation__c opptB1Alloc;
         Allocation__c pymtB1Alloc;
+        Allocation__c opptDgau1Alloc;
+        Allocation__c opptDgau3Alloc;
+        Allocation__c pymtDgau1Alloc;
+        Allocation__c pymtDgau3Alloc;
 
         for(Allocation__c alloc : [SELECT Id,
                 Opportunity__c,
@@ -279,11 +320,27 @@ public with sharing class BDI_GAUAllocationsUtil_TEST {
                 opptB1Alloc = alloc;
             } else if (alloc.Payment__c == testDIResultB.PaymentImported__c) {
                 pymtB1Alloc = alloc;
+            } else if (alloc.Opportunity__c == testDIResultD.DonationImported__c &&
+                    alloc.General_Accounting_Unit__c == gau1.Id) {
+                opptDgau1Alloc = alloc;
+            } else if (alloc.Opportunity__c == testDIResultD.DonationImported__c &&
+                    alloc.General_Accounting_Unit__c == gau3.Id) {
+                opptDgau3Alloc = alloc;
+            } else if (alloc.Payment__c == testDIResultD.PaymentImported__c &&
+                    alloc.General_Accounting_Unit__c == gau1.Id) {
+                pymtDgau1Alloc = alloc;
+            } else if (alloc.Payment__c == testDIResultD.PaymentImported__c &&
+                    alloc.General_Accounting_Unit__c == gau3.Id) {
+                pymtDgau3Alloc = alloc;
             }
         }
 
         System.assertNotEquals(null,opptB1Alloc);
         System.assertNotEquals(null,pymtB1Alloc);
+        System.assertNotEquals(null,opptDgau1Alloc);
+        System.assertNotEquals(null,opptDgau3Alloc);
+        System.assertNotEquals(null,pymtDgau1Alloc);
+        System.assertNotEquals(null,pymtDgau3Alloc);
         System.assertEquals(opptB1Alloc.General_Accounting_Unit__c,gau3.id);
         System.assertEquals(pymtB1Alloc.General_Accounting_Unit__c,gau3.id);
 

--- a/src/classes/BDI_ObjectWrapper.cls
+++ b/src/classes/BDI_ObjectWrapper.cls
@@ -52,7 +52,7 @@ public with sharing class BDI_ObjectWrapper {
     * @param dataImport Instance of DataImport__c 
     * @param objMapping  CMT record for object from config
     * @param fieldMappings CMT records for field mappings from config
-    * @param predessessorObjMapping CMT record of predessessor
+    * @param predecessorObjMapping CMT record of predecessor
     * @param dynamicSource if dynamic source objects are being used, this object contains the sourceSObj.
     */
     public BDI_ObjectWrapper(DataImport__c dataImport, 

--- a/src/classes/BDI_RecurringDonations_TEST.cls
+++ b/src/classes/BDI_RecurringDonations_TEST.cls
@@ -2,9 +2,6 @@
 private class BDI_RecurringDonations_TEST {
     static final String RD_STATUS_CLOSED = 'Closed';
 
-    private static final String OPTION_NAME_DISABLE_FIRST =
-            RD2_Constants.InstallmentCreateOptions.Disable_First_Installment.name();
-  
     @TestSetup
     static void setupTestData(){
 

--- a/src/classes/CRLP_RollupBatch_SVC.cls
+++ b/src/classes/CRLP_RollupBatch_SVC.cls
@@ -60,51 +60,19 @@ public class CRLP_RollupBatch_SVC {
      * @return A portion of a WHERE clause without WHERE or AND; or an empty string
      */
     public static String getSkewWhereClause(CRLP_RollupProcessingOptions.RollupType jobType, CRLP_RollupProcessingOptions.BatchJobMode jobMode,
-            String parentRelationshipField) {
+        String parentRelationshipField) {
         String queryFilter = '';
         Integer maxRelatedOppsForNonLDVMode = CRLP_Rollup_SVC.getMaxRelatedOppsForNonSkewMode();
 
-        // If the Summary Object is the Account, then filter on Accounts that have at least a single
-        // Opportunity attached. This is helpful to reduce the overall query size.
-        // To handle a scenario where an attached Opportunity was deleted, but the record not recalculated
-        // also include any records where the TotalGifts or TotalMemberships fields are not zero.
-        // If the field is null, a query with "< #" will not work. "= null" must be explicitly included in the query.
-        if (jobType == CRLP_RollupProcessingOptions.RollupType.ContactHardCredit ||
-                jobType == CRLP_RollupProcessingOptions.RollupType.AccountHardCredit) {
+        if (jobType != CRLP_RollupProcessingOptions.RollupType.GAU &&
+            jobType != CRLP_RollupProcessingOptions.RollupType.RecurringDonations
+            ) {
 
             if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '(' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c = null OR ' + parentRelationshipField +
-                    'npo02__NumberOfClosedOpps__c < ' + maxRelatedOppsForNonLDVMode + ') ' +
-                    'AND (' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c = null OR ' + parentRelationshipField +
-                    'npo02__NumberOfMembershipOpps__c < ' + maxRelatedOppsForNonLDVMode + ')';
+                queryFilter = '(' + parentRelationshipField + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = false)';
             } else {
-                queryFilter = '(' + parentRelationshipField + 'npo02__NumberOfClosedOpps__c >= ' + maxRelatedOppsForNonLDVMode +
-                        ' OR ' + parentRelationshipField + 'npo02__NumberOfMembershipOpps__c >= ' + maxRelatedOppsForNonLDVMode + ')';
+                queryFilter = '(' + parentRelationshipField + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c') + ' = true)';
             }
-
-        } else if (jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
-
-            String softCreditField = parentRelationshipField + UTIL_Namespace.StrAllNSPrefix('Number_of_Soft_Credits__c');
-            if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '(' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')';
-            } else {
-                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode + ')';
-            }
-
-        } else if (jobType == CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit ||
-            jobType == CRLP_RollupProcessingOptions.RollupType.AccountSoftCredit) {
-
-            // TODO -- How to get Accounts that require using this method for Soft Credits??
-            // For now just use the NumberOfClosedOpportunities field as a proxy for the number of SoftCredits
-            String softCreditField = parentRelationshipField + 'npo02__NumberOfClosedOpps__c';
-            if (jobMode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode) {
-                queryFilter = '(' + softCreditField + ' = null OR ' + softCreditField + ' < ' + maxRelatedOppsForNonLDVMode + ')';
-            } else {
-                queryFilter = '(' + softCreditField + ' >= ' + maxRelatedOppsForNonLDVMode + ')';
-            }
-
-        } else if (jobType == CRLP_RollupProcessingOptions.RollupType.GAU) {
-            // no extra filter on this type since we're always processing all GAU's using the skew method
 
         } else if (jobType == CRLP_RollupProcessingOptions.RollupType.RecurringDonations) {
 
@@ -131,18 +99,13 @@ public class CRLP_RollupBatch_SVC {
             jobType != CRLP_RollupProcessingOptions.RollupType.RecurringDonations)
         {
             String objName = recordId.getSobjectType().getDescribe().getName();
-            String soql = 'SELECT Id FROM ' + objName + ' WHERE Id = :recordID AND ('
-                + UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c')
-                + ' = true';
+            String soql = 'SELECT Id FROM ' + objName + ' WHERE Id = :recordID ';
             String filter = getSkewWhereClause(jobType, CRLP_RollupProcessingOptions.BatchJobMode.SkewMode);
             if (!String.isEmpty(filter)) {
-                soql += ' OR ' + filter + ')';
+                soql += ' AND ' + filter;
             }
-            else {
-                soql += ')';
-            }
-            List<SObject> cntObj = database.query(soql);
-            return cntObj.size() == 1;
+            List<SObject> rollupSummaryObjects = database.query(soql);
+            return rollupSummaryObjects.size() == 1;
         }
         return true;
     }

--- a/src/classes/CRLP_RollupBatch_TEST.cls
+++ b/src/classes/CRLP_RollupBatch_TEST.cls
@@ -42,8 +42,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c',
-            'npo02__NumberOfMembershipOpps__c', 2, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -52,8 +51,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.ContactHardCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c',
-            'npo02__NumberOfMembershipOpps__c', 2, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -62,8 +60,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c',
-            'npo02__NumberOfMembershipOpps__c', 2, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -72,8 +69,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountHardCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c',
-            'npo02__NumberOfMembershipOpps__c', 2, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -82,7 +78,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'Number_of_Soft_Credits__c', 1, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -91,7 +87,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'Number_of_Soft_Credits__c', 1, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -100,7 +96,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c', 1, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -109,7 +105,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c', 1, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -118,7 +114,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.SkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c', 1, '>=');
+        assertSkewModeBoolean(whereClause, true);
     }
 
     @IsTest
@@ -127,7 +123,7 @@ private class CRLP_RollupBatch_TEST {
             CRLP_RollupProcessingOptions.RollupType.AccountSoftCredit,
             CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode
         );
-        assertFieldsAndComparisonOperators(whereClause, 'npo02__NumberOfClosedOpps__c', 1, '<');
+        assertSkewModeBoolean(whereClause, false);
     }
 
     @IsTest
@@ -173,5 +169,14 @@ private class CRLP_RollupBatch_TEST {
         if (count > 1) {
             System.assert(whereClause.contains(apiName2), 'Expected field ' + apiName2 + ' missing from skew mode where clause');
         }
+    }
+
+    private static void assertSkewModeBoolean(String whereClause, Boolean isSkewMode)
+    {
+        final String apiName = 'CustomizableRollups_UseSkewMode__c';
+
+        System.assert(whereClause.contains(apiName), 'Expected field ' + apiName + ' missing from skew mode where clause');
+        System.assert(whereClause.contains(String.valueOf(isSkewMode)), 'Expected Boolean value ' + isSkewMode +
+            ' missing from skew mode where clause');
     }
 }

--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -111,10 +111,7 @@ public inherited sharing class CRLP_RollupProcessor {
      */
     private String qualifiedSkewField;
 
-    /**
-     * @description Boolean set true if parent record should use the force skew mode field on Account & Contact
-     */
-    private Boolean useForceSkewModeField;
+    private SObjectType summaryObjectType;
 
     /** *************************************************************************************************************
     * @description Constructor
@@ -498,16 +495,9 @@ public inherited sharing class CRLP_RollupProcessor {
         // has changed or not.
         Id parentId = parent.Id;
 
-        // Determine status of force skew mode field
-        initForceSkewModeValues(parent.getSObjectType());
-        Boolean isForceSkewModeTrue = false;
-        if (this.useForceSkewModeField && parent.isSet(this.qualifiedSkewField)) {
-            isForceSkewModeTrue = (Boolean) parent.get(this.qualifiedSkewField);
-        }
-
         CRLP_VRollupHandler handler = initHandlerClass(parent);
 
-        List<CRLP_Rollup> rollupDefs = doFinalRollup(handler, parentId);
+        List<CRLP_Rollup> rollupsToCalculate = doFinalRollup(handler, parentId);
         if (options.doSummaryObjectComparison == false) {
             return null;
         }
@@ -516,16 +506,14 @@ public inherited sharing class CRLP_RollupProcessor {
         SObject updatedRecord = handler.getPopulatedSObject();
 
         // Determine if the updated SObject record is different than the parent.
-        Boolean needsUpdate = CRLP_Rollup_SVC.resultsNeedUpdate(parent, updatedRecord, rollupDefs);
+        Boolean needsUpdate = CRLP_Rollup_SVC.resultsNeedUpdate(parent, updatedRecord, rollupsToCalculate);
 
-        // Unconditionally set force skew flag if parent is Account/Contact and running in skew mode
-        if (mode == CRLP_RollupProcessingOptions.BatchJobMode.SkewMode && this.useForceSkewModeField && !isForceSkewModeTrue) {
+        initForceSkewModeValues(parent);
+        if (isSkewModeNeeded(updatedRecord)) {
             updatedRecord.put(this.qualifiedSkewField, true);
-            needsUpdate = true;
-        }
 
-        if (!needsUpdate) {
-            updatedRecord = null;
+        } else if (!needsUpdate) {
+            return null;
         }
 
         return updatedRecord;
@@ -533,13 +521,52 @@ public inherited sharing class CRLP_RollupProcessor {
 
     /**
      * @description Set variables associated with handling force skew mode checkbox on Account and Contact
-     * @param parentObjType Base SObject type for the dynamically generated query
+     * @param parent Base SObject for the dynamically generated query
      */
-    private void initForceSkewModeValues(SObjectType parentObjType) {
+    private void initForceSkewModeValues(SObject parent) {
         if (this.qualifiedSkewField == null) {
             this.qualifiedSkewField = UTIL_Namespace.StrTokenNSPrefix('CustomizableRollups_UseSkewMode__c');
-            this.useForceSkewModeField = (parentObjType == Account.SObjectType || parentObjType == Contact.SObjectType);
+            this.summaryObjectType = parent.getSObjectType();
         }
+    }
+
+    /**
+     * @description Determine whether skew mode is needed in the future for this job
+     * @param updatedRecord Base SObject for the dynamically generated query
+     * @return Boolean
+     */
+    private Boolean isSkewModeNeeded(SObject updatedRecord) {
+        if ((this.summaryObjectType != Account.SObjectType && this.summaryObjectType != Contact.SObjectType)
+            || mode == CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
+        {
+            return false;
+        }
+
+        if (isRollupFieldAtThreshold(updatedRecord)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @description Determine whether calculated rollups have arrived at threshold value.
+     * @param summaryObject Updated SObject reflecting rollup calculations
+     * @return Boolean
+     */
+    private Boolean isRollupFieldAtThreshold(SObject summaryObject) {
+        Integer maxRelatedOppsForNonLDVMode = CRLP_Rollup_SVC.getMaxRelatedOppsForNonSkewMode();
+
+        if ((Decimal) summaryObject.get('npo02__NumberOfClosedOpps__c') >= maxRelatedOppsForNonLDVMode ||
+            (Decimal) summaryObject.get('npo02__NumberOfMembershipOpps__c') >= maxRelatedOppsForNonLDVMode) {
+            return true;
+
+        } else if (this.summaryObjectType == Contact.SObjectType &&
+            (Decimal) summaryObject.get(UTIL_Namespace.StrAllNSPrefix('Number_of_Soft_Credits__c'))
+                >= maxRelatedOppsForNonLDVMode) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/classes/CRLP_RollupProcessor.cls
+++ b/src/classes/CRLP_RollupProcessor.cls
@@ -522,11 +522,6 @@ public inherited sharing class CRLP_RollupProcessor {
         if (mode == CRLP_RollupProcessingOptions.BatchJobMode.SkewMode && this.useForceSkewModeField && !isForceSkewModeTrue) {
             updatedRecord.put(this.qualifiedSkewField, true);
             needsUpdate = true;
-
-        // Reset any flags erroneously set for NonSkewMode records
-        } else if (mode == CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode && this.useForceSkewModeField && isForceSkewModeTrue) {
-            updatedRecord.put(this.qualifiedSkewField, false);
-            needsUpdate = true;
         }
 
         if (!needsUpdate) {

--- a/src/classes/CRLP_RollupProcessor_TEST.cls
+++ b/src/classes/CRLP_RollupProcessor_TEST.cls
@@ -539,8 +539,8 @@ private class CRLP_RollupProcessor_TEST {
         account.CustomizableRollups_UseSkewMode__c = true;
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
-                .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
-                .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
 
         Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
 
@@ -560,8 +560,29 @@ private class CRLP_RollupProcessor_TEST {
         account.CustomizableRollups_UseSkewMode__c = false;
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
-                .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
-                .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
+
+        Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
+
+        System.assertEquals(null, updatedAcct,
+            'Account should not be updated if running in non skew mode.');
+    }
+
+    /**
+     * @description Verify that skew mode flag is not updated if running in non skew mode.  Test only validates
+     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
+     */
+    @IsTest
+    static void shouldNotSetSkewModeFlagFalseWhenInNonSkewMode() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+
+        Account account = buildMockAccount();
+        account.CustomizableRollups_UseSkewMode__c = true;
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
 
         Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
 

--- a/src/classes/CRLP_RollupProcessor_TEST.cls
+++ b/src/classes/CRLP_RollupProcessor_TEST.cls
@@ -507,87 +507,135 @@ private class CRLP_RollupProcessor_TEST {
     }
 
     /**
-     * @description Verify that skew mode flag is set true when running in skew mode. Test only validates
-     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
+     * @description Verify that skew mode flag is not updated when running in skew mode.
      */
     @IsTest
-    static void shouldSetSkewModeFlagTrueWhenSkewModeFlagIsFalse() {
+    static void shouldNotSetSkewModeFlagWhenInSkewMode() {
         CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
-
-        Account account = buildMockAccount();
-        account.CustomizableRollups_UseSkewMode__c = false;
-
-        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
-                .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
-                .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
-
-        Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
-
-        System.assertEquals(true, updatedAcct.CustomizableRollups_UseSkewMode__c,
-            'CustomizableRollups_UseSkewMode__c should be set true if currently false and running in skew mode.');
-    }
-
-    /**
-     * @description Verify that skew mode flag is not updated if already set true.  Test only validates
-     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
-     */
-    @IsTest
-    static void shouldNotUpdateUpdateRecordWhenSkewModeFlagIsAlreadyTrue() {
-        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
-
-        Account account = buildMockAccount();
-        account.CustomizableRollups_UseSkewMode__c = true;
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
             .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
             .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
 
+        Account account = buildMockAccount();
         Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
 
         System.assertEquals(null, updatedAcct,
-            'Account should not be updated if CustomizableRollups_UseSkewMode__c is already true.');
+            'Account should not be updated when in skew mode.');
     }
 
-    /**
-     * @description Verify that skew mode flag is not updated if running in non skew mode.  Test only validates
-     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
-     */
     @IsTest
-    static void shouldNotSetSkewModeFlagTrueWhenInNonSkewMode() {
+    static void shouldNotSetSkewModeFlagWhenInNonSkewModeWithNoUpdate() {
         CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 1)
+        );
 
         Account account = buildMockAccount();
-        account.CustomizableRollups_UseSkewMode__c = false;
+        Contact contact = buildMockContact(account.Id);
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
             .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
-            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.ContactHardCredit);
+        Contact updatedContact = (Contact) processor.completeRollupForSingleSummaryRecord(contact);
 
-        Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
-
-        System.assertEquals(null, updatedAcct,
-            'Account should not be updated if running in non skew mode.');
+        System.assertEquals(null, updatedContact,
+            'CustomizableRollups_UseSkewMode__c should not be set if no update and under threshold.');
     }
 
-    /**
-     * @description Verify that skew mode flag is not updated if running in non skew mode.  Test only validates
-     * whether CustomizableRollups_UseSkewMode__c is updated appropriately.
-     */
     @IsTest
-    static void shouldNotSetSkewModeFlagFalseWhenInNonSkewMode() {
+    static void shouldNotSetSkewModeFlagWhenInNonSkewModeAndBelowOpportunityThreshold() {
         CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 2)
+        );
 
         Account account = buildMockAccount();
-        account.CustomizableRollups_UseSkewMode__c = true;
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
 
         CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
             .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
-            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit);
-
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit)
+            .withDetailRecords(new List<SObject>{opp});
         Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
 
-        System.assertEquals(null, updatedAcct,
-            'Account should not be updated if running in non skew mode.');
+        System.assertEquals(false, updatedAcct.CustomizableRollups_UseSkewMode__c,
+            'CustomizableRollups_UseSkewMode__c should not be set if at threshold and running in nonskew mode.');
+    }
+
+    @IsTest
+    static void shouldNotSetSkewModeFlagWhenInNonSkewModeAndBelowSoftCreditThreshold() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 2)
+        );
+
+        Account account = buildMockAccount();
+        Contact contact = buildMockContact(account.Id);
+
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
+        OpportunityContactRole ocr = buildMockContactRoles(opp, new List<Contact>{ contact })[0];
+
+        List<Partial_Soft_Credit__c> pscRecords = new List<Partial_Soft_Credit__c>{
+            buildMockPartialSoftCredit(opp, ocr, contact, opp.Amount)
+        };
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit)
+            .withDetailRecords(pscRecords);
+        Contact updatedContact = (Contact) processor.completeRollupForSingleSummaryRecord(contact);
+        System.debug(updatedContact);
+
+        System.assertEquals(false, updatedContact.CustomizableRollups_UseSkewMode__c,
+            'CustomizableRollups_UseSkewMode__c should be false if below threshold and running in nonskew mode.');
+    }
+
+    @IsTest
+    static void shoulSetSkewModeFlagWhenInNonSkewModeAndAtOpportunityThreshold() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 1)
+        );
+
+        Account account = buildMockAccount();
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.AccountHardCredit)
+            .withDetailRecords(new List<SObject>{opp});
+        Account updatedAcct = (Account) processor.completeRollupForSingleSummaryRecord(account);
+
+        System.assertEquals(true, updatedAcct.CustomizableRollups_UseSkewMode__c,
+            'CustomizableRollups_UseSkewMode__c should be set if at threshold and running in nonskew mode.');
+    }
+
+    @IsTest
+    static void shouldSetSkewModeFlagWhenInNonSkewModeAndAtSoftCreditThreshold() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+        UTIL_CustomSettingsFacade.getRollupSettingsForTests(
+            new Customizable_Rollup_Settings__c(Rollups_Limit_on_Attached_Opps_for_Skew__c = 1)
+        );
+
+        Account account = buildMockAccount();
+        Contact contact = buildMockContact(account.Id);
+
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
+        OpportunityContactRole ocr = buildMockContactRoles(opp, new List<Contact>{ contact })[0];
+
+        List<Partial_Soft_Credit__c> pscRecords = new List<Partial_Soft_Credit__c>{
+            buildMockPartialSoftCredit(opp, ocr, contact, opp.Amount)
+        };
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.NonSkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit)
+            .withDetailRecords(pscRecords);
+        Contact updatedContact = (Contact) processor.completeRollupForSingleSummaryRecord(contact);
+
+        System.assertEquals(true, updatedContact.CustomizableRollups_UseSkewMode__c,
+            'CustomizableRollups_UseSkewMode__c should be true if at threshold and running in nonskew mode.');
     }
 
     // **************************** HELPER METHODS ****************************
@@ -620,7 +668,9 @@ private class CRLP_RollupProcessor_TEST {
             Id = UTIL_UnitTestData_TEST.mockId(Account.SObjectType),
             Name = 'TestAccount',
             npo02__TotalOppAmount__c = null,
-            npo02__NumberOfClosedOpps__c = null
+            npo02__NumberOfClosedOpps__c = null,
+            npo02__NumberOfMembershipOpps__c = null,
+            CustomizableRollups_UseSkewMode__c = null
         );
     }
 
@@ -630,17 +680,25 @@ private class CRLP_RollupProcessor_TEST {
             AccountId = acctId,
             LastName = 'TestContact',
             Number_of_Soft_Credits__c = null,
-            npo02__Soft_Credit_Total__c = null
+            npo02__Soft_Credit_Total__c = null,
+            npo02__NumberOfClosedOpps__c = null,
+            npo02__NumberOfMembershipOpps__c = null,
+            CustomizableRollups_UseSkewMode__c = null
         );
+    }
+
+    private static Opportunity buildMockOpportunity(Id accountId, Double amt) {
+        return (buildMockOpportunity(accountId, null, amt));
     }
 
     /**
      * @description Instantiate a single mock Opportunity that will not be inserted
      */
-    private static Opportunity buildMockOpportunity(Id accountId, Double amt) {
+    private static Opportunity buildMockOpportunity(Id accountId, Id primaryContactId, Double amt) {
         return new Opportunity(
             Id = UTIL_UnitTestData_TEST.mockId(Opportunity.SObjectType),
             AccountId = accountId,
+            Primary_Contact__c = primaryContactId,
             Amount = amt,
             CloseDate = Date.today(),
             StageName = UTIL_UnitTestData_TEST.getClosedWonStage()

--- a/src/package.xml
+++ b/src/package.xml
@@ -113,6 +113,8 @@
         <members>BDI_DynamicSourceGroup</members>
         <members>BDI_FieldMapping</members>
         <members>BDI_FieldMappingSet</members>
+        <members>BDI_GAUAllocationsUtil</members>
+        <members>BDI_GAUAllocationsUtil_TEST</members>
         <members>BDI_IMatchDonations</members>
         <members>BDI_IPostProcess</members>
         <members>BDI_ManageAdvancedMappingCtrl</members>
@@ -2077,6 +2079,9 @@
         <members>bdiErrorDonationMultiMatch</members>
         <members>bdiErrorDonationNoMatch</members>
         <members>bdiErrorDonationRequireNoMatch</members>
+        <members>bdiErrorExistingDonationAllocations</members>
+        <members>bdiErrorExistingPaymentAllocations</members>
+        <members>bdiErrorGAUAllocationOver100</members>
         <members>bdiErrorInvalidCampaignName</members>
         <members>bdiErrorInvalidDonor</members>
         <members>bdiErrorInvalidIMatchDonations</members>
@@ -3463,11 +3468,13 @@
         <members>Data_Import_Field_Mapping.GAU_Allocation_1_Opportunity</members>
         <members>Data_Import_Field_Mapping.GAU_Allocation_1_Payment</members>
         <members>Data_Import_Field_Mapping.GAU_Allocation_1_Percent</members>
+        <members>Data_Import_Field_Mapping.GAU_Allocation_1_Recurring_Donation</members>
         <members>Data_Import_Field_Mapping.GAU_Allocation_2_Amount</members>
         <members>Data_Import_Field_Mapping.GAU_Allocation_2_GAU</members>
         <members>Data_Import_Field_Mapping.GAU_Allocation_2_Opportunity</members>
         <members>Data_Import_Field_Mapping.GAU_Allocation_2_Payment</members>
         <members>Data_Import_Field_Mapping.GAU_Allocation_2_Percent</members>
+        <members>Data_Import_Field_Mapping.GAU_Allocation_2_Recurring_Donation</members>
         <members>Data_Import_Field_Mapping.Home_City</members>
         <members>Data_Import_Field_Mapping.Home_Country</members>
         <members>Data_Import_Field_Mapping.Home_State_Province</members>


### PR DESCRIPTION
- Previously we attached DI GAU Allocations to the payment level if payment allocations were enabled since we relied on two-way sync to populate the GAU allocations on the Donation level.  Now that we are using Allo_AllocationsService it is no longer necessary, and the DI GAU allocations should be attached to either Donation or Recurring donation depending on which is present.
- Added a unit test to specifically test that partial GAU allocations will be correctly handled with the new logic.
- Also cleaned up a few typos and other things I spotted.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
