### PR TITLE
Fix Test that Fails With Gem Installed

### DIFF
--- a/force-app/main/default/classes/HouseholdService.cls
+++ b/force-app/main/default/classes/HouseholdService.cls
@@ -92,14 +92,8 @@ public inherited sharing class HouseholdService {
         oldHouseholds.deleteEmptyHouseholds();
     }
 
-    /**
-     * @description Static flag used to prevent hitting governor limits when this method
-     * runs multiple times during Contact merges.
-     */
-    private static Integer numberOfTimesUpdateHouseholdNamesHasRun = 0;
     public void updateHouseholdNamesFor(ContactsInLegacyHouseholds contactsInLegacyHouseholds) {
-        if (contactsInLegacyHouseholds.householdsWithMembershipOrNamingFieldChanges().size() > 0
-                && numberOfTimesUpdateHouseholdNamesHasRun < 2) {
+        if (contactsInLegacyHouseholds.householdsWithMembershipOrNamingFieldChanges().size() > 0) {
             if (isFutureEligible()) {
                 HouseholdNamingService.updateHouseholdNameAndMemberCountAsynchronously(
                         contactsInLegacyHouseholds
@@ -110,7 +104,6 @@ public inherited sharing class HouseholdService {
                         contactsInLegacyHouseholds
                                 .householdsWithMembershipOrNamingFieldChanges());
             }
-            numberOfTimesUpdateHouseholdNamesHasRun++;
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue that causes an Apex test (HH_Households_TEST.testNewAndUpdateContactWithHHNaming) to fail when Gem is installed.  

WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000S23YYAS/view

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
