### PR TITLE
[a11y] Making error messages more descriptive on Edit Level Page

### DIFF
--- a/force-app/main/default/classes/LVL_LevelEdit_CTRL.cls
+++ b/force-app/main/default/classes/LVL_LevelEdit_CTRL.cls
@@ -37,6 +37,7 @@ public with sharing class LVL_LevelEdit_CTRL {
 
     /** @description holds the Level currently being edited by the page */
     public Level__c lvl {get; set;}
+    private List<String> requiredFieldSetFields;
     
     /*******************************************************************************************************
     * @description constructor for the page
@@ -50,7 +51,11 @@ public with sharing class LVL_LevelEdit_CTRL {
         fieldSetList.add(UTIL_Namespace.StrTokenNSPrefix('Engagement_Plan_Template__c'));
         if (!Test.isRunningTest()) controller.addFields(fieldSetList);
         lvl = (Level__c)controller.getRecord();
-        
+
+        // Keep track of which fields in the Field Set are required so we can create custom error messages
+        requiredFieldSetFields = UTIL_Describe.listStrFromFieldSet(UTIL_Namespace.StrTokenNSPrefix('Level__c'),
+            UTIL_Namespace.StrTokenNSPrefix('LevelEdit'), true);
+
         //if clone param is set, this is the clone button override
         Map<String,String> params = ApexPages.currentPage().getParameters();
         if (params.containsKey('clone') && params.get('clone') == '1') {
@@ -150,7 +155,11 @@ public with sharing class LVL_LevelEdit_CTRL {
     */
     public PageReference saveAndNew() {
         try {
-            upsert lvl;
+            if (!reportFieldSetErrors()) {
+                upsert lvl;
+            } else {
+                return null;
+            }
             // now fixup lvl to be the new next level
             lvl.Id = null;
             lvl.Name = null;
@@ -170,11 +179,31 @@ public with sharing class LVL_LevelEdit_CTRL {
     */
     public PageReference save() {
         try {
-            upsert lvl;
+            if (!reportFieldSetErrors()) {
+                upsert lvl;
+            } else {
+                return null;
+            }
             return new PageReference('/' + lvl.Id);
         } catch (Exception ex) {
             ApexPages.addMessages(ex);            
             return null;
         }
     }
+
+    /*********************************************************************************************************
+    * @description Add errors to required Field Set fields that are empty
+    */
+    private Boolean reportFieldSetErrors(){
+        Boolean hasError = false;
+        for(String fieldPath : requiredFieldSetFields){
+            if (lvl.get(fieldPath) == null) {
+                hasError = true;
+                String fieldLabel = UTIL_Describe.getFieldLabel('Level__c', fieldPath);
+                lvl.addError(fieldPath, Label.errErrorTypeRequiredFieldMissing + ': ' + fieldLabel);
+            }
+        }
+        return hasError;
+    }
+
 }

--- a/force-app/main/default/classes/LVL_LevelEdit_CTRL.cls
+++ b/force-app/main/default/classes/LVL_LevelEdit_CTRL.cls
@@ -155,11 +155,10 @@ public with sharing class LVL_LevelEdit_CTRL {
     */
     public PageReference saveAndNew() {
         try {
-            if (!reportFieldSetErrors()) {
-                upsert lvl;
-            } else {
+            if (reportFieldSetErrors()) {
                 return null;
             }
+            upsert lvl;
             // now fixup lvl to be the new next level
             lvl.Id = null;
             lvl.Name = null;
@@ -179,11 +178,10 @@ public with sharing class LVL_LevelEdit_CTRL {
     */
     public PageReference save() {
         try {
-            if (!reportFieldSetErrors()) {
-                upsert lvl;
-            } else {
+            if (reportFieldSetErrors()) {
                 return null;
             }
+            upsert lvl;
             return new PageReference('/' + lvl.Id);
         } catch (Exception ex) {
             ApexPages.addMessages(ex);            

--- a/force-app/main/default/classes/LVL_LevelEdit_TEST.cls
+++ b/force-app/main/default/classes/LVL_LevelEdit_TEST.cls
@@ -81,7 +81,8 @@ private with sharing class LVL_LevelEdit_TEST {
         ctrl.lvl.Name = 'test level2';
         system.assertEquals(200, ctrl.lvl.Minimum_Amount__c);
         system.assertEquals(null, ctrl.lvl.Maximum_Amount__c);
-        stdCtrl.save();
+        PageReference newLevel = ctrl.save();
+        system.assertEquals(true, newLevel.getUrl().contains(ctrl.lvl.Id));
         Test.stopTest();
         
         list<Level__c> listLvl = [Select Id, Name, Target__c from Level__c order by Name];

--- a/force-app/main/default/classes/UTIL_Describe.cls
+++ b/force-app/main/default/classes/UTIL_Describe.cls
@@ -534,12 +534,23 @@ public class UTIL_Describe {
     }
 
     /*******************************************************************************************************
-    * @description utility to return a list of strings from a field set.
+    * @description utility to return a list of field names from a field set.
     * @param obj the namespaced name of the object
     * @param fieldSet the namespaced name of the object's field set
     * @return a list of strings of field names in the field set
     */
     public static List<String> listStrFromFieldSet(String obj, String fieldSetName) {
+        return listStrFromFieldSet(obj, fieldSetName, false);
+    }
+
+    /*******************************************************************************************************
+    * @description utility to return a list of field names from a field set.
+    * @param obj the namespaced name of the object
+    * @param fieldSet the namespaced name of the object's field set
+    * @param onlyRequired if true, only return required fields
+    * @return a list of strings of field names in the field set
+    */
+    public static List<String> listStrFromFieldSet(String obj, String fieldSetName, Boolean onlyRequired) {
         List<String> fieldNames = new List<String>();
         if (gd==null) gd = Schema.getGlobalDescribe();
         Schema.SObjectType targetType = gd.get(obj);
@@ -555,7 +566,9 @@ public class UTIL_Describe {
                             '\'.  You can only include fields directly on object \'' + obj + '\'.';
                     throw (new SchemaDescribeException(errorMessage));
                 }
-                fieldNames.add(fieldSetMember.getFieldPath());
+                if(!onlyRequired || fieldSetMember.getDBRequired() || fieldSetMember.getRequired()){
+                    fieldNames.add(fieldSetMember.getFieldPath());
+                }
             }
             return fieldNames;
         }

--- a/force-app/main/default/classes/UTIL_Describe.cls
+++ b/force-app/main/default/classes/UTIL_Describe.cls
@@ -561,9 +561,8 @@ public class UTIL_Describe {
         } else {
             for(Schema.FieldSetMember fieldSetMember : fieldSetDescribe.getFields()) {
                 if (fieldSetMember.getFieldPath().contains('.')) {
-                    String errorMessage = 'Related field \'' + fieldSetMember.getFieldPath() +
-                            '\' not supported ' + 'in field set \'' + fieldSetName +
-                            '\'.  You can only include fields directly on object \'' + obj + '\'.';
+                    String errorMessage = String.format(Label.FieldSetRelatedFieldError, 
+                        new List<String>{'\''+fieldSetMember.getFieldPath()+'\'', '\''+fieldSetName+'\'', '\''+obj+'\''});
                     throw (new SchemaDescribeException(errorMessage));
                 }
                 if(!onlyRequired || fieldSetMember.getDBRequired() || fieldSetMember.getRequired()){

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -1434,6 +1434,14 @@
         <value>Salesforce encountered these NPSP errors. To learn more about common errors, see &quot;Troubleshoot the Nonprofit Success Pack&quot; on the Power of Us Hub. If you&apos;re unsure how to resolve the errors, post a message in the Nonprofit Success Pack group: https://powerofus.force.com/HUB_NPSP_Group</value>
     </labels>
     <labels>
+        <fullName>FieldSetRelatedFieldError</fullName>
+        <categories>Error</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Error when including Related Fields in a managed Field Set</shortDescription>
+        <value>Related field {0} not supported in field set {1}. You can only include fields directly on object {2}.</value>
+    </labels>
+    <labels>
         <fullName>HiddenForSecurity</fullName>
         <categories>settings</categories>
         <language>en_US</language>

--- a/force-app/main/default/pages/LVL_LevelEdit.page
+++ b/force-app/main/default/pages/LVL_LevelEdit.page
@@ -145,6 +145,7 @@
                             <c:UTIL_FormField field="{!f.fieldPath}"
                                               sObj="{!Level__c}"
                                               sObjType="Level__c"
+                                              overrideRequired="{!f.DBRequired}"
                                               appearRequired="{!f.DBRequired || f.Required}"/>
                         </apex:repeat>
                     </div>

--- a/force-app/main/default/pages/LVL_LevelEdit.page
+++ b/force-app/main/default/pages/LVL_LevelEdit.page
@@ -145,7 +145,7 @@
                             <c:UTIL_FormField field="{!f.fieldPath}"
                                               sObj="{!Level__c}"
                                               sObjType="Level__c"
-                                              required="{!f.DBRequired || f.Required}"/>
+                                              appearRequired="{!f.DBRequired || f.Required}"/>
                         </apex:repeat>
                     </div>
                 </div>


### PR DESCRIPTION
- We improved the error messages on the Edit Level Page so they will be more descriptive to screen readers.

# Critical Changes

# Changes
- We improved the error messages on the edit Level page so they are more descriptive to screen readers.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
