### PR TITLE
W-8256939 - Payment Allocations - Recurring Donations Updates to Allocation not Propagating to Payment Allocations for Open Opportunities

### DIFF
--- a/force-app/main/default/classes/ALLO_Allocations_TDTM.cls
+++ b/force-app/main/default/classes/ALLO_Allocations_TDTM.cls
@@ -42,6 +42,17 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
     /** @description Allocations settings. */
     public DmlWrapper dmlWrapper = new dmlWrapper();
 
+    /** @description Contains Record Ids for Any Opportunities whose Allocations were recreated as a result of a Recurring Donation Allocation change */
+    public Set<Id> updatedRecurringDonationOppIds {
+       public get {
+            if (updatedRecurringDonationOppIds == null) {
+                updatedRecurringDonationOppIds = new Set<Id>();
+            }
+            return updatedRecurringDonationOppIds;
+        }
+        private set;
+    }
+
     /** @description Allocations settings. */
     public static Allocations_Settings__c settings = UTIL_CustomSettingsFacade.getAllocationsSettings();
 
@@ -112,6 +123,10 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
         TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.flag.ALLOC, true);
         TDTM_TriggerHandler.processDML(dmlWrapper);
         dmlWrapper = null;
+
+        // Post processing of payment allocations is required if Payment Allocations is enabled and Recurring Donation Allocations were updated
+        recreateScheduledPaymentAllocationsIfNecessary();
+
         TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.flag.ALLOC, false);
 
         return null;
@@ -216,7 +231,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
         List<npe01__OppPayment__c> pmtsNeedingAllocations = new List<npe01__OppPayment__c>();
 
         //do not run if Payment allocations are disabled
-        if (settings.Payment_Allocations_Enabled__c != true) {
+        if (!isPaymentAllocationsEnabled()) {
             return;
         }
 
@@ -297,7 +312,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
             }
 
             //throw error if payment allocations are disabled and Payment__c is not null
-            if (settings.Payment_Allocations_Enabled__c != true && allo.Payment__c != null) {
+            if (!isPaymentAllocationsEnabled() && allo.Payment__c != null) {
                 allo.addError(Label.alloPaymentNotEnabled);
                 parentErrorDetected = true;
             }
@@ -511,6 +526,9 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
 
                 //first, delete all existing opp allocations
                 for (Opportunity opp : listRecDonOpps) {
+                    if (isPaymentAllocationsEnabled()) { // Record for further processing if Payment Allocations is enabled
+                        updatedRecurringDonationOppIds.add(opp.Id);
+                    }
                     if (mapWrapper.containsKey(opp.Id)){
                         alloWrapper oppWrap = mapWrapper.get(opp.Id);
                         dmlWrapper.objectsToDelete.addAll((List<SObject>)oppWrap.listAllo);
@@ -1174,6 +1192,59 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
     ********************************************************************************************************/
     @testVisible private static Decimal valueOrDefaultIfNull(Decimal val, Decimal defaultVal) {
         return (val != null) ? val : defaultVal;
+    }
+
+    /**
+     * @description Recreates the Scheduled Payment Allocations for Opportunities whose Allocations were updated as a
+     *              result of A Recurring Donations GAU Allocations being updated.
+     */
+    @testVisible private void recreateScheduledPaymentAllocationsIfNecessary() {
+        if (!isPaymentAllocationsEnabled() || updatedRecurringDonationOppIds.isEmpty()) {
+            return;
+        }
+
+        dmlWrapper = (dmlWrapper == null) ? new DMLWrapper() : dmlWrapper;
+
+        // Payment with Payment Allocations Query for Scheduled Payments related to Opportunities
+        // whose Allocations were recreated because the Recurring Donations Allocations changed
+        String pmtReviewQuery = 'SELECT     Id, ' +
+                                ' (SELECT Id FROM Allocations__r) ' +
+                                'FROM npe01__OppPayment__c ' +
+                                'WHERE npe01__Paid__c <> true AND ' +
+                                '      npe01__Written_Off__c <> true AND ' +
+                                '      npe01__Opportunity__c in :updatedRecurringDonationOppIds';
+
+        List<SObject> pmtsRequiringAllocationReview = Database.query(pmtReviewQuery);
+
+        List<SObject> pmtAllocations = new List<SObject>();
+        for (SObject pmtSObj : pmtsRequiringAllocationReview) {
+            npe01__OppPayment__c pmt = (npe01__OppPayment__c) pmtSObj;
+            if (pmt.Allocations__r != null && !pmt.Allocations__r.isEmpty()) {
+                dmlWrapper.objectsToDelete.addAll((List<SObject>)pmt.Allocations__r);
+            }
+        }
+
+        // Delete the existing Payment Allocations
+        TDTM_TriggerHandler.processDML(dmlWrapper);
+        dmlWrapper = null;
+
+        // Leverage the Allocations Service class to recreate the Payment Allocations
+        // Let it log the errors, if any occur.
+        ALLO_AllocationsService allocService = new ALLO_AllocationsService()
+                                                .withAllocationTriggersDisabled(true)
+                                                .withCommitAndClearRecordsEnabled(true);
+
+        // Process Allocations (Will Replicate Opportunity Allocations to Scheduled Payments without Allocations)
+        Set<Id> successfullyProcessedOppIds = allocService.processRecords(updatedRecurringDonationOppIds);
+    }
+
+    /**
+     * @description Wraps checks to see if Payment Allocations are enabled so it can be changed in one spot
+     *              in class later
+     * @return Boolean true if enabled
+     */
+    @testVisible private static Boolean isPaymentAllocationsEnabled() {
+        return (settings.Payment_Allocations_Enabled__c == true);
     }
 
 }

--- a/force-app/main/default/classes/ALLO_Allocations_TDTM.cls
+++ b/force-app/main/default/classes/ALLO_Allocations_TDTM.cls
@@ -1203,7 +1203,7 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
             return;
         }
 
-        dmlWrapper = (dmlWrapper == null) ? new DMLWrapper() : dmlWrapper;
+        DmlWrapper paDMLWrapper =  new DMLWrapper();
 
         // Payment with Payment Allocations Query for Scheduled Payments related to Opportunities
         // whose Allocations were recreated because the Recurring Donations Allocations changed
@@ -1220,13 +1220,12 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
         for (SObject pmtSObj : pmtsRequiringAllocationReview) {
             npe01__OppPayment__c pmt = (npe01__OppPayment__c) pmtSObj;
             if (pmt.Allocations__r != null && !pmt.Allocations__r.isEmpty()) {
-                dmlWrapper.objectsToDelete.addAll((List<SObject>)pmt.Allocations__r);
+                paDMLWrapper.objectsToDelete.addAll((List<SObject>)pmt.Allocations__r);
             }
         }
 
         // Delete the existing Payment Allocations
-        TDTM_TriggerHandler.processDML(dmlWrapper);
-        dmlWrapper = null;
+        TDTM_TriggerHandler.processDML(paDMLWrapper);
 
         // Leverage the Allocations Service class to recreate the Payment Allocations
         // Let it log the errors, if any occur.

--- a/force-app/main/default/classes/ALLO_Allocations_TEST.cls
+++ b/force-app/main/default/classes/ALLO_Allocations_TEST.cls
@@ -742,6 +742,116 @@ private with sharing class ALLO_Allocations_TEST {
     }
 
     /*******************************************************************************************************
+    * @description Recurring Donation Allocations test:
+    * Create recurring donation. Pledged opportunity is generated automatically with a default allocation.
+    * Scheduled Payment created with a default allocation.
+    * Create allocations for the recurring donation, verify opp allocations are created, default opp
+    * allocation is deleted.  verify payment allocations are created, default opp allocation is deleted.
+    * Set Payment to Written Off.  modify recurring donation allocations: Opportunity's allocations are
+    * updated, but Written Off Payment's Allocations are left unchanged/
+    ********************************************************************************************************/
+    static testMethod void recurringDonationsPaymentAllocationValidation() {
+        General_Accounting_Unit__c defaultgau = new General_Accounting_Unit__c(Name='General');
+        insert defaultgau;
+
+        setupSettings(new Allocations_Settings__c(
+                        Default_Allocations_Enabled__c = true,
+                        Payment_Allocations_Enabled__c = true,
+                        Default__c = defaultGau.Id
+        ));
+
+        Account acc = new Account(Name='foo');
+        insert acc;
+        General_Accounting_Unit__c gau = new General_Accounting_Unit__c(Name = 'rdGAU1');
+        General_Accounting_Unit__c gau2 = new General_Accounting_Unit__c(Name = 'rdGAU2');
+        List<General_Accounting_Unit__c> gaus = new List<General_Accounting_Unit__c> {gau, gau2};
+
+        insert gaus;
+
+
+        npe03__Recurring_Donation__c rd = new TEST_RecurringDonationBuilder()
+            .withInstallmentPeriodYearly()
+            .withDateEstablished(System.today())
+            .withAccount(acc.id)
+            .withAmount(20)
+            .withScheduleTypeMultiplyValue()
+            .withOpenEndedStatusOpen()
+            .build();
+
+        // this initial creation of the RD with default allocations set up, which get copied to the opp
+        // will be what we soql limit profile in this test (and thus the startTest/stopTest).
+        Test.startTest();
+        insert rd;
+        Test.stopTest();
+
+        //query for the opportunity automatically created by the schedule
+        list<Opportunity> queryOpp = [SELECT Id, npe03__Recurring_Donation__c, Amount, CloseDate, StageName FROM Opportunity WHERE npe03__Recurring_Donation__c = :rd.Id];
+        System.assertEquals(1,queryOpp.size(),'A single opportunity should be created.');
+
+        list<Allocation__c> queryAllo = getAllocationsOrderByPercent(queryOpp[0].Id);
+        System.assertEquals(1,queryAllo.size(),'A single default allocation should be created.');
+        System.assertEquals(defaultgau.Id,queryAllo[0].General_Accounting_Unit__c,'The allocation should be assigned to the default General Accounting Unit.');
+        System.assertEquals(20,queryAllo[0].Amount__c,'The default allocation should be for the total amount of the Opportunity.');
+
+        List<npe01__OppPayment__c> pmts = [SELECT   Id,
+                                                    npe01__Paid__c,
+                                                    npe01__Written_Off__c
+                                           FROM npe01__OppPayment__c
+                                           where npe01__Opportunity__c = :queryOpp[0].Id];
+        System.assertEquals(1, pmts.size(), 'A single payment should be created.');
+
+        Map<Id, Allocation__c> pmtAllocsByGAU = getPaymentAllocationsByGAU(pmts[0].Id);
+        System.assertEquals(1,pmtAllocsByGAU.size(),'A single default payment allocation should be created.');
+        System.assertEquals(true, pmtAllocsByGAU.containsKey(defaultgau.Id),'The Payment allocation should be assigned to the default General Accounting Unit.');
+        System.assertEquals(20, pmtAllocsByGAU.get(defaultgau.Id).Amount__c,'The default Payment allocation should be for the total amount of the Payment.');
+
+        list<Allocation__c> alloForInsert = new list<Allocation__c>();
+        Allocation__c percentAllo = new Allocation__c(Recurring_Donation__c = rd.Id, Percent__c = 50, General_Accounting_Unit__c = gau.Id);
+        alloForInsert.add(percentAllo);
+        Allocation__c amountAllo = new Allocation__c(Recurring_Donation__c = rd.Id, Amount__c = 10, General_Accounting_Unit__c = gau2.Id);
+        alloForInsert.add(amountAllo);
+        insert alloForInsert;
+
+        // Confirm Opportunity Allocations were updated to match the Recurring Donation Allocations
+        queryAllo = getAllocationsOrderByPercent(queryOpp[0].Id);
+        System.assertEquals(2,queryAllo.size(), 'Allocations for the open Recurring Donation Opportunity should be created automatically after they are created for the Recurring Donation.');
+        System.assertEquals(gau2.Id,queryAllo[0].General_Accounting_Unit__c, 'Allocations should be to the non-default GAU.');
+        System.assertEquals(gau.Id,queryAllo[1].General_Accounting_Unit__c, 'Allocations should be to the non-default GAU.');
+        System.assertEquals(10,queryAllo[0].Amount__c, 'The allocation amount should be set to a fixed amount.');
+        System.assertEquals(10,queryAllo[1].Amount__c, 'The percentage based allocation amount should be set based on the opportunity amount.');
+
+        // Confirm Payment Allocations were updated to match the Opportunity Allocations updates
+        pmtAllocsByGAU = getPaymentAllocationsByGAU(pmts[0].Id);
+        System.assertEquals(2, pmtAllocsByGAU.size(), 'Allocations for the scheduled Payment should be created automatically after they are updated for the Opportunity as a result of the Recurring Donation change.');
+        System.assertEquals(true, pmtAllocsByGAU.containsKey(gau.Id),'Allocations should be to the non-default GAU.');
+        System.assertEquals(true, pmtAllocsByGAU.containsKey(gau2.Id),'Allocations should be to the non-default GAU 2.');
+
+        System.assertEquals(10, pmtAllocsByGAU.get(gau.Id).Amount__c,'The amount of the allocation.');
+        System.assertEquals(10, pmtAllocsByGAU.get(gau2.Id).Amount__c,'The amount of the allocation.');
+
+        // Make Payment Written Off
+        pmts[0].npe01__Written_Off__c = true;
+        update pmts;
+
+        // Adjust the Recurring Donation Percent Allocation to 20%
+        percentAllo.Percent__c = 20;
+        update percentAllo;
+
+        // Confirm Opportunity Allocations were updated
+        queryAllo = getAllocationsOrderByPercent(queryOpp[0].Id);
+        System.assertEquals(3,queryAllo.size(), 'Allocations updated for the percentage change.');
+
+        // Confirm Payment Allocations were not updated since Payment is now Written Off
+        pmtAllocsByGAU = getPaymentAllocationsByGAU(pmts[0].Id);
+        System.assertEquals(2, pmtAllocsByGAU.size(), 'Allocations for the scheduled Payment should be created automatically after they are updated for the Opportunity as a result of the Recurring Donation change.');
+        System.assertEquals(true, pmtAllocsByGAU.containsKey(gau.Id),'Allocations should be to the non-default GAU.');
+        System.assertEquals(true, pmtAllocsByGAU.containsKey(gau2.Id),'Allocations should be to the non-default GAU 2.');
+
+        System.assertEquals(10, pmtAllocsByGAU.get(gau.Id).Amount__c,'The amount of the allocation.');
+        System.assertEquals(10, pmtAllocsByGAU.get(gau2.Id).Amount__c,'The amount of the allocation.');
+    }
+
+    /*******************************************************************************************************
     * @description Create a campaign with an allocation, and 100 opportunities, half of which are attributed
     * to the campaign. Verifies that default allocations and campaign allocations are created.
     * Updates all opportunity amounts to be equal to the campaign allocation amount, verifies that default
@@ -1354,6 +1464,23 @@ private with sharing class ALLO_Allocations_TEST {
      */
     private static Map<Id, Allocation__c> getPaymentAllocationsByGAU(Id paymentId) {
         List<Allocation__c> allocs = Database.query(getPaymentAllocationsQuery(paymentId).build());
+        Map<Id, Allocation__c> allocsByGAU = new Map<Id, Allocation__c>();
+
+        for (Allocation__c alloc : allocs) {
+            allocsByGAU.put(alloc.General_Accounting_Unit__c, alloc);
+        }
+        return allocsByGAU;
+    }
+
+        /**
+     * @description Gets a List of Allocations associated with a particular Opportunity
+     *              and builds a map by GAU of them.  Assumes only one allocation per
+     *              Opportunity and GAU, since it is a test
+     * @param  opportunityId Opportunity Id to retrieve Allocations for
+     * @return Allocations By GAU Id
+     */
+    private static Map<Id, Allocation__c> getOpportunityAllocationsByGAU(Id opportunityId) {
+        List<Allocation__c> allocs = Database.query(getAllocationsQuery(opportunityId).build());
         Map<Id, Allocation__c> allocsByGAU = new Map<Id, Allocation__c>();
 
         for (Allocation__c alloc : allocs) {


### PR DESCRIPTION
- Modified to call private method that checks whether Payment Allocations is enabled, rather than having logic replicated throughout class
- [IF Payment Allocations are Enabled]  Modified to keep track of Opportunities Record Ids whose Allocations were recreated as a result of a Recurring Donations Allocation Update
- [IF Payment Allocations are Enabled] Modified to recreate Scheduled Payment's Payment Allocations associated with Opportunities whose Allocations were recreated for Recurring Donations changes

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
