### PR TITLE
Update Recurring Donation and Data Import End Date Help Text

### DIFF
--- a/force-app/main/default/lwc/rd2EntryForm/__tests__/data/recurringDonationObjectInfo.json
+++ b/force-app/main/default/lwc/rd2EntryForm/__tests__/data/recurringDonationObjectInfo.json
@@ -463,7 +463,7 @@
       "filteredLookupInfo": null,
       "highScaleNumber": false,
       "htmlFormatted": false,
-      "inlineHelpText": "After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed.",
+      "inlineHelpText": "The date on which this Recurring Donation was closed.",
       "label": "End Date",
       "length": 0,
       "nameField": false,

--- a/force-app/main/default/lwc/rd2EntryFormDonorSection/__tests__/data/recurringDonationObjectInfo.json
+++ b/force-app/main/default/lwc/rd2EntryFormDonorSection/__tests__/data/recurringDonationObjectInfo.json
@@ -463,7 +463,7 @@
       "filteredLookupInfo": null,
       "highScaleNumber": false,
       "htmlFormatted": false,
-      "inlineHelpText": "After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed.",
+      "inlineHelpText": "The date on which this Recurring Donation was closed.",
       "label": "End Date",
       "length": 0,
       "nameField": false,

--- a/force-app/main/default/objectTranslations/DataImport__c-en_GB/Recurring_Donation_End_Date__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/DataImport__c-en_GB/Recurring_Donation_End_Date__c.fieldTranslation-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help>After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed.</help>
+    <help>The date on which this Recurring Donation was closed.</help>
     <label>Recurring Donation End Date</label>
     <name>Recurring_Donation_End_Date__c</name>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/DataImport__c-en_US/Recurring_Donation_End_Date__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/DataImport__c-en_US/Recurring_Donation_End_Date__c.fieldTranslation-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed. --></help>
+    <help><!-- The date on which this Recurring Donation was closed. --></help>
     <label><!-- Recurring Donation End Date --></label>
     <name>Recurring_Donation_End_Date__c</name>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/DataImport__c-iw/Recurring_Donation_End_Date__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/DataImport__c-iw/Recurring_Donation_End_Date__c.fieldTranslation-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed. --></help>
+    <help><!-- The date on which this Recurring Donation was closed. --></help>
     <label><!-- Recurring Donation End Date --></label>
     <name>Recurring_Donation_End_Date__c</name>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/npe03__Recurring_Donation__c-en_GB/EndDate__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/npe03__Recurring_Donation__c-en_GB/EndDate__c.fieldTranslation-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help>After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed.</help>
+    <help>The date on which this Recurring Donation was closed.</help>
     <label>End Date</label>
     <name>EndDate__c</name>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/npe03__Recurring_Donation__c-iw/EndDate__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/npe03__Recurring_Donation__c-iw/EndDate__c.fieldTranslation-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <help><!-- After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed. --></help>
+    <help><!-- The date on which this Recurring Donation was closed. --></help>
     <label><!-- End Date --></label>
     <name>EndDate__c</name>
 </CustomFieldTranslation>

--- a/force-app/main/default/objects/DataImport__c/fields/Recurring_Donation_End_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/DataImport__c/fields/Recurring_Donation_End_Date__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Recurring_Donation_End_Date__c</fullName>
-    <description>After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed.</description>
+    <description>The date on which this Recurring Donation was closed.</description>
     <externalId>false</externalId>
-    <inlineHelpText>After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed.</inlineHelpText>
+    <inlineHelpText>The date on which this Recurring Donation was closed.</inlineHelpText>
     <label>Recurring Donation End Date</label>
     <required>false</required>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/npe03__Recurring_Donation__c/fields/EndDate__c.field-meta.xml
+++ b/force-app/main/default/objects/npe03__Recurring_Donation__c/fields/EndDate__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>EndDate__c</fullName>
-    <description>After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed.</description>
+    <description>The date on which this Recurring Donation was closed.</description>
     <externalId>false</externalId>
-    <inlineHelpText>After this date, NPSP no longer creates installments for this Recurring Donation and updates Status to Closed.</inlineHelpText>
+    <inlineHelpText>The date on which this Recurring Donation was closed.</inlineHelpText>
     <label>End Date</label>
     <required>false</required>
     <trackTrending>false</trackTrending>

--- a/unpackaged/config/rd2_post_config/objects/npe03__Recurring_Donation__c.object
+++ b/unpackaged/config/rd2_post_config/objects/npe03__Recurring_Donation__c.object
@@ -323,6 +323,17 @@
         <type>Date</type>
     </fields>
     <fields>
+        <fullName>%%%NAMESPACE%%%EndDate__c</fullName>
+        <description>The date on which this Recurring Donation was closed.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The date on which this Recurring Donation was closed.</inlineHelpText>
+        <label>End Date</label>
+        <required>false</required>
+        <trackHistory>false</trackHistory>
+        <trackTrending>false</trackTrending>
+        <type>Date</type>
+    </fields>
+    <fields>
         <fullName>%%%NAMESPACE%%%Status__c</fullName>
         <description>Indicates if this Recurring Donation is actively in use, temporarily suspended, or closed.</description>
         <externalId>false</externalId>


### PR DESCRIPTION
- Update DataImport__c.Recurring_Donation_End_Date__c description and help text
- Update npe03__Recurring_Donation__c.EndDate__c description and help text

# Critical Changes

# Changes

 - To make the field's purpose clearer, we updated the help text for End Date on the Recurring Donation and NPSP Data Import objects. Existing customers will need to make this update manually. Ask your system administrator to update the help text to: "The date on which this Recurring Donation was closed."

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
