### PR TITLE
Add isActive Service Record Check in Elevate Enabled Check

### DIFF
--- a/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
@@ -76,6 +76,22 @@ public with sharing class PS_IntegrationServiceConfig {
     };
 
     /**
+    * @description Returns the Elevate integration service enablement status
+    * @return Boolean
+    */
+    public Boolean isIntegrationEnabled() {
+        return isEnabled;
+    }
+
+    /**
+    * @description Determines if the current user has the appropriate permissions to modify Elevate records
+    * @return Boolean
+    */
+    public Boolean hasIntegrationPermissions() {
+        return hasPermissions;
+    }
+
+    /**
     * @description Determines if the Elevate integration service is configured and enabled.
     * The Elevate Payment Services integration is considered enabled when all required
     * service records are present with value and isActive record is either missing or true
@@ -120,14 +136,6 @@ public with sharing class PS_IntegrationServiceConfig {
     }
 
     /**
-    * @description Returns the Elevate integration service enablement status
-    * @return Boolean
-    */
-    public Boolean isIntegrationEnabled() {
-        return isEnabled;
-    }
-
-    /**
     * @description Determines if the current user has the appropriate permissions to modify Elevate records
     * @return Boolean
     */
@@ -144,13 +152,6 @@ public with sharing class PS_IntegrationServiceConfig {
         set;
     }
 
-    /**
-    * @description Determines if the current user has the appropriate permissions to modify Elevate records
-    * @return Boolean
-    */
-    public Boolean hasIntegrationPermissions() {
-        return hasPermissions;
-    }
 
     /**
     * @description Returns the same instance of the Configuration inner class

--- a/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
@@ -53,7 +53,7 @@ public with sharing class PS_IntegrationServiceConfig {
     public static final String CLIENTID = 'clientId';
 
     //Determine if Elevate connection is active
-    public static final String isActive = 'isActive';
+    public static final String IS_ACTIVE = 'isActive';
 
     // Elevate record view types
     public enum VIEW_TYPE {
@@ -78,11 +78,11 @@ public with sharing class PS_IntegrationServiceConfig {
     /**
     * @description Determines if the Elevate integration service is configured and enabled.
     * The Elevate Payment Services integration is considered enabled when all required
-    * service records are present with value and isActive record is either missing or true
+    * service records are present with value and Integration is Active
     * @return Boolean
     */
     public Boolean isIntegrationEnabled() {
-        return isIntegrationActive() && hasElevateServiceData();
+        return isIntegrationActive() && ElevateConfigService.hasAllRequiredServiceData();
     }
 
     /**
@@ -100,25 +100,7 @@ public with sharing class PS_IntegrationServiceConfig {
     * @return Boolean
     */
     private Boolean isIntegrationActive() {
-        if (config.keyValueMap.containsKey(isActive)) {
-            return Boolean.valueOf(config.keyValueMap.get(isActive));
-        }
-
-        return true;
-    }
-
-    /**
-    * @description Determine is all required service record exist and has value
-    * @return Boolean 
-    */
-    private Boolean hasElevateServiceData() {
-        for (String requiredConfigKey : REQUIRED_CONFIG_KEYS) {
-            if (String.isBlank(config.keyValueMap.get(requiredConfigKey))) {
-                return false;
-            }
-        }
-
-        return true;
+       return ElevateConfigService.getIsActiveFlag();
     }
 
     /**
@@ -149,6 +131,19 @@ public with sharing class PS_IntegrationServiceConfig {
                 config = new Configuration();
             }
             return config;
+        } set;
+    }
+
+     /**
+    * @description Returns the instance of Elevate Related Configuration Service
+    * @return Service
+    */
+    private static Service ElevateConfigService {
+        get {
+            if (ElevateConfigService == null) {
+                ElevateConfigService = new Service();
+            }
+            return ElevateConfigService;
         } set;
     }
 
@@ -271,12 +266,32 @@ public with sharing class PS_IntegrationServiceConfig {
             return config.get(API_KEY);
         }
 
+        public Boolean getIsActiveFlag() {
+            return hasIsActiveFlag() 
+                ? Boolean.valueOf(config.get(IS_ACTIVE))
+                : true;
+        }
+
         public String getViewURLPrefix(PS_IntegrationServiceConfig.VIEW_TYPE recordType) {
             return getRecordViewURL('', recordType);
         }
 
         public String getRecordViewURL(String elevateId, PS_IntegrationServiceConfig.VIEW_TYPE recordType) {
             return getRecordViewBaseURL() + '/' + getRecordViewTypeSuffix(recordType) + '/' + elevateId;
+        }
+
+        public Boolean hasIsActiveFlag() {
+            return config.containsKey(IS_ACTIVE);
+        }
+
+        public Boolean hasAllRequiredServiceData() {
+            for (String requiredConfigKey : REQUIRED_CONFIG_KEYS) {
+                if (String.isBlank(config.get(requiredConfigKey))) {
+                    return false;
+                }
+            }
+    
+            return true;
         }
 
         private String getRecordViewBaseURL() {

--- a/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
@@ -82,7 +82,7 @@ public with sharing class PS_IntegrationServiceConfig {
     * @return Boolean
     */
     public Boolean isIntegrationEnabled() {
-        return isIntegrationActive() && ElevateConfigService.hasAllRequiredServiceData();
+        return isIntegrationActive() && hasAllRequiredServiceData();
     }
 
     /**
@@ -101,6 +101,14 @@ public with sharing class PS_IntegrationServiceConfig {
     */
     private Boolean isIntegrationActive() {
        return ElevateConfigService.getIsActiveFlag();
+    }
+
+    /**
+    * @description Determine if all required Elevate service record data exist and have values stored in it.
+    * @return Boolean
+    */
+    private Boolean hasAllRequiredServiceData() {
+        return ElevateConfigService.hasAllRequiredServiceData();
     }
 
     /**

--- a/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
@@ -104,7 +104,7 @@ public with sharing class PS_IntegrationServiceConfig {
     }
 
     /**
-    * @description Determine if all required Elevate service record data exist and have values stored in it.
+    * @description Determine if all required Elevate service records exist and have values stored in it.
     * @return Boolean
     */
     private Boolean hasAllRequiredServiceData() {

--- a/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
@@ -52,6 +52,9 @@ public with sharing class PS_IntegrationServiceConfig {
     public static final String ELEVATE_SDK = 'elevateSDK';
     public static final String CLIENTID = 'clientId';
 
+    //Determine if Elevate connection is active
+    public static final String isActive = 'isActive';
+
     // Elevate record view types
     public enum VIEW_TYPE {
         COMMITMENT,
@@ -74,18 +77,46 @@ public with sharing class PS_IntegrationServiceConfig {
 
     /**
     * @description Determines if the Elevate integration service is configured and enabled.
-    * The Elevate Payment Services integration is considered "enabled" (for now) when there
-    * is at least a single record in the protected Payment Services Configuration object
+    * The Elevate Payment Services integration is considered enabled when all required
+    * service records are present with value and isActive record is either missing or true
     * @return Boolean
     */
     private Boolean isEnabled {
         get {
             if (isEnabled == null) {
-                return config.keyValueMap.keySet().containsAll(REQUIRED_CONFIG_KEYS);
+                return isIntegrationActive() && hasElevateServiceData();
             }
             return isEnabled;
         }
         set;
+    }
+
+    /**
+    * @description Determine if isActive service record exist. If the record exist,
+    * using the record to determine if Elevate is regiesterd. Else assume the key
+    * is active
+    * @return Boolean
+    */
+    private Boolean isIntegrationActive() {
+        if (config.keyValueMap.containsKey(isActive)) {
+            return Boolean.valueOf(config.keyValueMap.get(isActive));
+        }
+
+        return true;
+    }
+
+    /**
+    * @description Determine is all required service record exist and has value
+    * @return Boolean 
+    */
+    private Boolean hasElevateServiceData() {
+        for (String requiredConfigKey : REQUIRED_CONFIG_KEYS) {
+            if (String.isBlank(config.keyValueMap.get(requiredConfigKey))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig.cls
@@ -76,11 +76,13 @@ public with sharing class PS_IntegrationServiceConfig {
     };
 
     /**
-    * @description Returns the Elevate integration service enablement status
+    * @description Determines if the Elevate integration service is configured and enabled.
+    * The Elevate Payment Services integration is considered enabled when all required
+    * service records are present with value and isActive record is either missing or true
     * @return Boolean
     */
     public Boolean isIntegrationEnabled() {
-        return isEnabled;
+        return isIntegrationActive() && hasElevateServiceData();
     }
 
     /**
@@ -92,24 +94,8 @@ public with sharing class PS_IntegrationServiceConfig {
     }
 
     /**
-    * @description Determines if the Elevate integration service is configured and enabled.
-    * The Elevate Payment Services integration is considered enabled when all required
-    * service records are present with value and isActive record is either missing or true
-    * @return Boolean
-    */
-    private Boolean isEnabled {
-        get {
-            if (isEnabled == null) {
-                return isIntegrationActive() && hasElevateServiceData();
-            }
-            return isEnabled;
-        }
-        set;
-    }
-
-    /**
     * @description Determine if isActive service record exist. If the record exist,
-    * using the record to determine if Elevate is regiesterd. Else assume the key
+    * using the record to determine if Elevate is registered. Else assume the key
     * is active
     * @return Boolean
     */

--- a/force-app/main/default/classes/PS_IntegrationServiceConfig_TEST.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig_TEST.cls
@@ -109,6 +109,28 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
     }
 
     @IsTest
+    private static void shouldHaveIntegrationDisabledWhenRequirdRecordsAreMissingValues() {
+        List<Payment_Services_Configuration__c> serviceRecords = getConfigurations();
+        for (Payment_Services_Configuration__c serviceRecord : serviceRecords) {
+            serviceRecord.Value__c = null;
+        }
+        serviceRecords.add(
+            new Payment_Services_Configuration__c(
+                Service__c = PS_IntegrationServiceConfig.PAYMENTS_SERVICE_NAME,
+                Key__c = PS_IntegrationServiceConfig.isActive,
+                Value__c = 'true'
+            )
+        );
+
+        insert serviceRecords;
+
+        PS_IntegrationServiceConfig ps = new PS_IntegrationServiceConfig();
+        System.assertEquals(false, ps.isIntegrationEnabled(),
+            'The org should have Integration Disabled when required service records do not have values');
+
+    }
+
+    @IsTest
     private static void shouldNotHaveIntegrationEnabledWhenOrgIsNotConnectedToElevate() {
         PS_IntegrationServiceConfig ps = new PS_IntegrationServiceConfig();
         System.assertEquals(false, ps.isIntegrationEnabled(),
@@ -227,10 +249,7 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
     // Helpers
     //////////////
 
-    /***
-     * @descriptions Inserts required payments services configuration 
-     */
-    private static void setUpConfiguration() {
+    private static List<Payment_Services_Configuration__c> getConfigurations() {
         List<Payment_Services_Configuration__c> requiredConfigs = new List<Payment_Services_Configuration__c>();
 
         for (Integer i = 0; i < PS_IntegrationServiceConfig.REQUIRED_CONFIG_KEYS.size(); i++) {
@@ -241,6 +260,13 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
             ));
         }
 
-        insert requiredConfigs;
+        return requiredConfigs;
+    }
+
+    /***
+     * @descriptions Inserts required payments services configuration 
+     */
+    private static void setUpConfiguration() {
+        insert getConfigurations();
     }
 }

--- a/force-app/main/default/classes/PS_IntegrationServiceConfig_TEST.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig_TEST.cls
@@ -60,7 +60,7 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
                     'value' => testBaseUrl
                 },
                 new Map<String, String>{
-                    'key' => PS_IntegrationServiceConfig.isActive,
+                    'key' => PS_IntegrationServiceConfig.IS_ACTIVE,
                     'value' => 'true'
                 }
             }
@@ -99,7 +99,7 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
         setUpConfiguration();
         insert new Payment_Services_Configuration__c(
             Service__c = PS_IntegrationServiceConfig.PAYMENTS_SERVICE_NAME,
-            Key__c = PS_IntegrationServiceConfig.isActive,
+            Key__c = PS_IntegrationServiceConfig.IS_ACTIVE,
             Value__c = 'false'
         );
 
@@ -117,7 +117,7 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
         serviceRecords.add(
             new Payment_Services_Configuration__c(
                 Service__c = PS_IntegrationServiceConfig.PAYMENTS_SERVICE_NAME,
-                Key__c = PS_IntegrationServiceConfig.isActive,
+                Key__c = PS_IntegrationServiceConfig.IS_ACTIVE,
                 Value__c = 'true'
             )
         );

--- a/force-app/main/default/classes/PS_IntegrationServiceConfig_TEST.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig_TEST.cls
@@ -58,6 +58,10 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
                 new Map<String, String>{
                     'key' => PS_IntegrationServiceConfig.BASE_URL,
                     'value' => testBaseUrl
+                },
+                new Map<String, String>{
+                    'key' => PS_IntegrationServiceConfig.isActive,
+                    'value' => 'true'
                 }
             }
         };
@@ -88,6 +92,20 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
         System.assert(ps.isIntegrationEnabled(),
             'The org should have Integration Enabled when '
             + 'all required configuration keys are present.');
+    }
+
+    @IsTest
+    private static void shouldHaveIntegrationDisabledWhenIsActiveServiceRecordIsFalse() {
+        setUpConfiguration();
+        insert new Payment_Services_Configuration__c(
+            Service__c = PS_IntegrationServiceConfig.PAYMENTS_SERVICE_NAME,
+            Key__c = PS_IntegrationServiceConfig.isActive,
+            Value__c = 'false'
+        );
+
+        PS_IntegrationServiceConfig ps = new PS_IntegrationServiceConfig();
+        System.assertEquals(false, ps.isIntegrationEnabled(),
+            'The org should have Integration Disabled when isActive record is false');
     }
 
     @IsTest
@@ -166,7 +184,6 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
         System.assertEquals(testCommitmentViewURL, expectedURL,
             'Commitment View URL should be ' + testCommitmentViewURL);
     }
-
 
     /***
     * @description Stub for the integration service config instance

--- a/force-app/main/default/classes/PS_IntegrationServiceConfig_TEST.cls
+++ b/force-app/main/default/classes/PS_IntegrationServiceConfig_TEST.cls
@@ -249,6 +249,9 @@ public with sharing class PS_IntegrationServiceConfig_TEST {
     // Helpers
     //////////////
 
+    /**
+    * @description Create all required Payment Services Configuration Records 
+    */
     private static List<Payment_Services_Configuration__c> getConfigurations() {
         List<Payment_Services_Configuration__c> requiredConfigs = new List<Payment_Services_Configuration__c>();
 


### PR DESCRIPTION
Implement the isActive record validation in Apex to check if Elevate is registered or not
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers
 - We added an additional check to the Elevate integration when a request is sent to deregister Elevate from Salesforce.

# New Metadata

# Deleted Metadata
