### PR TITLE
Gift Entry - Script Error on Gift Save Fix

### DIFF
--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -135,6 +135,10 @@ const DONATION_DONOR_TYPE_ENUM = Object.freeze({
     CONTACT1: 'Contact1'
 });
 
+const FORM_STATE_IMMUTABLE_FIELDS_BY_APINAME = [
+    NPSP_DATA_IMPORT_BATCH_FIELD.fieldApiName
+];
+
 const ACH_CONSENT_MESSAGE = 'true';
 const EXPANDABLE_SECTION_CONTAINER = 'expandableSectionContainer';
 
@@ -1693,6 +1697,8 @@ export default class GeFormRenderer extends LightningElement{
      * @param fields An object with key-value pairs.
      */
     updateFormState(fields) {
+        fields = this.removeFieldsNotUpdatableInFormState(fields);
+
         Object.assign(this.formState, fields);
         if (fields.hasOwnProperty(apiNameFor(DONATION_RECORD_TYPE_NAME))) {
             this.updateFormStateForDonationRecordType(fields);
@@ -1704,6 +1710,20 @@ export default class GeFormRenderer extends LightningElement{
 
         // Shallow-copy to a new object to prompt reactivity
         this.formState = Object.assign({}, this.formState);
+    }
+
+    removeFieldsNotUpdatableInFormState(fieldsToUpdate) {
+        FORM_STATE_IMMUTABLE_FIELDS_BY_APINAME.forEach(immutableField => {
+            if (this.isFormStateFieldNotUpdatable(fieldsToUpdate, immutableField)) {
+                delete fieldsToUpdate[immutableField];
+            }
+        });
+
+        return fieldsToUpdate;
+    }
+
+    isFormStateFieldNotUpdatable(fields, field) {
+        return fields.hasOwnProperty(field) && this.formState[field];
     }
 
     updateFormStateFromMap(fieldReferenceToValueMap) {

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -135,7 +135,7 @@ const DONATION_DONOR_TYPE_ENUM = Object.freeze({
     CONTACT1: 'Contact1'
 });
 
-const FORM_STATE_IMMUTABLE_FIELDS_BY_API_NAME = [
+const FORM_STATE_IMMUTABLE_FIELDS_API_NAMES = [
     NPSP_DATA_IMPORT_BATCH_FIELD.fieldApiName
 ];
 
@@ -1713,7 +1713,7 @@ export default class GeFormRenderer extends LightningElement{
     }
 
     removeFieldsNotUpdatableInFormState(fieldsToUpdate) {
-        FORM_STATE_IMMUTABLE_FIELDS_BY_API_NAME.forEach(immutableField => {
+        FORM_STATE_IMMUTABLE_FIELDS_API_NAMES.forEach(immutableField => {
             if (this.isFormStateFieldNotUpdatable(fieldsToUpdate, immutableField)) {
                 delete fieldsToUpdate[immutableField];
             }

--- a/src/lwc/geFormRenderer/geFormRenderer.js
+++ b/src/lwc/geFormRenderer/geFormRenderer.js
@@ -135,7 +135,7 @@ const DONATION_DONOR_TYPE_ENUM = Object.freeze({
     CONTACT1: 'Contact1'
 });
 
-const FORM_STATE_IMMUTABLE_FIELDS_BY_APINAME = [
+const FORM_STATE_IMMUTABLE_FIELDS_BY_API_NAME = [
     NPSP_DATA_IMPORT_BATCH_FIELD.fieldApiName
 ];
 
@@ -1713,7 +1713,7 @@ export default class GeFormRenderer extends LightningElement{
     }
 
     removeFieldsNotUpdatableInFormState(fieldsToUpdate) {
-        FORM_STATE_IMMUTABLE_FIELDS_BY_APINAME.forEach(immutableField => {
+        FORM_STATE_IMMUTABLE_FIELDS_BY_API_NAME.forEach(immutableField => {
             if (this.isFormStateFieldNotUpdatable(fieldsToUpdate, immutableField)) {
                 delete fieldsToUpdate[immutableField];
             }


### PR DESCRIPTION
# Critical Changes

Issue

When a customer reviews potential matching donations for a Contact or Account using the Review Donations Modal in Gift Entry and they click either the Add New Payment or Update this Opportunity link, the transaction fails and the customer sees a "Script-Thrown Exception" error.

Github Issue: #6221

Resolution

There are certain fields within form state that we should only expect to be set once, likely when a gift (new or existing) is initially loaded in geFormRenderer. In fact, we can get into trouble when these fields are changed during the lifecycle of a gift edit.

In our case here (based on the details provided above), the lookup field that lives on the Data Import record and looks up to the Data Import Batch record gets cleared out after a user runs through the “Review Donations” process. We can address this by introducing the notion of immutability to Form State.

Certain fields should only be set ONCE in form state (when creating or editing a gift) and we can build out functionality to block any subsequent update to that field. At the same time, we’ll make sure that this field value can be reset when form state is initialized/re-initialized.

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
