### PR TITLE
Fix General Accounting Unit CRLP Reset to 0 bug

### DIFF
--- a/force-app/main/default/classes/CRLP_Batch_Base_Skew.cls
+++ b/force-app/main/default/classes/CRLP_Batch_Base_Skew.cls
@@ -145,16 +145,8 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
                 parentKeyField = parentKeyField.split('\\.')[1];
             }
 
-            Id firstParentId, lastParentId;
-            if (parentObjectField == null) {
-                firstParentId = (Id)detailRecords[0].get(parentKeyField);
-                lastParentId = (Id)detailRecords[detailRecords.size()-1].get(parentKeyField);
-            } else {
-                SObject dtlRecord = detailRecords[0].getSObject(parentObjectField);
-                firstParentId = (Id)dtlRecord.get(parentKeyField);
-                dtlRecord = detailRecords[detailRecords.size()-1].getSObject(parentObjectField);
-                lastParentId = (Id)dtlRecord.get(parentKeyField);
-            }
+            Id firstParentId = getParentId(parentObjectField, detailRecords[0], parentKeyField);
+            Id lastParentId = getParentId(parentObjectField, detailRecords[detailRecords.size() - 1], parentKeyField);
 
             // Get all parent records to be processed by this batch iteration
             List<Id> parentIds = getUniqueParentIds(this.summaryObjectType, detailRecords,
@@ -162,6 +154,10 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
 
             // If there is any post-query filtering that needs to be applied, do it here
             detailRecords = applyPostQueryLocatorFilters(detailRecords);
+
+            // Check if we need to keep the last processed parent id
+            Boolean hasNoDetailsForLastParentId =
+                hasNoDetailsForLastParentId(lastParentId, parentObjectField, detailRecords, parentKeyField);
 
             // Map of Payment Child details by parent Opportunity (this job only handles Opportunity or Allocation
             // as the primary queryLocator).
@@ -192,7 +188,8 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
                 .withRelatedRecords(paymentsByOpp)
                 .withPreviouslyProcessedOppIdsMap(this.statefulMapOfOppIdsByParentId)
                 .withRollupDefinitions(this.statefulRollupsById)
-                .withJobOptions(options);
+                .withJobOptions(options)
+                .withLastParentDetails(hasNoDetailsForLastParentId);
 
             List<SObject> updatedRecords = processor.startRollupProcessing();
 
@@ -216,6 +213,47 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
         } catch (Exception ex) {
             ERR_Handler.processError(ex, ERR_Handler_API.Context.CRLP + '.' + this.jobType.name());
         }
+    }
+
+    /**
+    * @description Check to see if lastParentId has had all detail records removed
+    * @param lastParentId
+    * @param parentObjectField
+    * @param detailRecords
+    * @param parentKeyField
+    * @return Boolean true if lastParentId has no associated detail records in a GAU rollup
+    */
+    @TestVisible
+    private Boolean hasNoDetailsForLastParentId(
+        Id lastParentId,
+        String parentObjectField,
+        List<SObject> detailRecords,
+        String parentKeyField
+    ) {
+        if (this.jobType == CRLP_RollupProcessingOptions.RollupType.GAU &&
+            lastParentId != getParentId(parentObjectField, detailRecords[detailRecords.size() - 1], parentKeyField)
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+    * @description Get the parent Id of the referenced detail record
+    * @param parentObjectField
+    * @param detailRecord
+    * @param parentKeyField
+    * @return Id
+    */
+    @TestVisible
+    private Id getParentId(String parentObjectField, SObject detailRecord, String parentKeyField) {
+        Id parentId;
+        if (parentObjectField == null) {
+            parentId = (Id) detailRecord.get(parentKeyField);
+        } else {
+            parentId = (Id) detailRecord.getSObject(parentObjectField).get(parentKeyField);
+        }
+        return parentId;
     }
 
     /********************************************************************************************************
@@ -262,8 +300,6 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
         // may cause a cpu time out issue.
         String query = CRLP_Query_SEL.buildDetailObjectQueryForRollup(detailObjectType, new List<SObjectType>());
 
-        npo02__Households_Settings__c householdSettings = UTIL_CustomSettingsFacade.getHouseholdsSettings();
-
         if (!CRLP_Rollup_SVC.hasActiveRollups(jobType)) {
             // If there are no active rollups for the object type, then force the query to return zero records.
             // This is needed because can't return null as a valid iterator.
@@ -294,38 +330,15 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
 
         // Exclude Organization Donations (where Opp.Account.SYSTEM_IsIndividual=false) from Contact Hard Credit rollups
         // Depending on the npo02__Always_Rollup_to_Primary_Contact__c custom setting
-        if (householdSettings.npo02__Always_Rollup_to_Primary_Contact__c == false
-                && this.jobType == CRLP_RollupProcessingOptions.RollupType.ContactHardCredit) {
-            whereClauses.add('Account.npe01__SYSTEMIsIndividual__c = True');
-
-        } else if (householdSettings.npo02__Always_Rollup_to_Primary_Contact__c == false
-                && CRLP_Rollup_SVC.isOppContactRoleSoftCreditRollup(this.jobType)
-        ) {
-            whereClauses.add('(IsPrimary = False OR Opportunity.Account.npe01__SYSTEMIsIndividual__c = False)');
-
-        } else if (householdSettings.npo02__Always_Rollup_to_Primary_Contact__c == true
-                && CRLP_Rollup_SVC.isOppContactRoleSoftCreditRollup(this.jobType)
-        ) {
-            whereClauses.add('IsPrimary = False');
+        String householdSettingsFilter = getHouseholdSettingsFilter();
+        if (!String.isEmpty(householdSettingsFilter)) {
+            whereClauses.add(householdSettingsFilter);
         }
 
         // Identify a common filter that can be applied to the main query to reduce the number of records queried
-        String addlFilter;
-        if (detailObjectType == Opportunity.SObjectType) {
-            addlFilter = CRLP_Query_SEL.buildCommonQueryFilterOnOpportunity(this.summaryObjectType, detailObjectType,
-                    this.statefulCacheOfRollupsToBeProcessed);
-
-        } else if (this.jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
-            addlFilter = CRLP_Query_SEL.buildCommonQueryFilterOnOpportunity(Contact.SObjectType, Partial_Soft_Credit__c.SObjectType);
-
-        } else if (this.jobType == CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit) {
-            addlFilter = CRLP_Query_SEL.buildCommonQueryFilterOnOpportunity(Account.SObjectType, Partial_Soft_Credit__c.SObjectType);
-
-        } else if (this.jobType == CRLP_RollupProcessingOptions.RollupType.AccountSoftCredit) {
-            addlFilter = CRLP_Query_SEL.buildCommonQueryFilterOnOpportunity(this.summaryObjectType, this.detailObjectType);
-        }
-        if (!String.isEmpty(addlFilter)) {
-            whereClauses.add(addlFilter);
+        String additionalFilter = getAdditionalFilter();
+        if (!String.isEmpty(additionalFilter)) {
+            whereClauses.add(additionalFilter);
         }
 
         if (!whereClauses.isEmpty()) {
@@ -335,6 +348,53 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
         query += ' ORDER BY ' + keyFieldOverrideForQuery + ', CreatedDate ASC';
 
         return query;
+    }
+
+    /**
+    * @description Get any additional where clause filter related to household settings
+    * @return String
+    */
+    private String getHouseholdSettingsFilter() {
+        npo02__Households_Settings__c householdSettings = UTIL_CustomSettingsFacade.getHouseholdsSettings();
+        String householdSettingsFilter;
+
+        if (householdSettings.npo02__Always_Rollup_to_Primary_Contact__c == false
+            && this.jobType == CRLP_RollupProcessingOptions.RollupType.ContactHardCredit) {
+            householdSettingsFilter = 'Account.npe01__SYSTEMIsIndividual__c = True';
+
+        } else if (householdSettings.npo02__Always_Rollup_to_Primary_Contact__c == false
+            && CRLP_Rollup_SVC.isOppContactRoleSoftCreditRollup(this.jobType)
+            ) {
+            householdSettingsFilter = '(IsPrimary = False OR Opportunity.Account.npe01__SYSTEMIsIndividual__c = False)';
+
+        } else if (householdSettings.npo02__Always_Rollup_to_Primary_Contact__c == true
+            && CRLP_Rollup_SVC.isOppContactRoleSoftCreditRollup(this.jobType)
+            ) {
+            householdSettingsFilter = 'IsPrimary = False';
+        }
+        return householdSettingsFilter;
+    }
+
+    /**
+    * @description Get additional where clause filter to narrow retrieval based on rollup type
+    * @return String
+    */
+    private String getAdditionalFilter() {
+        String additionalFilter;
+        if (detailObjectType == Opportunity.SObjectType) {
+            additionalFilter = CRLP_Query_SEL.buildCommonQueryFilterOnOpportunity(this.summaryObjectType, detailObjectType,
+                this.statefulCacheOfRollupsToBeProcessed);
+
+        } else if (this.jobType == CRLP_RollupProcessingOptions.RollupType.ContactSoftCredit) {
+            additionalFilter = CRLP_Query_SEL.buildCommonQueryFilterOnOpportunity(Contact.SObjectType, Partial_Soft_Credit__c.SObjectType);
+
+        } else if (this.jobType == CRLP_RollupProcessingOptions.RollupType.AccountContactSoftCredit) {
+            additionalFilter = CRLP_Query_SEL.buildCommonQueryFilterOnOpportunity(Account.SObjectType, Partial_Soft_Credit__c.SObjectType);
+
+        } else if (this.jobType == CRLP_RollupProcessingOptions.RollupType.AccountSoftCredit) {
+            additionalFilter = CRLP_Query_SEL.buildCommonQueryFilterOnOpportunity(this.summaryObjectType, this.detailObjectType);
+        }
+        return additionalFilter;
     }
 
     /**
@@ -457,9 +517,6 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
         }
         if (lastParentId != firstParentId && processor.getRollupDefsForParent(lastParentId) != null) {
             updateStatefulCollections(processor, lastParentId);
-        }
-        if (lastParentIdProcessed != lastParentId && lastParentIdProcessed != null && processor.getRollupDefsForParent(lastParentIdProcessed) != null) {
-            updateStatefulCollections(processor, lastParentIdProcessed);
         }
 
         // Remember which batch iteration this parent was last NOT updated

--- a/force-app/main/default/classes/CRLP_Batch_Base_Skew.cls
+++ b/force-app/main/default/classes/CRLP_Batch_Base_Skew.cls
@@ -145,8 +145,12 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
                 parentKeyField = parentKeyField.split('\\.')[1];
             }
 
-            Id firstParentId = getParentId(parentObjectField, detailRecords[0], parentKeyField);
-            Id lastParentId = getParentId(parentObjectField, detailRecords[detailRecords.size() - 1], parentKeyField);
+            Id firstParentId =
+                CRLP_Rollup_SVC.getParentIdFromRecord(detailRecords[0], parentKeyField, parentObjectField);
+            Id lastParentId =
+                CRLP_Rollup_SVC.getParentIdFromRecord(
+                    detailRecords[detailRecords.size() - 1], parentKeyField, parentObjectField
+                );
 
             // Get all parent records to be processed by this batch iteration
             List<Id> parentIds = getUniqueParentIds(this.summaryObjectType, detailRecords,
@@ -231,29 +235,13 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
         String parentKeyField
     ) {
         if (this.jobType == CRLP_RollupProcessingOptions.RollupType.GAU &&
-            lastParentId != getParentId(parentObjectField, detailRecords[detailRecords.size() - 1], parentKeyField)
+            lastParentId != CRLP_Rollup_SVC.getParentIdFromRecord(
+                detailRecords[detailRecords.size() - 1], parentKeyField, parentObjectField
+            )
         ) {
             return true;
         }
         return false;
-    }
-
-    /**
-    * @description Get the parent Id of the referenced detail record
-    * @param parentObjectField
-    * @param detailRecord
-    * @param parentKeyField
-    * @return Id
-    */
-    @TestVisible
-    private Id getParentId(String parentObjectField, SObject detailRecord, String parentKeyField) {
-        Id parentId;
-        if (parentObjectField == null) {
-            parentId = (Id) detailRecord.get(parentKeyField);
-        } else {
-            parentId = (Id) detailRecord.getSObject(parentObjectField).get(parentKeyField);
-        }
-        return parentId;
     }
 
     /********************************************************************************************************

--- a/force-app/main/default/classes/CRLP_Batch_Base_Skew.cls
+++ b/force-app/main/default/classes/CRLP_Batch_Base_Skew.cls
@@ -160,8 +160,8 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
             detailRecords = applyPostQueryLocatorFilters(detailRecords);
 
             // Check if we need to keep the last processed parent id
-            Boolean hasNoDetailsForLastParentId =
-                hasNoDetailsForLastParentId(lastParentId, parentObjectField, detailRecords, parentKeyField);
+            Boolean hasLastParentDetails =
+                hasLastParentDetails(lastParentId, parentObjectField, detailRecords, parentKeyField);
 
             // Map of Payment Child details by parent Opportunity (this job only handles Opportunity or Allocation
             // as the primary queryLocator).
@@ -193,7 +193,7 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
                 .withPreviouslyProcessedOppIdsMap(this.statefulMapOfOppIdsByParentId)
                 .withRollupDefinitions(this.statefulRollupsById)
                 .withJobOptions(options)
-                .withLastParentDetails(hasNoDetailsForLastParentId);
+                .withLastParentDetails(hasLastParentDetails);
 
             List<SObject> updatedRecords = processor.startRollupProcessing();
 
@@ -228,7 +228,7 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
     * @return Boolean true if lastParentId has no associated detail records in a GAU rollup
     */
     @TestVisible
-    private Boolean hasNoDetailsForLastParentId(
+    private Boolean hasLastParentDetails(
         Id lastParentId,
         String parentObjectField,
         List<SObject> detailRecords,
@@ -239,9 +239,9 @@ public abstract class CRLP_Batch_Base_Skew extends CRLP_Batch_Base {
                 detailRecords[detailRecords.size() - 1], parentKeyField, parentObjectField
             )
         ) {
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 
     /********************************************************************************************************

--- a/force-app/main/default/classes/CRLP_GAU_BATCH_TEST.cls
+++ b/force-app/main/default/classes/CRLP_GAU_BATCH_TEST.cls
@@ -1,0 +1,86 @@
+/*
+    Copyright (c) 2021, Salesforce.org
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+* @author Salesforce.org
+* @date 2021
+* @group Customizable Rollups Operations Services
+* @description Unit Tests for the GAU Batch class
+*/
+@IsTest(IsParallel=true)
+private with sharing class CRLP_GAU_BATCH_TEST {
+
+    @IsTest
+    private static void shouldDetermineLastParentIdHasNoDetails() {
+        String parentKeyField = 'General_Accounting_Unit__c';
+
+        General_Accounting_Unit__c gau = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+
+        List<Allocation__c> detailRecords = new List<Allocation__c> {
+            new Allocation__c(
+                Id = UTIL_UnitTestData_TEST.mockId(Allocation__c.SObjectType),
+                General_Accounting_Unit__c = gau.Id,
+                General_Accounting_Unit__r = gau)
+        };
+
+        CRLP_GAU_BATCH gauBatch = new CRLP_GAU_BATCH(CRLP_RollupProcessingOptions.RollupTypeFilter.All);
+        Id lastParentId = gau2.Id;
+        System.assertEquals(true,
+            gauBatch.hasNoDetailsForLastParentId(lastParentId, null, detailRecords, parentKeyField));
+    }
+
+    @IsTest
+    private static void shouldDetermineLastParentIdHasDetails() {
+        String parentKeyField = 'General_Accounting_Unit__c';
+
+        General_Accounting_Unit__c gau = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+
+        List<Allocation__c> detailRecords = new List<Allocation__c> {
+            new Allocation__c(
+                Id = UTIL_UnitTestData_TEST.mockId(Allocation__c.SObjectType),
+                General_Accounting_Unit__c = gau.Id,
+                General_Accounting_Unit__r = gau),
+            new Allocation__c(
+                Id = UTIL_UnitTestData_TEST.mockId(Allocation__c.SObjectType),
+                General_Accounting_Unit__c = gau2.Id,
+                General_Accounting_Unit__r = gau2)
+        };
+
+        CRLP_GAU_BATCH gauBatch = new CRLP_GAU_BATCH();
+        Id lastParentId = gau2.Id;
+        System.assertEquals(false,
+            gauBatch.hasNoDetailsForLastParentId(lastParentId, null, detailRecords, parentKeyField));
+    }
+}

--- a/force-app/main/default/classes/CRLP_GAU_BATCH_TEST.cls
+++ b/force-app/main/default/classes/CRLP_GAU_BATCH_TEST.cls
@@ -54,8 +54,8 @@ private with sharing class CRLP_GAU_BATCH_TEST {
 
         CRLP_GAU_BATCH gauBatch = new CRLP_GAU_BATCH(CRLP_RollupProcessingOptions.RollupTypeFilter.All);
         Id lastParentId = gau2.Id;
-        System.assertEquals(true,
-            gauBatch.hasNoDetailsForLastParentId(lastParentId, null, detailRecords, parentKeyField));
+        System.assertEquals(false,
+            gauBatch.hasLastParentDetails(lastParentId, null, detailRecords, parentKeyField));
     }
 
     @IsTest
@@ -80,7 +80,7 @@ private with sharing class CRLP_GAU_BATCH_TEST {
 
         CRLP_GAU_BATCH gauBatch = new CRLP_GAU_BATCH();
         Id lastParentId = gau2.Id;
-        System.assertEquals(false,
-            gauBatch.hasNoDetailsForLastParentId(lastParentId, null, detailRecords, parentKeyField));
+        System.assertEquals(true,
+            gauBatch.hasLastParentDetails(lastParentId, null, detailRecords, parentKeyField));
     }
 }

--- a/force-app/main/default/classes/CRLP_GAU_BATCH_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CRLP_GAU_BATCH_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/CRLP_GAU_BATCH_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/CRLP_GAU_BATCH_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CRLP_RollupProcessor.cls
+++ b/force-app/main/default/classes/CRLP_RollupProcessor.cls
@@ -81,6 +81,11 @@ public inherited sharing class CRLP_RollupProcessor {
     private Id lastParentIdProcessed;
 
     /**
+    * @description used to flag a condition that requires us NOT to remove lastParentIdProcessed defs.
+    */
+    private Boolean hasNoDetailsForLastParent = false;
+
+    /**
      * @description Used to return a true to the calling LDV class when the last parent Id was removed from
      * the list of updated SObjects
      */
@@ -182,6 +187,15 @@ public inherited sharing class CRLP_RollupProcessor {
      */
     public CRLP_RollupProcessor withRelatedRecords(Map<Id, List<SObject>> relatedRecords) {
         this.relatedRecordsByDetailId = relatedRecords;
+        return this;
+    }
+
+    /**
+     * @description Inject the value of hasNoDetailsForLastParent - used to prevent removal
+     * of lastParentIdProcessed. Optional.
+     */
+    public CRLP_RollupProcessor withLastParentDetails(Boolean hasNoDetailsForLastParent) {
+        this.hasNoDetailsForLastParent = hasNoDetailsForLastParent;
         return this;
     }
 
@@ -421,8 +435,9 @@ public inherited sharing class CRLP_RollupProcessor {
         // the LDV Batch job.
         lastParentIdRemovedFromUpdatesList = false;
         if (isSkewMode
-                && lastParentIdProcessed != null
-                && recordsToUpdate.containsKey(lastParentIdProcessed)
+            && lastParentIdProcessed != null
+            && recordsToUpdate.containsKey(lastParentIdProcessed)
+            && !hasNoDetailsForLastParent
         ) {
             recordsToUpdate.remove(lastParentIdProcessed);
             lastParentIdRemovedFromUpdatesList = true;

--- a/force-app/main/default/classes/CRLP_RollupProcessor.cls
+++ b/force-app/main/default/classes/CRLP_RollupProcessor.cls
@@ -83,12 +83,14 @@ public inherited sharing class CRLP_RollupProcessor {
     /**
     * @description used to flag a condition that requires us NOT to remove lastParentIdProcessed defs.
     */
+    @TestVisible
     private Boolean hasNoDetailsForLastParent = false;
 
     /**
      * @description Used to return a true to the calling LDV class when the last parent Id was removed from
      * the list of updated SObjects
      */
+    @TestVisible
     private Boolean lastParentIdRemovedFromUpdatesList = false;
 
     /**

--- a/force-app/main/default/classes/CRLP_RollupProcessor.cls
+++ b/force-app/main/default/classes/CRLP_RollupProcessor.cls
@@ -81,10 +81,10 @@ public inherited sharing class CRLP_RollupProcessor {
     private Id lastParentIdProcessed;
 
     /**
-    * @description used to flag a condition that requires us NOT to remove lastParentIdProcessed defs.
+    * @description used to flag whether lastParentId has associated detail records..
     */
     @TestVisible
-    private Boolean hasNoDetailsForLastParent = false;
+    private Boolean hasLastParentDetails = true;
 
     /**
      * @description Used to return a true to the calling LDV class when the last parent Id was removed from
@@ -193,11 +193,11 @@ public inherited sharing class CRLP_RollupProcessor {
     }
 
     /**
-     * @description Inject the value of hasNoDetailsForLastParent - used to prevent removal
+     * @description Inject the value of hasLastParentDetails - used to prevent removal
      * of lastParentIdProcessed. Optional.
      */
-    public CRLP_RollupProcessor withLastParentDetails(Boolean hasNoDetailsForLastParent) {
-        this.hasNoDetailsForLastParent = hasNoDetailsForLastParent;
+    public CRLP_RollupProcessor withLastParentDetails(Boolean hasLastParentDetails) {
+        this.hasLastParentDetails = hasLastParentDetails;
         return this;
     }
 
@@ -439,7 +439,7 @@ public inherited sharing class CRLP_RollupProcessor {
         if (isSkewMode
             && lastParentIdProcessed != null
             && recordsToUpdate.containsKey(lastParentIdProcessed)
-            && !hasNoDetailsForLastParent
+            && this.hasLastParentDetails
         ) {
             recordsToUpdate.remove(lastParentIdProcessed);
             lastParentIdRemovedFromUpdatesList = true;

--- a/force-app/main/default/classes/CRLP_RollupProcessor_TEST.cls
+++ b/force-app/main/default/classes/CRLP_RollupProcessor_TEST.cls
@@ -655,8 +655,10 @@ private class CRLP_RollupProcessor_TEST {
             Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
         General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(
             Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+        General_Accounting_Unit__c gau3 = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
 
-        List<General_Accounting_Unit__c> gauRecords = new List<General_Accounting_Unit__c>{gau, gau2};
+        List<General_Accounting_Unit__c> gauRecords = new List<General_Accounting_Unit__c>{gau, gau2, gau3};
 
         List<Allocation__c> allocRecords = new List<Allocation__c>{
             buildMockAllocation(gau, opp, null, opp.Amount),
@@ -673,7 +675,7 @@ private class CRLP_RollupProcessor_TEST {
             .withRollupType(CRLP_RollupProcessingOptions.RollupType.GAU)
             .withSummaryRecords(gauRecords)
             .withDetailRecords(allocRecords)
-            .withLastParentDetails(false)
+            .withLastParentDetails(true)
             .withJobOptions(options);
 
         System.assertEquals(Allocation__c.SObjectType, processor.detailObjectType);
@@ -706,17 +708,21 @@ private class CRLP_RollupProcessor_TEST {
 
         Opportunity opp = buildMockOpportunity(account.Id, 100);
         Opportunity opp2 = buildMockOpportunity(account.Id, 200);
+        Opportunity opp3 = buildMockOpportunity(account.Id, 300);
 
         General_Accounting_Unit__c gau = new General_Accounting_Unit__c(
             Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
         General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(
             Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+        General_Accounting_Unit__c gau3 = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
 
-        List<General_Accounting_Unit__c> gauRecords = new List<General_Accounting_Unit__c>{gau, gau2};
+        List<General_Accounting_Unit__c> gauRecords = new List<General_Accounting_Unit__c>{gau, gau2, gau3};
 
         List<Allocation__c> allocRecords = new List<Allocation__c>{
             buildMockAllocation(gau, opp, null, opp.Amount),
-            buildMockAllocation(gau2, opp2, null, opp2.Amount)
+            buildMockAllocation(gau2, opp2, null, opp2.Amount),
+            buildMockAllocation(gau3, opp3, null, opp3.Amount)
         };
 
         CRLP_RollupProcessingOptions.ProcessingOptions options = new CRLP_RollupProcessingOptions.ProcessingOptions();
@@ -729,7 +735,7 @@ private class CRLP_RollupProcessor_TEST {
             .withRollupType(CRLP_RollupProcessingOptions.RollupType.GAU)
             .withSummaryRecords(gauRecords)
             .withDetailRecords(allocRecords)
-            .withLastParentDetails(true)
+            .withLastParentDetails(false)
             .withJobOptions(options);
 
         System.assertEquals(Allocation__c.SObjectType, processor.detailObjectType);

--- a/force-app/main/default/classes/CRLP_RollupProcessor_TEST.cls
+++ b/force-app/main/default/classes/CRLP_RollupProcessor_TEST.cls
@@ -638,6 +638,118 @@ private class CRLP_RollupProcessor_TEST {
             'CustomizableRollups_UseSkewMode__c should be true if at threshold and running in nonskew mode.');
     }
 
+    /**
+     * @description Verify that lastParentIdProcessed is not removed from recordsToUpdate when detail records do not
+     * exist for lastParentId.
+     */
+    @IsTest
+    private static void shouldRemoveLastParentIdFromRecordsToUpdate() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+
+        Account account = buildMockAccount();
+
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
+        Opportunity opp2 = buildMockOpportunity(account.Id, 200);
+
+        General_Accounting_Unit__c gau = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+
+        List<General_Accounting_Unit__c> gauRecords = new List<General_Accounting_Unit__c>{gau, gau2};
+
+        List<Allocation__c> allocRecords = new List<Allocation__c>{
+            buildMockAllocation(gau, opp, null, opp.Amount),
+            buildMockAllocation(gau2, opp2, null, opp2.Amount)
+        };
+
+        CRLP_RollupProcessingOptions.ProcessingOptions options = new CRLP_RollupProcessingOptions.ProcessingOptions();
+        options.useRollupDefsByParentIdMap = true;
+
+        Test.startTest();
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.GAU)
+            .withSummaryRecords(gauRecords)
+            .withDetailRecords(allocRecords)
+            .withLastParentDetails(false)
+            .withJobOptions(options);
+
+        System.assertEquals(Allocation__c.SObjectType, processor.detailObjectType);
+        System.assertEquals(UTIL_Namespace.StrAllNSPrefix('General_Accounting_Unit__c'), processor.parentKeyField);
+        System.assertEquals(UTIL_Namespace.StrAllNSPrefix('General_Accounting_Unit__c'), processor.parentRelationshipField);
+        System.assertEquals(null, processor.parentRelationshipObject);
+
+        System.assertEquals(true, processor.isSkewMode);
+
+        // Run the Account through the Skew Mode processor.
+        List<SObject> updatedRecords = processor.startRollupProcessing();
+
+        Test.stopTest();
+
+        System.assert(!updatedRecords.isEmpty());
+        System.assertNotEquals(null, processor.getLastParentIdProcessed());
+        System.assertEquals(true, processor.hasLastParentIdCompleted());
+        System.assertEquals(true, processor.lastParentIdRemovedFromUpdatesList);
+    }
+
+    /**
+     * @description Verify that lastParentIdProcessed is removed from recordsToUpdate when detail records
+     * exist for lastParentId.
+     */
+    @IsTest
+    private static void shouldNotRemoveLastParentIdFromRecordsToUpdate() {
+        CMT_UnitTestData_TEST.mockFullSetOfRollupDefinitions();
+
+        Account account = buildMockAccount();
+
+        Opportunity opp = buildMockOpportunity(account.Id, 100);
+        Opportunity opp2 = buildMockOpportunity(account.Id, 200);
+
+        General_Accounting_Unit__c gau = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(
+            Id = UTIL_UnitTestData_TEST.mockId(General_Accounting_Unit__c.SObjectType));
+
+        List<General_Accounting_Unit__c> gauRecords = new List<General_Accounting_Unit__c>{gau, gau2};
+
+        List<Allocation__c> allocRecords = new List<Allocation__c>{
+            buildMockAllocation(gau, opp, null, opp.Amount),
+            buildMockAllocation(gau2, opp2, null, opp2.Amount)
+        };
+
+        CRLP_RollupProcessingOptions.ProcessingOptions options = new CRLP_RollupProcessingOptions.ProcessingOptions();
+        options.useRollupDefsByParentIdMap = true;
+
+        Test.startTest();
+
+        CRLP_RollupProcessor processor = new CRLP_RollupProcessor()
+            .withBatchJobMode(CRLP_RollupProcessingOptions.BatchJobMode.SkewMode)
+            .withRollupType(CRLP_RollupProcessingOptions.RollupType.GAU)
+            .withSummaryRecords(gauRecords)
+            .withDetailRecords(allocRecords)
+            .withLastParentDetails(true)
+            .withJobOptions(options);
+
+        System.assertEquals(Allocation__c.SObjectType, processor.detailObjectType);
+        System.assertEquals(UTIL_Namespace.StrAllNSPrefix('General_Accounting_Unit__c'), processor.parentKeyField);
+        System.assertEquals(UTIL_Namespace.StrAllNSPrefix('General_Accounting_Unit__c'), processor.parentRelationshipField);
+        System.assertEquals(null, processor.parentRelationshipObject);
+
+        System.assertEquals(true, processor.isSkewMode);
+
+        // Run the Account through the Skew Mode processor.
+        List<SObject> updatedRecords = processor.startRollupProcessing();
+
+        Test.stopTest();
+
+        System.assert(!updatedRecords.isEmpty());
+        System.assertNotEquals(null, processor.getLastParentIdProcessed());
+        System.assertEquals(false, processor.hasLastParentIdCompleted());
+        System.assertEquals(false, processor.lastParentIdRemovedFromUpdatesList);
+    }
+
     // **************************** HELPER METHODS ****************************
 
     /**
@@ -738,6 +850,22 @@ private class CRLP_RollupProcessor_TEST {
             Contact__r = con,
             Role_Name__c = UTIL_CustomSettingsFacade.DEFAULT_OPPORTUNITY_CONTACT_ROLE_DONOR,
             Contact_Role_Id__c = ocr.Id,
+            Amount__c = amt
+        );
+    }
+
+    /**
+     * @description Instantiate a mock Allocation__c record
+     */
+    private static Allocation__c buildMockAllocation(General_Accounting_Unit__c gau,
+        Opportunity opp, Campaign cam, Decimal amt
+    ) {
+        return new Allocation__c(
+            Id = UTIL_UnitTestData_TEST.mockId(Allocation__c.SObjectType),
+            General_Accounting_Unit__c = gau.Id,
+            General_Accounting_Unit__r = gau,
+            Opportunity__c = opp.Id,
+            Opportunity__r = opp,
             Amount__c = amt
         );
     }


### PR DESCRIPTION
We fixed an issue that could cause a single General Accounting Unit rollup record to have zeroed out totals
# Critical Changes

# Changes

# Issues Closed
Fixes #6204 

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
