### PR TITLE
Missing label workaround

### DIFF
--- a/force-app/main/default/classes/CON_ContactMerge_TEST.cls
+++ b/force-app/main/default/classes/CON_ContactMerge_TEST.cls
@@ -1028,6 +1028,9 @@ public class CON_ContactMerge_TEST {
         controller.getUnactionableDuplicateRecordSets();
         System.assertEquals(controller.unactionableDuplicateRecordSets.size(), 0,
             'All Duplicate Record Sets should be visible');
+        System.assertEquals(Label.commonContactCount, Label.commonContactCount,
+            'Label should be ' + Label.commonContactCount);
+
         Test.stopTest();
     }
 


### PR DESCRIPTION
Added a test class reference to Label.commonContactCount to work around packaging issue.
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
