### PR TITLE
Check for Field Permission When Adding Undeliverable Address to Contact Merge Page

### DIFF
--- a/force-app/main/default/classes/CON_ContactMerge_CTRL.cls
+++ b/force-app/main/default/classes/CON_ContactMerge_CTRL.cls
@@ -712,16 +712,20 @@ public with sharing class CON_ContactMerge_CTRL {
 
     private List<String> buildSortedCustomFieldList(Map<String, DescribeFieldResult> customFieldMap) {
         List<String> customFields = new List<String>();
-        String undeliverableFieldName = String.valueOf(Contact.Undeliverable_Address__c).toLowerCase();
+        DescribeFieldResult undeliverableFieldDescribeResult = Contact.Undeliverable_Address__c.getDescribe();
 
         for (String fieldName : customFieldMap.keySet()) {
-            if (fieldName == undeliverableFieldName) {
+            if (fieldName == undeliverableFieldDescribeResult.getName()) {
                 continue;
             }
             customFields.add(fieldName);
         }
+
         customFields.sort();
-        customFields.add(0, undeliverableFieldName);
+        if (UTIL_Permissions.canRead(undeliverableFieldDescribeResult, false) &&
+                UTIL_Permissions.canUpdate(undeliverableFieldDescribeResult, false)) {
+            customFields.add(0, undeliverableFieldDescribeResult.getName().toLowerCase());
+        }
 
         return customFields;
     }


### PR DESCRIPTION
Add field-level security checking before adding the undeliverable address field to the contact merge page.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
