### PR TITLE
RD2: Update non-Elevate fields on Closed Elevate RD

### DIFF
--- a/force-app/main/default/classes/RD2_EntryFormController.cls
+++ b/force-app/main/default/classes/RD2_EntryFormController.cls
@@ -86,7 +86,8 @@ public with sharing class RD2_EntryFormController {
             'InstallmentPeriodPermissions' => getFieldPermissionsMap('npe03__Installment_Period__c'),
             'InstallmentFrequencyPermissions' => getFieldPermissionsMap(UTIL_Namespace.StrTokenNSPrefix('InstallmentFrequency__c')),
             'customFieldSets' => getCustomFieldSectionFields(),
-            'isElevateCustomer' => RD2_ElevateIntegrationService.isIntegrationEnabled()
+            'isElevateCustomer' => RD2_ElevateIntegrationService.isIntegrationEnabled(),
+            'closedStatusValues' => RD2_StatusMapper.getInstance().getClosedStatusValues()
         };
     }
 

--- a/force-app/main/default/classes/RD2_ValidationService.cls
+++ b/force-app/main/default/classes/RD2_ValidationService.cls
@@ -241,7 +241,7 @@ public with sharing class RD2_ValidationService {
             validateStatus(rd, errorCollection);
             validateDayOfMonthChange(rd, oldRd, errorCollection);
             validateElevateRDCampaignCannotUpdateToEmpty(rd, oldRd, errorCollection);
-            validateCloseElevateReucrringDonation(rd, oldRd, errorCollection);
+            validateClosedElevateRecurringDonation(rd, oldRd, errorCollection);
 
             Boolean isValid = validateDonorChange(rd, oldRd, errorCollection);
             if (isValid) {
@@ -258,13 +258,17 @@ public with sharing class RD2_ValidationService {
         return errorRecords;
     }
 
-    private void validateCloseElevateReucrringDonation(npe03__Recurring_Donation__c rd, npe03__Recurring_Donation__c oldRd, ErrorRecord errorCollection) {
+    private void validateClosedElevateRecurringDonation(npe03__Recurring_Donation__c rd, npe03__Recurring_Donation__c oldRd, ErrorRecord errorCollection) {
         RD2_RecurringDonation recurringDonation = new RD2_RecurringDonation(rd);
-        if (!recurringDonation.isElevateRecord() || !recurringDonation.isClosed()) {
-            return;
+        if (recurringDonation.isClosed()
+            && recurringDonation.isElevateRecord()
+            && isElevateFieldChanged(rd, oldRd)) {
+                errorCollection.addError(System.Label.RD2_ElevateRDCannotChangeElevateFields);
         }
+    }
 
-        Boolean isElevateFieldChange = rd.npe03__Contact__c != oldRd.npe03__Contact__c
+    private Boolean isElevateFieldChanged(npe03__Recurring_Donation__c rd, npe03__Recurring_Donation__c oldRd) {
+        return rd.npe03__Contact__c != oldRd.npe03__Contact__c
         || rd.npe03__Organization__c != oldRd.npe03__Organization__c
         || rd.PaymentMethod__c != oldRd.PaymentMethod__c
         || rd.npe03__Recurring_Donation_Campaign__c != oldRd.npe03__Recurring_Donation_Campaign__c
@@ -274,11 +278,6 @@ public with sharing class RD2_ValidationService {
         || rd.StartDate__c != oldRd.StartDate__c
         || rd.npe03__Date_Established__c != oldRd.npe03__Date_Established__c
         || rd.Day_of_Month__c != oldRd.Day_of_Month__c;
-
-        if (isElevateFieldChange) {
-            errorCollection.addError(System.Label.RD2_ElevateRDCannotChangeElevateFields);
-        }
-        
     }
 
     private void validatePaymentMethod(RD2_RecurringDonation recurringDonation, ErrorRecord errorCollection) {

--- a/force-app/main/default/classes/RD2_ValidationService.cls
+++ b/force-app/main/default/classes/RD2_ValidationService.cls
@@ -241,6 +241,7 @@ public with sharing class RD2_ValidationService {
             validateStatus(rd, errorCollection);
             validateDayOfMonthChange(rd, oldRd, errorCollection);
             validateElevateRDCampaignCannotUpdateToEmpty(rd, oldRd, errorCollection);
+            validateCloseElevateReucrringDonation(rd, oldRd, errorCollection);
 
             Boolean isValid = validateDonorChange(rd, oldRd, errorCollection);
             if (isValid) {
@@ -255,6 +256,29 @@ public with sharing class RD2_ValidationService {
         }
 
         return errorRecords;
+    }
+
+    private void validateCloseElevateReucrringDonation(npe03__Recurring_Donation__c rd, npe03__Recurring_Donation__c oldRd, ErrorRecord errorCollection) {
+        RD2_RecurringDonation recurringDonation = new RD2_RecurringDonation(rd);
+        if (!recurringDonation.isElevateRecord() || !recurringDonation.isClosed()) {
+            return;
+        }
+
+        Boolean isElevateFieldChange = rd.npe03__Contact__c != oldRd.npe03__Contact__c
+        || rd.npe03__Organization__c != oldRd.npe03__Organization__c
+        || rd.PaymentMethod__c != oldRd.PaymentMethod__c
+        || rd.npe03__Recurring_Donation_Campaign__c != oldRd.npe03__Recurring_Donation_Campaign__c
+        || rd.npe03__Amount__c != oldRd.npe03__Amount__c
+        || rd.InstallmentFrequency__c != oldRd.InstallmentFrequency__c
+        || rd.npe03__Installment_Period__c != oldRd.npe03__Installment_Period__c
+        || rd.StartDate__c != oldRd.StartDate__c
+        || rd.npe03__Date_Established__c != oldRd.npe03__Date_Established__c
+        || rd.Day_of_Month__c != oldRd.Day_of_Month__c;
+
+        if (isElevateFieldChange) {
+            errorCollection.addError(System.Label.RD2_ElevateRDCannotChangeElevateFields);
+        }
+        
     }
 
     private void validatePaymentMethod(RD2_RecurringDonation recurringDonation, ErrorRecord errorCollection) {

--- a/force-app/main/default/classes/RD2_ValidationService_TEST.cls
+++ b/force-app/main/default/classes/RD2_ValidationService_TEST.cls
@@ -1363,7 +1363,7 @@ private with sharing class RD2_ValidationService_TEST {
     }
 
     @isTest
-    private static void test123test34() {
+    private static void shouldAllowClosedElevateRDUpdateWhenNotElevateRelatedFieldIsChanged() {
         RD2_EnablementService_TEST.setRecurringDonations2Enabled();
 
         PS_IntegrationServiceConfig_TEST.Stub configStub = new PS_IntegrationServiceConfig_TEST.Stub()

--- a/force-app/main/default/classes/RD2_ValidationService_TEST.cls
+++ b/force-app/main/default/classes/RD2_ValidationService_TEST.cls
@@ -1327,6 +1327,76 @@ private with sharing class RD2_ValidationService_TEST {
         }
     }
 
+    @isTest
+    private static void shouldNotAllowClosedElevateRDUpdateWhenElevateRelatedFieldIsChanged() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        PS_IntegrationServiceConfig_TEST.Stub configStub = new PS_IntegrationServiceConfig_TEST.Stub()
+            .withIsIntegrationEnabled(true)
+            .withHasIntegrationPermissions(true);
+        RD2_ElevateIntegrationService.config = (PS_IntegrationServiceConfig) Test.createStub(
+            PS_IntegrationServiceConfig.class,
+            configStub
+        );
+
+        npe03__Recurring_Donation__c oldRd = getRecurringDonationBuilder()
+            .withContact(getContact().Id)
+            .withStatusClosed()
+            .withPaymentMethod(RD2_Constants.PAYMENT_PICKLIST_VALUE_CARD)
+            .withCommitmentId(RD2_ElevateIntegrationService_TEST.COMMITMENT_ID)
+            .build();
+        
+        npe03__Recurring_Donation__c rd = oldRd.clone();
+        rd.npe03__Amount__c = oldRd.npe03__Amount__c + 1;
+
+        RD2_ValidationService validationService = new RD2_ValidationService(
+            new List<npe03__Recurring_Donation__c>{rd},
+            new List<npe03__Recurring_Donation__c>{oldRd}
+        );
+
+        Test.startTest();
+        List<RD2_ValidationService.ErrorRecord> errorRecords = validationService.validate();
+        Test.stopTest();
+
+        System.assertEquals(System.Label.RD2_ElevateRDCannotChangeElevateFields, errorRecords[0].getFirstError(),
+            System.Label.RD2_ElevateRDCannotChangeElevateFields);
+    }
+
+    @isTest
+    private static void test123test34() {
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        PS_IntegrationServiceConfig_TEST.Stub configStub = new PS_IntegrationServiceConfig_TEST.Stub()
+            .withIsIntegrationEnabled(true)
+            .withHasIntegrationPermissions(true);
+        RD2_ElevateIntegrationService.config = (PS_IntegrationServiceConfig) Test.createStub(
+            PS_IntegrationServiceConfig.class,
+            configStub
+        );
+
+        npe03__Recurring_Donation__c oldRd = getRecurringDonationBuilder()
+            .withContact(getContact().Id)
+            .withStatusClosed()
+            .withPaymentMethod(RD2_Constants.PAYMENT_PICKLIST_VALUE_CARD)
+            .withCommitmentId(RD2_ElevateIntegrationService_TEST.COMMITMENT_ID)
+            .build();
+        
+        npe03__Recurring_Donation__c rd = oldRd.clone();
+        rd.Name = 'random text';
+
+        RD2_ValidationService validationService = new RD2_ValidationService(
+            new List<npe03__Recurring_Donation__c>{rd},
+            new List<npe03__Recurring_Donation__c>{oldRd}
+        );
+
+        Test.startTest();
+        List<RD2_ValidationService.ErrorRecord> errorRecords = validationService.validate();
+        Test.stopTest();
+
+        System.assertEquals(0, errorRecords.size(),
+            'There should be no error when updating Closed Elevate RD non-elevate related fields');
+    }
+
     // Helper Methods
     /////////////////////
 

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -1762,6 +1762,14 @@
         <value>Please enter a new Effective Date. The Effective Date for an Elevate Recurring Donation cannot be in the future.</value>
     </labels>
     <labels>
+        <fullName>RD2_ElevateRDCannotChangeElevateFields</fullName>
+        <categories>Recurring-Donations</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Checks if Closed Elevate Recurring Donation&apos;s Elevate fields have been modified</shortDescription>
+        <value>You can&apos;t edit the donor, amount, schedule, or campaign fields on a Closed Elevate-connected Recurring Donation.</value>
+    </labels>
+    <labels>
         <fullName>RD2_ElevateRDCampaignCannotUpdateToNull</fullName>
         <categories>Recurring-Donations</categories>
         <language>en_US</language>

--- a/force-app/main/default/lwc/rd2EntryForm/__tests__/data/getRecurringSettings.json
+++ b/force-app/main/default/lwc/rd2EntryForm/__tests__/data/getRecurringSettings.json
@@ -12,5 +12,6 @@
     "Visible": true
   },
   "customFieldSets": [],
-  "isElevateCustomer": true
+  "isElevateCustomer": true,
+  "closedStatusValues": ["Closed"]
 }

--- a/force-app/main/default/lwc/rd2EntryForm/rd2EntryForm.html
+++ b/force-app/main/default/lwc/rd2EntryForm/rd2EntryForm.html
@@ -86,6 +86,7 @@
                                             <lightning-input-field
                                                     data-id="status"
                                                     field-name={fields.status.apiName}
+                                                    onchange={handleStatusChange}
                                                     required>
                                             </lightning-input-field>
                                         </lightning-layout-item>

--- a/force-app/main/default/lwc/rd2EntryForm/rd2EntryForm.js
+++ b/force-app/main/default/lwc/rd2EntryForm/rd2EntryForm.js
@@ -643,15 +643,17 @@ export default class rd2EntryForm extends LightningElement {
     }
 
     /***
-    * @description Determines if new or existing Recurring Donation is an Elevate recurring commitment
+    * @description Determines if new or existing Recurring Donation update should send to Elevate
     */
     shouldSendToElevate(allFields) {
         if (!this.isElevateCustomer) {
             return false;
         }
-
+    
         return this.isElevateWidgetDisplayed()
-            || (this.hasElevateFieldsChange(allFields) && !isEmpty(this.getCommitmentId()));
+            || (this.hasElevateFieldsChange(allFields) 
+                && !isEmpty(this.getCommitmentId())
+                && getFieldValue(this.record, FIELD_STATUS) !== STATUS_CLOSED);
     }
 
     /***

--- a/force-app/main/default/lwc/rd2EntryForm/rd2EntryForm.js
+++ b/force-app/main/default/lwc/rd2EntryForm/rd2EntryForm.js
@@ -64,8 +64,6 @@ import CONTACT_LAST_NAME from '@salesforce/schema/Contact.LastName';
 import ACCOUNT_NAME from '@salesforce/schema/Account.Name';
 import ACCOUNT_PRIMARY_CONTACT_LAST_NAME from '@salesforce/schema/Account.npe01__One2OneContact__r.LastName';
 
-
-const STATUS_CLOSED = 'Closed';
 const RECURRING_TYPE_OPEN = 'Open';
 const ELEVATE_SUPPORTED_COUNTRIES = ['US', 'USA', 'United States', 'United States of America'];
 const ELEVATE_SUPPORTED_CURRENCIES = ['USD'];
@@ -140,6 +138,7 @@ export default class rd2EntryForm extends LightningElement {
     accountHolderType;
     recurringPeriod;
     periodType;
+    closedStatusValues;
 
     contact = {
         MailingCountry: null
@@ -206,6 +205,7 @@ export default class rd2EntryForm extends LightningElement {
                 this.customFields = response.customFieldSets;
                 this.hasCustomFields = Object.keys(this.customFields).length !== 0;
                 this.isElevateCustomer = response.isElevateCustomer;
+                this.closedStatusValues = response.closedStatusValues;
             })
             .catch((error) => {
                 this.handleError(error);
@@ -426,7 +426,7 @@ export default class rd2EntryForm extends LightningElement {
     evaluateElevateEditWidget() {
         const statusField = getFieldValue(this.record, FIELD_STATUS);
 
-        if (this.isElevateCustomer && this.isEdit && statusField !== STATUS_CLOSED) {
+        if (this.isElevateCustomer && this.isEdit && !this.closedStatusValues.includes(statusField)) {
             const recurringType = this.getRecurringType();
 
             // Since the widget requires interaction to Edit, this should start as true
@@ -653,7 +653,8 @@ export default class rd2EntryForm extends LightningElement {
         return this.isElevateWidgetDisplayed()
             || (this.hasElevateFieldsChange(allFields) 
                 && !isEmpty(this.getCommitmentId())
-                && getFieldValue(this.record, FIELD_STATUS) !== STATUS_CLOSED);
+                && !this.closedStatusValues.includes(getFieldValue(this.record, FIELD_STATUS))
+            );
     }
 
     /***


### PR DESCRIPTION
[W-9580620](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000QmHkYAK/view)
Fixes an issue when editing a Closed Elevate Recurring Donation, a misleading error will display block the update

# Critical Changes

# Changes

# Issues Closed
 Fixes #6650
# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers
Allow users to edit Closed Elevate Recurring Donations when the fields changes are not related to Elevate Service.

# New Metadata
- Custom Label: RD2_ElevateRDCannotChangeElevateFields

# Deleted Metadata
