### PR TITLE
Hotfix: Contact Naming Exclusions not being synced before update

### DIFF
--- a/src/classes/Contacts.cls
+++ b/src/classes/Contacts.cls
@@ -59,7 +59,7 @@ public inherited sharing class Contacts extends fflib_SObjects {
     }
 
     public void onBeforeInsert() {
-        synchronizeNamingExclusions();
+        syncNamingExclusionsBeforeInsert();
     }
 
     /**
@@ -107,7 +107,7 @@ public inherited sharing class Contacts extends fflib_SObjects {
     }
 
     public void onBeforeUpdate() {
-        applyExclusionsStringChangesToCheckboxes();
+        syncNamingExclusionsBeforeUpdate();
     }
 
     /**
@@ -643,15 +643,43 @@ public inherited sharing class Contacts extends fflib_SObjects {
         return new Contacts(consInHouseholds);
     }
 
-    private void applyExclusionsStringChangesToCheckboxes() {
+    private void syncNamingExclusionsBeforeInsert() {
         for (Contact con : (List<Contact>) getRecords()) {
             HouseholdNamingExclusionsString namingExclusionsString =
                     new HouseholdNamingExclusionsString(con);
-            HouseholdNamingExclusionsString oldNamingExclusionsString =
-                    new HouseholdNamingExclusionsString(oldVersionOf(con));
-            if (!namingExclusionsString.equals(oldNamingExclusionsString)) {
-                HouseholdNamingExclusionsCheckboxes exclusionsAsCheckboxes = new HouseholdNamingExclusionsCheckboxes(con);
+
+            HouseholdNamingExclusionsCheckboxes exclusionsAsCheckboxes =
+                    new HouseholdNamingExclusionsCheckboxes(con);
+
+            if (namingExclusionsString.hasNamingExclusions()) {
                 exclusionsAsCheckboxes.updateFrom(namingExclusionsString);
+                setExclusionsCheckboxes(con, exclusionsAsCheckboxes);
+            }
+
+            if (exclusionsAsCheckboxes.hasNamingExclusions()) {
+                namingExclusionsString.synchronizeFrom(exclusionsAsCheckboxes);
+                setExclusionsStringFor(con, namingExclusionsString.value());
+            }
+        }
+    }
+
+    private void syncNamingExclusionsBeforeUpdate() {
+        for (Contact con : (List<Contact>) getRecords()) {
+            HouseholdNamingExclusionsCheckboxes exclusionsAsCheckboxes =
+                    new HouseholdNamingExclusionsCheckboxes(con);
+            HouseholdNamingExclusionsCheckboxes oldExclusionsAsCheckboxes =
+                    new HouseholdNamingExclusionsCheckboxes(oldVersionOf(con));
+            HouseholdNamingExclusionsString householdNamingExclusionsString =
+                    new HouseholdNamingExclusionsString(con);
+            HouseholdNamingExclusionsString oldHouseholdNamingExclusionsString =
+                    new HouseholdNamingExclusionsString(oldVersionOf(con));
+
+            if (!exclusionsAsCheckboxes.equals(oldExclusionsAsCheckboxes)) {
+                householdNamingExclusionsString.synchronizeFrom(exclusionsAsCheckboxes);
+                setExclusionsStringFor(con, householdNamingExclusionsString.value());
+            } else if (!householdNamingExclusionsString.equals
+                    (oldHouseholdNamingExclusionsString)) {
+                exclusionsAsCheckboxes.synchronizeFrom(householdNamingExclusionsString);
                 setExclusionsCheckboxes(con, exclusionsAsCheckboxes);
             }
         }

--- a/src/classes/Contacts.cls
+++ b/src/classes/Contacts.cls
@@ -679,7 +679,7 @@ public inherited sharing class Contacts extends fflib_SObjects {
                 setExclusionsStringFor(con, householdNamingExclusionsString.value());
             } else if (!householdNamingExclusionsString.equals
                     (oldHouseholdNamingExclusionsString)) {
-                exclusionsAsCheckboxes.synchronizeFrom(householdNamingExclusionsString);
+                exclusionsAsCheckboxes.updateFrom(householdNamingExclusionsString);
                 setExclusionsCheckboxes(con, exclusionsAsCheckboxes);
             }
         }

--- a/src/classes/HouseholdNamingExclusions_TEST.cls
+++ b/src/classes/HouseholdNamingExclusions_TEST.cls
@@ -1,0 +1,44 @@
+@IsTest
+private class HouseholdNamingExclusions_TEST {
+
+    @IsTest
+    static void checkboxesShouldSyncToStringBeforeInsert() {
+        Contact c = new Contact(
+                LastName='test',
+                Exclude_from_Household_Name__c = true
+        );
+
+        Contacts contacts = new Contacts(new List<Contact>{c});
+        contacts.onBeforeInsert();
+        
+        HouseholdNamingExclusionsString householdNamingExclusionsString =
+                new HouseholdNamingExclusionsString(c);
+        System.assertEquals(true, householdNamingExclusionsString.isExcludedFromName(),
+                'The Household Naming Exclusions String should be synced with the' +
+                        'Exclusion Checkboxes on Contact insert.');
+    }
+
+    @IsTest
+    static void checkboxesShouldSyncToStringBeforeUpdate() {
+        Id id = UTIL_UnitTestData_TEST.mockId(Contact.SObjectType);
+        Contact c = new Contact(
+                Id = id,
+                LastName='test',
+                Exclude_from_Household_Name__c = true
+        );
+
+        Contact oldContact = new Contact(
+                Id = id,
+                LastName='test'
+        );
+        Contacts contacts = new Contacts(new List<Contact>{c}, new List<Contact>{oldContact});
+        contacts.onBeforeUpdate();
+
+        HouseholdNamingExclusionsString householdNamingExclusionsString =
+                new HouseholdNamingExclusionsString(c);
+        System.assertEquals(true, householdNamingExclusionsString.isExcludedFromName(),
+                'The Household Naming Exclusions String should be synced with the ' +
+                        'Exclusion Checkboxes on Contact update.');
+    }
+
+}

--- a/src/classes/HouseholdNamingExclusions_TEST.cls
+++ b/src/classes/HouseholdNamingExclusions_TEST.cls
@@ -1,21 +1,82 @@
+/*
+    Copyright (c) 2021 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2021
+* @description Tests for the synchronization of Household Naming Exclusions on Contacts.
+*/
 @IsTest
 private class HouseholdNamingExclusions_TEST {
 
     @IsTest
     static void checkboxesShouldSyncToStringBeforeInsert() {
         Contact c = new Contact(
-                LastName='test',
-                Exclude_from_Household_Name__c = true
+                LastName = 'test',
+                Exclude_from_Household_Name__c = true,
+                Exclude_from_Household_Formal_Greeting__c = true
         );
 
-        Contacts contacts = new Contacts(new List<Contact>{c});
+        Contacts contacts = new Contacts(new List<Contact>{
+                c
+        });
         contacts.onBeforeInsert();
-        
+
         HouseholdNamingExclusionsString householdNamingExclusionsString =
                 new HouseholdNamingExclusionsString(c);
         System.assertEquals(true, householdNamingExclusionsString.isExcludedFromName(),
-                'The Household Naming Exclusions String should be synced with the' +
-                        'Exclusion Checkboxes on Contact insert.');
+                'The Household Naming Exclusions string should be synced with the ' +
+                        'Naming Exclusion checkboxes on Contact insert.');
+    }
+
+    @IsTest
+    static void multipleCheckboxesShouldSyncToStringBeforeInsert() {
+        String assertMsg = 'The Household Naming Exclusions string should be synced with the ' +
+                'Naming Exclusion checkboxes on Contact insert.';
+
+        Contact c = new Contact(
+                LastName = 'test',
+                Exclude_from_Household_Name__c = true,
+                Exclude_from_Household_Formal_Greeting__c = true
+        );
+
+        Contacts contacts = new Contacts(new List<Contact>{
+                c
+        });
+        contacts.onBeforeInsert();
+
+        HouseholdNamingExclusionsString householdNamingExclusionsString =
+                new HouseholdNamingExclusionsString(c);
+        System.assertEquals(true, householdNamingExclusionsString.isExcludedFromName(),
+                assertMsg);
+        System.assertEquals(true, householdNamingExclusionsString.isExcludedFromFormalGreeting(),
+                assertMsg);
     }
 
     @IsTest
@@ -23,22 +84,146 @@ private class HouseholdNamingExclusions_TEST {
         Id id = UTIL_UnitTestData_TEST.mockId(Contact.SObjectType);
         Contact c = new Contact(
                 Id = id,
-                LastName='test',
+                LastName = 'test',
                 Exclude_from_Household_Name__c = true
         );
 
         Contact oldContact = new Contact(
                 Id = id,
-                LastName='test'
+                LastName = 'test'
         );
-        Contacts contacts = new Contacts(new List<Contact>{c}, new List<Contact>{oldContact});
+        Contacts contacts = new Contacts(new List<Contact>{
+                c
+        }, new List<Contact>{
+                oldContact
+        });
         contacts.onBeforeUpdate();
 
         HouseholdNamingExclusionsString householdNamingExclusionsString =
                 new HouseholdNamingExclusionsString(c);
         System.assertEquals(true, householdNamingExclusionsString.isExcludedFromName(),
-                'The Household Naming Exclusions String should be synced with the ' +
-                        'Exclusion Checkboxes on Contact update.');
+                'The Household Naming Exclusions string should be synced with the ' +
+                        'Naming Exclusion checkboxes on Contact update.');
     }
 
+    @IsTest
+    static void stringShouldSyncToCheckboxesBeforeInsert() {
+        Contact c = new Contact(
+                LastName = 'test',
+                npo02__Naming_Exclusions__c = 'Household__c.Name'
+        );
+
+        Contacts contacts = new Contacts(new List<Contact>{
+                c
+        });
+        contacts.onBeforeInsert();
+
+        HouseholdNamingExclusionsCheckboxes exclusionsCheckboxes =
+                new HouseholdNamingExclusionsCheckboxes(c);
+        System.assertEquals(true, exclusionsCheckboxes.isExcludedFromName(),
+                'The Household Naming Exclusions checkboxes should be synced with the' +
+                        'Naming Exclusions string on Contact insert.');
+    }
+
+    @IsTest
+    static void stringShouldSyncToCheckboxesBeforeUpdate() {
+        Id id = UTIL_UnitTestData_TEST.mockId(Contact.SObjectType);
+        Contact c = new Contact(
+                Id = id,
+                LastName = 'test',
+                npo02__Naming_Exclusions__c = 'Household__c.Name'
+        );
+
+        Contact oldContact = new Contact(
+                Id = id,
+                LastName = 'test'
+        );
+        Contacts contacts = new Contacts(new List<Contact>{
+                c
+        }, new List<Contact>{
+                oldContact
+        });
+        contacts.onBeforeUpdate();
+
+        HouseholdNamingExclusionsCheckboxes exclusionsCheckboxes =
+                new HouseholdNamingExclusionsCheckboxes(c);
+        System.assertEquals(true, exclusionsCheckboxes.isExcludedFromName(),
+                'The Household Naming Exclusions checkboxes should be synced with the' +
+                        'Naming Exclusions string on Contact update.');
+    }
+
+    @IsTest
+    static void prefersCheckboxesWhenBothStringAndCheckboxAreUpdated() {
+        String assertMsg = 'The Household Naming Exclusions checkboxes should be ' +
+                'honored when both the string and the checkboxes change.';
+
+        Id id = UTIL_UnitTestData_TEST.mockId(Contact.SObjectType);
+        Contact c = new Contact(
+                Id = id,
+                LastName = 'test',
+                npo02__Naming_Exclusions__c = 'Household__c.Name',
+                Exclude_from_Household_Informal_Greeting__c = true
+        );
+
+        Contact oldContact = new Contact(
+                Id = id,
+                LastName = 'test'
+        );
+        Contacts contacts = new Contacts(new List<Contact>{
+                c
+        }, new List<Contact>{
+                oldContact
+        });
+        contacts.onBeforeUpdate();
+
+        HouseholdNamingExclusionsCheckboxes exclusionsCheckboxes =
+                new HouseholdNamingExclusionsCheckboxes(c);
+        System.assertEquals(false, exclusionsCheckboxes.isExcludedFromName(),
+                assertMsg);
+        System.assertEquals(true, exclusionsCheckboxes.isExcludedFromInformalGreeting(),
+                assertMsg);
+
+        HouseholdNamingExclusionsString exclusionsString = new
+                HouseholdNamingExclusionsString(c);
+        System.assertEquals(false, exclusionsString.isExcludedFromName(),
+                assertMsg);
+        System.assertEquals(true, exclusionsString.isExcludedFromInformalGreeting(),
+                assertMsg);
+    }
+
+    @IsTest
+    static void prefersStringWhenBothStringAndCheckboxesAreInserted() {
+        String assertMsg = 'The Household Naming Exclusions string should be ' +
+                'honored when both the string and the checkboxes are populated on insert.';
+
+        Contact c = new Contact(
+                LastName = 'test',
+                npo02__Naming_Exclusions__c =
+                        'Household__c.Name;Household__c.Informal_Greeting__c',
+                Exclude_from_Household_Formal_Greeting__c = true
+        );
+
+        Contacts contacts = new Contacts(new List<Contact>{
+                c
+        });
+        contacts.onBeforeInsert();
+
+        HouseholdNamingExclusionsCheckboxes exclusionsCheckboxes =
+                new HouseholdNamingExclusionsCheckboxes(c);
+        System.assertEquals(true, exclusionsCheckboxes.isExcludedFromName(),
+                assertMsg);
+        System.assertEquals(true, exclusionsCheckboxes.isExcludedFromInformalGreeting(),
+                assertMsg);
+        System.assertEquals(false, exclusionsCheckboxes.isExcludedFromFormalGreeting(),
+                assertMsg);
+
+        HouseholdNamingExclusionsString exclusionsString = new
+                HouseholdNamingExclusionsString(c);
+        System.assertEquals(true, exclusionsString.isExcludedFromName(),
+                assertMsg);
+        System.assertEquals(true, exclusionsString.isExcludedFromInformalGreeting(),
+                assertMsg);
+        System.assertEquals(false, exclusionsString.isExcludedFromFormalGreeting(),
+                assertMsg);
+    }
 }

--- a/src/classes/HouseholdNamingExclusions_TEST.cls
+++ b/src/classes/HouseholdNamingExclusions_TEST.cls
@@ -126,17 +126,56 @@ private class HouseholdNamingExclusions_TEST {
     }
 
     @IsTest
-    static void stringShouldSyncToCheckboxesBeforeUpdate() {
+    static void checkboxChangesOverwriteStringBeforeUpdate() {
         Id id = UTIL_UnitTestData_TEST.mockId(Contact.SObjectType);
         Contact c = new Contact(
+                Id = id,
+                LastName = 'test',
+                Exclude_from_Household_Formal_Greeting__c = true
+        );
+
+        Contact oldContact = new Contact(
                 Id = id,
                 LastName = 'test',
                 npo02__Naming_Exclusions__c = 'Household__c.Name'
         );
 
+        Contacts contacts = new Contacts(new List<Contact>{
+                c
+        }, new List<Contact>{
+                oldContact
+        });
+        contacts.onBeforeUpdate();
+
+        HouseholdNamingExclusionsCheckboxes exclusionsCheckboxes =
+                new HouseholdNamingExclusionsCheckboxes(c);
+        System.assertEquals(true, exclusionsCheckboxes.isExcludedFromFormalGreeting());
+        System.assertEquals(false, exclusionsCheckboxes.isExcludedFromName());
+
+        HouseholdNamingExclusionsString exclusionsString =
+                new HouseholdNamingExclusionsString(c);
+        System.assertEquals(true, exclusionsString.isExcludedFromFormalGreeting(),
+                'The Household Naming Exclusions string should be updated to match the' +
+                        'Naming Exclusions checkboxes when they change on Contact update.');
+        System.assertEquals(false, exclusionsString.isExcludedFromName(),
+                'The Household Naming Exclusions string should be updated to match the' +
+                        'Naming Exclusions checkboxes when they change on Contact update.');
+    }
+
+    @IsTest
+    static void stringChangesOverwriteCheckboxesBeforeUpdate() {
+        Id id = UTIL_UnitTestData_TEST.mockId(Contact.SObjectType);
+        Contact c = new Contact(
+                Id = id,
+                LastName = 'test',
+                npo02__Naming_Exclusions__c = 'Household__c.Name',
+                Exclude_from_Household_Formal_Greeting__c = true
+        );
+
         Contact oldContact = new Contact(
                 Id = id,
-                LastName = 'test'
+                LastName = 'test',
+                Exclude_from_Household_Formal_Greeting__c = true
         );
         Contacts contacts = new Contacts(new List<Contact>{
                 c
@@ -148,8 +187,11 @@ private class HouseholdNamingExclusions_TEST {
         HouseholdNamingExclusionsCheckboxes exclusionsCheckboxes =
                 new HouseholdNamingExclusionsCheckboxes(c);
         System.assertEquals(true, exclusionsCheckboxes.isExcludedFromName(),
-                'The Household Naming Exclusions checkboxes should be synced with the' +
-                        'Naming Exclusions string on Contact update.');
+                'The Household Naming Exclusions checkboxes should be updated to match the' +
+                        'Naming Exclusions string when it changes on Contact update.');
+        System.assertEquals(false, exclusionsCheckboxes.isExcludedFromFormalGreeting(),
+                'The Household Naming Exclusions checkboxes should be updated to match the' +
+                        'Naming Exclusions string when it changes on Contact update.');
     }
 
     @IsTest

--- a/src/classes/HouseholdNamingExclusions_TEST.cls-meta.xml
+++ b/src/classes/HouseholdNamingExclusions_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -370,17 +370,18 @@
         <members>HH_Households_TDTM</members>
         <members>HH_Households_TEST</members>
         <members>HH_INaming</members>
-        <members>HH_NameSpec</members>
-        <members>HH_NameSpec_TEST</members>
         <members>HH_ManageHH_CTRL</members>
         <members>HH_ManageHH_TEST</members>
         <members>HH_ManageHousehold_EXT</members>
+        <members>HH_NameSpec</members>
+        <members>HH_NameSpec_TEST</members>
         <members>HH_OppContactRoles_TDTM</members>
         <members>HH_OppContactRoles_TEST</members>
         <members>HouseholdAccounts</members>
         <members>HouseholdName</members>
         <members>HouseholdNamingExclusionsCheckboxes</members>
         <members>HouseholdNamingExclusionsString</members>
+        <members>HouseholdNamingExclusions_TEST</members>
         <members>HouseholdNamingService</members>
         <members>HouseholdNamingService_TEST</members>
         <members>HouseholdNamingUserControlledFields</members>


### PR DESCRIPTION
Fixes an issue where the Contact Naming Exclusions field isn't being synced correctly when Contacts are updated.

# Critical Changes

# Changes

# Issues Closed
Fixes: #6535
Fixes: #6531

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
