### PR TITLE
Block user edit of Default GAU row on allocation widget

### DIFF
--- a/src/lwc/geFormService/geFormService.js
+++ b/src/lwc/geFormService/geFormService.js
@@ -142,12 +142,13 @@ class GeFormService {
                     return element.dataImportFieldMappingDevNames.includes(mappingDevName);
                 }
             });
+            if (isNotEmpty(fieldElement)) {
+                // return custom label from the form template layout
+                return fieldElement.customLabel;
+            } 
         }
 
-        if (isNotEmpty(fieldElement)) {
-            // return custom label from the form template layout
-            return fieldElement.customLabel;
-        }
+        return OPPORTUNITY_AMOUNT.fieldApiName;        
     }
 
     getFormRenderWrapper(templateId) {

--- a/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
+++ b/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
@@ -1,10 +1,9 @@
-import {LightningElement, api, track, wire} from 'lwc';
+import {LightningElement, api, track} from 'lwc';
 import {
     isNumeric,
     isNotEmpty,
     isEmpty,
-    isEmptyObject,
-    apiNameFor, debouncify
+    apiNameFor
 } from 'c/utilCommon';
 
 import GeFormService from 'c/geFormService';

--- a/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
+++ b/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
@@ -51,7 +51,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
     }
 
     init = async () => {
-        if(!this.allocationSettings) {
+        if (!this.allocationSettings) {
             this.allocationSettings = await GeFormService.getAllocationSettings();
         }
         if (this.hasDefaultGAU) {
@@ -90,6 +90,10 @@ export default class GeFormWidgetAllocation extends LightningElement {
         this.validate();
     }
 
+    hasAllocations() {
+        return Array.isArray(this.rowList) && this.rowList.length > 0;
+    }
+
     get totalAmount() {
         return this._totalAmount;
     }
@@ -101,7 +105,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
 
     }
     get remainingAmount() {
-        if(isNumeric(this.totalAmount) && isNumeric(this.allocatedAmount)) {
+        if (isNumeric(this.totalAmount) && isNumeric(this.allocatedAmount)) {
             const remainingCents = Math.round(this.totalAmount * 100) - Math.round(this.allocatedAmount * 100);
             // avoid floating point errors by subtracting whole numbers
             return (remainingCents / 100);
@@ -110,12 +114,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
     }
 
     get hasRemainingAmount() {
-        return this.allocationSettings[ALLOC_SETTINGS_DEFAULT_ALLOCATIONS_ENABLED] &&
-            this.remainingAmount >= 0;
-    }
-
-    hasAllocations() {
-        return Array.isArray(this.rowList) && this.rowList.length > 0;
+        return this.hasDefaultGAU && this.remainingAmount >= 0;
     }
 
     get showRemainingAmount() {
@@ -135,7 +134,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
         return this.rowList
             .filter(row => {
                 const defaultGAUId = this.allocationSettings[ALLOC_SETTINGS_DEFAULT];
-                if(isNotEmpty(defaultGAUId)) {
+                if (this.hasDefaultGAU && isNotEmpty(defaultGAUId)) {
                     return row.record[GENERAL_ACCOUNT_UNIT] !== defaultGAUId;
                 }
 
@@ -149,7 +148,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
                     currentAmount = (currentPercent * this.totalAmount) / 100;
                 }
 
-                if(isNumeric(currentAmount)) {
+                if (isNumeric(currentAmount)) {
                     // prefix + to ensure operand is treated as a number
                     return currentAmount + accumulator;
                 }
@@ -172,7 +171,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
         element.key = this.rowList.length;
         const record = { ...rowRecord };
         let row = {};
-        if(isDefaultGAU === true) {
+        if (isDefaultGAU === true) {
             // default GAU should be locked.
             row.isDefaultGAU = true;
             row.disabled = true;
@@ -197,7 +196,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
 
     reset() {
         this.rowList = [];
-        if(this.hasDefaultGAU) {
+        if (this.hasDefaultGAU) {
             this.addRow(true);
         }
     }
@@ -244,14 +243,14 @@ export default class GeFormWidgetAllocation extends LightningElement {
             this.CUSTOM_LABELS.geErrorAmountDoesNotMatch,
             [this.donationAmountCustomLabel]);
 
-        if(this.isUnderAllocated) {
+        if (this.isUnderAllocated) {
             // if no default GAU and under-allocated, display warning
             this.alertBanner = {
                 message,
                 level: 'warning'
             };
             return false;
-        } else if(this.isOverAllocated) {
+        } else if (this.isOverAllocated) {
             // if over-allocated, display error
             this.alertBanner = {
                 message,
@@ -275,7 +274,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
     }
 
     get alertIcon() {
-        if(isNotEmpty(this.alertBanner.level)) {
+        if (isNotEmpty(this.alertBanner.level)) {
             const warningIcon = 'utility:warning';
             const errorIcon = 'utility:error';
             switch(this.alertBanner.level) {
@@ -290,7 +289,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
     }
 
     get alertClass() {
-        if(isNotEmpty(this.alertBanner.level)) {
+        if (isNotEmpty(this.alertBanner.level)) {
             const errorClass = 'error';
             const warningClass = 'warning';
 

--- a/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
+++ b/src/lwc/geFormWidgetAllocation/geFormWidgetAllocation.js
@@ -87,6 +87,7 @@ export default class GeFormWidgetAllocation extends LightningElement {
             })
         });
         this.addRows(rowList);
+        this.validate();
     }
 
     get totalAmount() {

--- a/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.html
+++ b/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.html
@@ -1,29 +1,30 @@
 <template>
     <lightning-layout>
-        <lightning-layout-item size="9">
+        <lightning-layout-item size="12">
                 <lightning-record-edit-form object-api-name={allocationObjectApiName}>
-                    <div class="slds-grid">
-                        <div class="slds-col slds-size_1-of-3">
+                    <div class="slds-grid slds-grid_vertical-align-end">
+                        <div class="slds-p-horizontal_small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
                             <lightning-input-field field-name={gauFieldApiName}
                                                    data-fieldname={gauFieldApiName}
                                                    required='true'
                                                    onchange={handleFieldValueChange}
                                                    value={gauValue}
-                                                   class="help-text-hidden"
-                                                   data-qa-locator={qaLocatorGAU}>
+                                                   class="help-text-hidden slds-m-bottom_none"
+                                                   data-qa-locator={qaLocatorGAU}
+                                                   disabled={shouldDisableGAULookup}>
                             </lightning-input-field>
                         </div>
-                        <div class="slds-col slds-size_1-of-3">
+                        <div class="slds-p-horizontal_small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
                             <lightning-input-field field-name={allocationAmountFieldApiName}
                                                    data-fieldname={allocationAmountFieldApiName}
                                                    onchange={handleFieldValueChange}
                                                    value={amountValue}
-                                                   class="help-text-hidden"
+                                                   class="help-text-hidden slds-m-bottom_none"
                                                    data-qa-locator={qaLocatorAllocationAmount}
                                                    disabled={shouldDisableAmount}>
                             </lightning-input-field>
                         </div>
-                        <div class="slds-col slds-size_1-of-3">
+                        <div class="slds-p-horizontal_small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
                             <lightning-input label={percentCustomLabel}
                                              data-fieldname={allocationPercentageFieldApiName}
                                              type='number'
@@ -31,21 +32,24 @@
                                              step='0.01'
                                              onchange={handleFieldValueChange}
                                              value={percentValue}
-                                             disabled={shouldDisablePercent}
-                                             data-qa-locator={qaLocatorAllocationPercent}>
+                                             data-qa-locator={qaLocatorAllocationPercent}
+                                             disabled={shouldDisablePercent}>
                             </lightning-input>
+                        </div>
+                        <div class="slds-p-horizontal_small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
+                            <template if:true={isRemovable}>
+                                <lightning-button variant='destructive'
+                                                  onclick={remove}
+                                                  label={CUSTOM_LABELS.commonDelete}
+                                                  data-qa-locator={qaLocatorDeleteRow}>
+                                </lightning-button>
+                            </template>
                         </div>
                     </div>
                 </lightning-record-edit-form>
         </lightning-layout-item>
         <lightning-layout-item size="3" class="slds-p-vertical_large slds-p-left_xx-small">
-            <span if:true={isRemovable}>
-                <lightning-button variant='destructive'
-                                  onclick={remove}
-                                  label={CUSTOM_LABELS.commonDelete}
-                                  data-qa-locator={qaLocatorDeleteRow}>
-                </lightning-button>
-            </span>
+
         </lightning-layout-item>
     </lightning-layout>
 </template>

--- a/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.html
+++ b/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.html
@@ -3,7 +3,7 @@
         <lightning-layout-item size="12">
                 <lightning-record-edit-form object-api-name={allocationObjectApiName}>
                     <div class="slds-grid slds-grid_vertical-align-end">
-                        <div class="slds-p-horizontal_small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
+                        <div class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
                             <lightning-input-field field-name={gauFieldApiName}
                                                    data-fieldname={gauFieldApiName}
                                                    required='true'
@@ -14,7 +14,7 @@
                                                    disabled={shouldDisableGAULookup}>
                             </lightning-input-field>
                         </div>
-                        <div class="slds-p-horizontal_small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
+                        <div class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
                             <lightning-input-field field-name={allocationAmountFieldApiName}
                                                    data-fieldname={allocationAmountFieldApiName}
                                                    onchange={handleFieldValueChange}
@@ -24,7 +24,7 @@
                                                    disabled={shouldDisableAmount}>
                             </lightning-input-field>
                         </div>
-                        <div class="slds-p-horizontal_small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
+                        <div class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
                             <lightning-input label={percentCustomLabel}
                                              data-fieldname={allocationPercentageFieldApiName}
                                              type='number'
@@ -36,7 +36,7 @@
                                              disabled={shouldDisablePercent}>
                             </lightning-input>
                         </div>
-                        <div class="slds-p-horizontal_small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
+                        <div class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-col slds-size_3-of-12">
                             <template if:true={isRemovable}>
                                 <lightning-button variant='destructive'
                                                   onclick={remove}

--- a/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.js
+++ b/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.js
@@ -1,5 +1,4 @@
 import {LightningElement, api, track} from 'lwc';
-import {fireEvent} from 'c/pubsubNoPageRef';
 import GeLabelService from 'c/geLabelService';
 import {
     apiNameFor,

--- a/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.js
+++ b/src/lwc/geFormWidgetRowAllocation/geFormWidgetRowAllocation.js
@@ -28,7 +28,7 @@ export default class GeFormWidgetRowAllocation extends LightningElement {
         return this._remainingAmount;
     }
     set remainingAmount(value) {
-        if (value === this._remainingAmount || value === 0 || isEmpty(value)) {
+        if (value === this._remainingAmount || isEmpty(value)) {
             return;
         }
 
@@ -156,18 +156,25 @@ export default class GeFormWidgetRowAllocation extends LightningElement {
     }
 
     get shouldDisablePercent() {
-        if (isEmpty(this.row.record[apiNameFor(PERCENT_FIELD)]) &&
-            Number.parseFloat(this.row.record[apiNameFor(AMOUNT_FIELD)]) > 0) {
+        if (this.row.disabled 
+            || (isEmpty(this.row.record[apiNameFor(PERCENT_FIELD)])
+                && Number.parseFloat(this.row.record[apiNameFor(AMOUNT_FIELD)]) > 0)) {
             return true;
         }
     }
+
     get shouldDisableAmount() {
-        if (!isEmpty(this.row.record[apiNameFor(PERCENT_FIELD)]) &&
-            Number.parseFloat(this.row.record[apiNameFor(PERCENT_FIELD)]) > 0) {
+        if (this.row.disabled 
+            || (!isEmpty(this.row.record[apiNameFor(PERCENT_FIELD)])
+                && Number.parseFloat(this.row.record[apiNameFor(PERCENT_FIELD)]) > 0)) {
 
             return true;
         }
     }
+
+    get shouldDisableGAULookup() {
+        return this.row.disabled;
+    }    
 
     get qaLocatorDeleteRow() {
         return `button ${this.CUSTOM_LABELS.commonDelete} ${this.rowIndex}`;


### PR DESCRIPTION
This resolves an issue with the GAU Allocations Field Bundle on the gift entry form that presents when the Default GAU is set in NPSP settings, where the user was allowed to incorrectly modify and replace the default GAU allocation. Following this change the default GAU row will be read-only in the allocations field bundle.

# Critical Changes

# Changes

# Issues Closed
Fixes #6480
Fixes #6385
Fixes #5824
Fixes #6066 

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
