### PR TITLE
Fix GAU CRLP Reset to 0 If Subsequent GAUs Have Allocations Only Tied to Non-Opportunities

### DIFF
--- a/force-app/main/default/classes/CRLP_Batch_Base_Skew.cls
+++ b/force-app/main/default/classes/CRLP_Batch_Base_Skew.cls
@@ -145,6 +145,9 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
                 parentKeyField = parentKeyField.split('\\.')[1];
             }
 
+            // If there is any post-query filtering that needs to be applied, do it here
+            detailRecords = applyPostQueryLocatorFilters(detailRecords);
+
             Id firstParentId, lastParentId;
             if (parentObjectField == null) {
                 firstParentId = (Id)detailRecords[0].get(parentKeyField);
@@ -159,9 +162,6 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
             // Get all parent records to be processed by this batch iteration
             List<Id> parentIds = getUniqueParentIds(this.summaryObjectType, detailRecords,
                 (parentObjectField != null ? parentObjectField + '.' : '') + parentKeyField);
-
-            // If there is any post-query filtering that needs to be applied, do it here
-            detailRecords = applyPostQueryLocatorFilters(detailRecords);
 
             // Map of Payment Child details by parent Opportunity (this job only handles Opportunity or Allocation
             // as the primary queryLocator).


### PR DESCRIPTION
We fixed an issue that caused a General Account Unit rollup record to reset to 0 if the next General Accounting Unit rollup record processed had no allocatons tied to Opportunities
# Critical Changes

# Changes

# Issues Closed
Fixes #6204 

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
