### PR TITLE
Feature/234  soft credits behavior

### DIFF
--- a/force-app/main/default/classes/Gift.cls
+++ b/force-app/main/default/classes/Gift.cls
@@ -82,6 +82,10 @@ public with sharing class Gift {
         delete this.dataImport;
     }
 
+    public void addSoftCredits(SoftCredits incomingSoftCredits) {
+        this.softCredits.addAll(incomingSoftCredits.all());
+    }
+
     private void populateAvailableFields() {
         Map<String, Object> dataImportFields = this.dataImport.getPopulatedFieldsAsMap();
         List<String> fields = new List<String>();

--- a/force-app/main/default/classes/GiftDTO.cls
+++ b/force-app/main/default/classes/GiftDTO.cls
@@ -37,9 +37,16 @@ public with sharing class GiftDTO {
     public Map<String, Object> fields;
     public SoftCreditsDTO softCreditsDTO;
 
+    public GiftDTO() {}
+
     public GiftDTO(Gift gift) {
         this.fields = gift.fields();
         this.softCreditsDTO = new SoftCreditsDTO(gift.softCredits());
+    }
+
+    public GiftDTO(Map<String, Object> genericObject) {
+        this.fields = (Map<String, Object>) genericObject.get('fields');
+        this.softCreditsDTO = (SoftCreditsDTO) genericObject.get('softCreditsDTO');
     }
 
     public Gift asGift() {
@@ -59,7 +66,4 @@ public with sharing class GiftDTO {
 
         return gift;
     }
-
-    @TestVisible
-    private GiftDTO() {}
 }

--- a/force-app/main/default/classes/GiftDTO.cls
+++ b/force-app/main/default/classes/GiftDTO.cls
@@ -41,4 +41,25 @@ public with sharing class GiftDTO {
         this.fields = gift.fields();
         this.softCreditsDTO = new SoftCreditsDTO(gift.softCredits());
     }
+
+    public Gift asGift() {
+        DataImport__c dataImport = new DataImport__c();
+
+        if (fields != null) {
+            for (String key : fields.keySet()) {
+                dataImport.put(key, fields.get(key));
+            }
+        }
+
+        Gift gift = new Gift(dataImport);
+
+        if (softCreditsDTO != null) {
+            gift.addSoftCredits(softCreditsDTO.asSoftCredits());
+        }
+
+        return gift;
+    }
+
+    @TestVisible
+    private GiftDTO() {}
 }

--- a/force-app/main/default/classes/GiftDTO_TEST.cls
+++ b/force-app/main/default/classes/GiftDTO_TEST.cls
@@ -1,0 +1,87 @@
+/*
+    Copyright (c) 2021 Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+@isTest
+private class GiftDTO_TEST {
+
+    @isTest
+    static void shouldReturnGift() {
+        GiftDTO dummyGiftDTO = new GiftDTO();
+        dummyGiftDTO.fields = new Map<String, Object>();
+        dummyGiftDTO.fields.put('Id', DUMMY_DATA_IMPORT_ID);
+        dummyGiftDTO.fields.put(ACCOUNT1_IMPORTED_FIELD, DUMMY_ACCOUNT_ID);
+        dummyGiftDTO.fields.put(DONATION_AMOUNT_FIELD, 55.55);
+        Gift dummyGift = dummyGiftDTO.asGift();
+
+        System.assertEquals(DUMMY_DATA_IMPORT_ID, dummyGift.fields().get('Id'));
+        System.assertEquals(DUMMY_ACCOUNT_ID, dummyGift.fields().get(ACCOUNT1_IMPORTED_FIELD));
+        System.assertEquals(55.55, dummyGift.fields().get(DONATION_AMOUNT_FIELD));
+    }
+
+    @isTest
+    static void shouldReturnGiftWithSoftCredits() {
+        List<OpportunityContactRole> dummyOpportunityContactRoles = buildDummyOCRs(5);
+        SoftCredits dummySoftCredits = new SoftCredits(dummyOpportunityContactRoles);
+        SoftCreditsDTO softCreditsDTO = new SoftCreditsDTO(dummySoftCredits);
+
+        String additionalObjectJSONStringWithSoftCredits =
+            new UTIL_AdditionalObjectData_TEST()
+                .withOpportunityContactRoles(3)
+                .build();
+        GiftDTO dummyGiftDTO = new GiftDTO();
+        dummyGiftDTO.fields = new Map<String, Object>();
+        dummyGiftDTO.fields.put(ADDITIONAL_OBJECT_JSON_FIELD, additionalObjectJSONStringWithSoftCredits);
+        dummyGiftDTO.softCreditsDTO = softCreditsDTO;
+
+        Gift dummyGift = dummyGiftDTO.asGift();
+
+        System.assertEquals(8, dummyGift.softCredits().size());
+        System.assertEquals(3, dummyGift.softCredits().unprocessed().size());
+    }
+
+    private static List<OpportunityContactRole> buildDummyOCRs(Integer count) {
+        List<OpportunityContactRole> dummyOpportunityContactRoles = new List<OpportunityContactRole>();
+        for (Integer i = 0; i < count; i++) {
+            OpportunityContactRole dummyOCR = new OpportunityContactRole(
+                Id = UTIL_UnitTestData_TEST.mockId(OpportunityContactRole.sObjectType),
+                Role = 'DUMMY ROLE ' + i,
+                ContactId = UTIL_UnitTestData_TEST.mockId(Contact.sObjectType)
+            );
+
+            dummyOpportunityContactRoles.add(dummyOCR);
+        }
+        return dummyOpportunityContactRoles;
+    }
+
+    private static final String DONATION_AMOUNT_FIELD = String.valueOf(DataImport__c.Donation_Amount__c);
+    private static final String ACCOUNT1_IMPORTED_FIELD = String.valueOf(DataImport__c.Account1Imported__c);
+    private static final String ADDITIONAL_OBJECT_JSON_FIELD = String.valueOf(DataImport__c.Additional_Object_JSON__c);
+    private static final String DUMMY_DATA_IMPORT_ID = UTIL_UnitTestData_TEST.mockId(DataImport__c.sObjectType);
+    private static final String DUMMY_ACCOUNT_ID = UTIL_UnitTestData_TEST.mockId(Account.sObjectType);
+}

--- a/force-app/main/default/classes/GiftDTO_TEST.cls
+++ b/force-app/main/default/classes/GiftDTO_TEST.cls
@@ -65,6 +65,48 @@ private class GiftDTO_TEST {
         System.assertEquals(3, dummyGift.softCredits().unprocessed().size());
     }
 
+    @isTest
+    static void shouldHaveExpectedPropertiesWhenConstructedWithAGenericMap() {
+        List<OpportunityContactRole> dummyOpportunityContactRoles = buildDummyOCRs(5);
+        SoftCredits dummySoftCredits = new SoftCredits(dummyOpportunityContactRoles);
+        SoftCreditsDTO dummySoftCreditsDTO = new SoftCreditsDTO(dummySoftCredits);
+
+        Map<String, Object> giftDTOAsGenericMap = new Map<String, Object>();
+        giftDTOAsGenericMap.put('fields', new Map<String, Object> {
+            'Id' => DUMMY_DATA_IMPORT_ID,
+            ACCOUNT1_IMPORTED_FIELD => DUMMY_ACCOUNT_ID
+        });
+        giftDTOAsGenericMap.put('softCreditsDTO', dummySoftCreditsDTO);
+
+        GiftDTO dummyGiftDTO = new GiftDTO(giftDTOAsGenericMap);
+
+        System.assertEquals(DUMMY_DATA_IMPORT_ID, dummyGiftDTO.fields.get('Id'));
+        System.assertEquals(dummySoftCreditsDTO, dummyGiftDTO.softCreditsDTO);
+    }
+
+    @isTest
+    static void shouldHaveExpectedPropertiesWhenConstructedWithAGift() {
+        String additionalObjectStringWithSoftCredits =
+            new UTIL_AdditionalObjectData_TEST()
+            .withOpportunityContactRoles(2)
+            .build();
+
+        DataImport__c dummyDataImport = new DataImport__c(
+            Id = DUMMY_DATA_IMPORT_ID,
+            Account1Imported__c = DUMMY_ACCOUNT_ID,
+            Donation_Amount__c = 33.33,
+            Additional_Object_JSON__c = additionalObjectStringWithSoftCredits
+        );
+        Gift dummyGift = new Gift(dummyDataImport);
+
+        GiftDTO dummyGiftDTO = new GiftDTO(dummyGift);
+
+        System.assertEquals(33.33, dummyGiftDTO.fields.get(DONATION_AMOUNT_FIELD));
+        System.assertEquals(DUMMY_ACCOUNT_ID, dummyGiftDTO.fields.get(ACCOUNT1_IMPORTED_FIELD));
+        System.assertEquals(DUMMY_DATA_IMPORT_ID, dummyGiftDTO.fields.get('Id'));
+        System.assertEquals(2, dummyGiftDTO.softCreditsDTO.softCredits.size());
+    }
+
     private static List<OpportunityContactRole> buildDummyOCRs(Integer count) {
         List<OpportunityContactRole> dummyOpportunityContactRoles = new List<OpportunityContactRole>();
         for (Integer i = 0; i < count; i++) {

--- a/force-app/main/default/classes/GiftDTO_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/GiftDTO_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SoftCreditsDTO.cls
+++ b/force-app/main/default/classes/SoftCreditsDTO.cls
@@ -39,4 +39,10 @@ public with sharing class SoftCreditsDTO {
     public SoftCreditsDTO(SoftCredits softCredits) {
         this.softCredits = softCredits.all();
     }
+
+    public SoftCredits asSoftCredits() {
+        List<OpportunityContactRole> softCredits =
+            (List<OpportunityContactRole>) softCredits;
+        return new SoftCredits(softCredits);
+    }
 }

--- a/force-app/main/default/lwc/geGift/__tests__/geGift.test.js
+++ b/force-app/main/default/lwc/geGift/__tests__/geGift.test.js
@@ -37,4 +37,9 @@ describe('ge-gift', () => {
 
         expect(Object.keys(gift.state().fields)).not.toContain('Contact1Imported__c');
     });
+
+    it('should return a string representation of the gift state', async () => {
+        const gift = new Gift(mockGiftView);
+        expect(gift.toJSON()).toBe(JSON.stringify(mockGiftView));
+    });
 });

--- a/force-app/main/default/lwc/geGift/geGift.js
+++ b/force-app/main/default/lwc/geGift/geGift.js
@@ -39,6 +39,10 @@ class Gift {
         return dataImportRecord;
     }
 
+    toJSON() {
+        return JSON.stringify(this.state());
+    }
+
     state() {
         return {
             fields: { ...this._fields },


### PR DESCRIPTION
[W-9547750](https://gus.my.salesforce.com/a07AH000000QAKkYAO)

The Soft Credits field bundle in Gift Entry will now be able to add, remove, and edit unprocessed soft credit entries.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
