### PR TITLE
Fix new methods in renamed AccountsAdapter to return correct type

### DIFF
--- a/force-app/main/Application.cls
+++ b/force-app/main/Application.cls
@@ -83,7 +83,7 @@ public inherited sharing class Application {
     }
 
     private void createAddressesFromNewAccounts(AccountsAdapter accounts, TDTM_Runnable.DmlWrapper dmlWrapper) {
-        Accounts accountsWithNewAddressesToCreate = accounts.newAccountsWithAddressesToCreate();
+        AccountsAdapter accountsWithNewAddressesToCreate = accounts.newAccountsWithAddressesToCreate();
         if (accountsWithNewAddressesToCreate.getRecords().size() > 0) {
             AddressService.createAddressesFor(accountsWithNewAddressesToCreate, dmlWrapper, false);
         }
@@ -112,7 +112,7 @@ public inherited sharing class Application {
             return;
         }
 
-        Accounts updatedAccountsWithAddressesToCreateOrUpdate = accounts.updatedAccountsWithAddressesToCreateOrUpdate();
+        AccountsAdapter updatedAccountsWithAddressesToCreateOrUpdate = accounts.updatedAccountsWithAddressesToCreateOrUpdate();
 
         if (updatedAccountsWithAddressesToCreateOrUpdate.getRecords().size() > 0) {
             AddressService.createAddressesFor(updatedAccountsWithAddressesToCreateOrUpdate, dmlWrapper, false);

--- a/force-app/main/Application.cls
+++ b/force-app/main/Application.cls
@@ -86,6 +86,7 @@ public inherited sharing class Application {
         Accounts accountsWithNewAddressesToCreate = accounts.newAccountsWithAddressesToCreate();
         if (accountsWithNewAddressesToCreate.getRecords().size() > 0) {
             AddressService.createAddressesFor(accountsWithNewAddressesToCreate, dmlWrapper, false);
+        }
     }
 
     public void onBeforeUpdateOf(AccountsAdapter accounts) {

--- a/force-app/main/adapter/in/sobjects/AccountsAdapter.cls
+++ b/force-app/main/adapter/in/sobjects/AccountsAdapter.cls
@@ -200,7 +200,7 @@ public inherited sharing class AccountsAdapter extends fflib_SObjects {
                 && !isBucketAccount(acc);
     }
 
-    public Accounts updatedAccountsWithAddressesToCreateOrUpdate() {
+    public AccountsAdapter updatedAccountsWithAddressesToCreateOrUpdate() {
         List<Account> updatedAccountsWithAddressesToCreate = new List<Account>();
 
         if (AddressService.isAddressManagementEnabled()) {
@@ -211,10 +211,10 @@ public inherited sharing class AccountsAdapter extends fflib_SObjects {
             updatedAccountsWithAddressesToCreate.addAll(withAddressChanges().orgAccounts());
         }
 
-        return new Accounts(updatedAccountsWithAddressesToCreate, oldMap.values());
+        return new AccountsAdapter(updatedAccountsWithAddressesToCreate, oldMap.values());
     }
 
-    public Accounts newAccountsWithAddressesToCreate() {
+    public AccountsAdapter newAccountsWithAddressesToCreate() {
         List<Account> addressesToCreate = new List<Account>();
 
         if (AddressService.isAddressManagementEnabled()) {
@@ -224,7 +224,7 @@ public inherited sharing class AccountsAdapter extends fflib_SObjects {
             addressesToCreate.addAll(withAddresses().orgAccounts());
         }
 
-        return new Accounts(addressesToCreate);
+        return new AccountsAdapter(addressesToCreate);
     }
 
     public List<Address__c> allAddresses() {

--- a/force-app/main/default/classes/AddressService.cls
+++ b/force-app/main/default/classes/AddressService.cls
@@ -105,7 +105,7 @@ public inherited sharing class AddressService {
     * @param dmlWrapper the Addresses to update
     * @param includeAddressType whether to include comparing the AddressType field
     */
-    public static void createAddressesFor(Accounts accounts,
+    public static void createAddressesFor(AccountsAdapter accounts,
             TDTM_Runnable.DmlWrapper dmlWrapper, Boolean includeAddressType) {
 
         Map<Address__c, Address__c> existingAddressesByAddress = Addresses.getExistingAddresses(
@@ -150,7 +150,7 @@ public inherited sharing class AddressService {
         }
     }
 
-    private static Map<Id, Account> getAccountsById(Accounts accounts) {
+    private static Map<Id, Account> getAccountsById(AccountsAdapter accounts) {
         Map<Id, Account> accountsById = new Map<Id, Account>();
         for (Account account : (List<Account>) accounts.getRecords()) {
             accountsById.put(account.Id, account);


### PR DESCRIPTION
This PR addresses an issue caused by a merge that did not complete cleanly, causing builds to not be able to run.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
