### PR TITLE
Update check of describe object type to avoid object comparison

### DIFF
--- a/force-app/main/default/classes/TDTM_TriggerHandler.cls
+++ b/force-app/main/default/classes/TDTM_TriggerHandler.cls
@@ -81,9 +81,10 @@ public class TDTM_TriggerHandler {
         // If there are no records, insert the defaults.
         if (!defaultRecordsInserted && dao.isEmpty()) {
             // We will not insert the default records when Triggered by the User object to prevent MixedDML errors
-            if (describeObj == Schema.SObjectType.User) {
+            if (describeObj.getsObjectType() == User.sObjectType) {
                 return;
             }
+            
             List<Trigger_Handler__c> defaultConfig = TDTM_DefaultConfig.getDefaultRecords();
             // Rather than insert the records in unit tests, just populate the static list
             // However to prevent any conflicts with our customers unit tests, always insert the records


### PR DESCRIPTION
This work updates a condition that intends to identify when a trigger is based on the User SObject and prevent insert of default trigger handlers when it does, as this results in a "mixed DML" error. The previous condition was testing the equality of a DescribeSObjectResult, which is not reliable, and replaces it with a test against the SObjectType, which should be reliable. 

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
