### PR TITLE
W-9549849 Fix for incorrect scale on Recurring Donation Amount field on NPSP Data Import object

### DIFF
--- a/src/objects/DataImport__c.object
+++ b/src/objects/DataImport__c.object
@@ -1733,7 +1733,7 @@
         <label>Recurring Donation Amount</label>
         <precision>18</precision>
         <required>false</required>
-        <scale>0</scale>
+        <scale>2</scale>
         <trackTrending>false</trackTrending>
         <type>Currency</type>
     </fields>

--- a/src/package.xml
+++ b/src/package.xml
@@ -370,11 +370,11 @@
         <members>HH_Households_TDTM</members>
         <members>HH_Households_TEST</members>
         <members>HH_INaming</members>
-        <members>HH_NameSpec</members>
-        <members>HH_NameSpec_TEST</members>
         <members>HH_ManageHH_CTRL</members>
         <members>HH_ManageHH_TEST</members>
         <members>HH_ManageHousehold_EXT</members>
+        <members>HH_NameSpec</members>
+        <members>HH_NameSpec_TEST</members>
         <members>HH_OppContactRoles_TDTM</members>
         <members>HH_OppContactRoles_TEST</members>
         <members>HouseholdAccounts</members>


### PR DESCRIPTION
Recurring Donation Amount field on NPSP Data Import object had incorrect Scale so updating the

scale value to avoid rounding off to the nearest whole number.
The change is performed on the DataImport__c object.

# Critical Changes

# Changes

# Issues Closed
Fixes: #[6523](https://github.com/SalesforceFoundation/NPSP/issues/6523)

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
