### PR TITLE
A11y: Contact Merge Page Provide a Valid Label for Form Fields with Empty Value

### DIFF
--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -10907,6 +10907,13 @@ If preferred, you can disable Gift Entry and instead use older Batch Gift Entry 
         <value>This component has been deprecated.</value>
     </labels>
     <labels>
+        <fullName>lblEmpty</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Label to display Empty.</shortDescription>
+        <value>empty</value>
+    </labels>
+    <labels>
         <fullName>lblExtendedStatus</fullName>
         <categories>UTIL_JobProgressLightning</categories>
         <language>en_US</language>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -10908,6 +10908,7 @@ If preferred, you can disable Gift Entry and instead use older Batch Gift Entry 
     </labels>
     <labels>
         <fullName>lblEmpty</fullName>
+        <categories>Contact Merge</categories>
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Label to display Empty.</shortDescription>

--- a/force-app/main/default/pages/CON_ContactMerge.page
+++ b/force-app/main/default/pages/CON_ContactMerge.page
@@ -498,7 +498,7 @@
                                                             </apex:outputText>
                                                             <span class="slds-radio_faux" aria-label="{!row.fieldLabel}"></span>
                                                             <span>
-                                                                <apex:outputText value="{!col.value}"/>
+                                                                <apex:outputText value="{!IF((col.value == null), '[empty]', col.value) }"/>
                                                             </span>
                                                         </label>
                                                     </td>

--- a/force-app/main/default/pages/CON_ContactMerge.page
+++ b/force-app/main/default/pages/CON_ContactMerge.page
@@ -498,7 +498,7 @@
                                                             </apex:outputText>
                                                             <span class="slds-radio_faux" aria-label="{!row.fieldLabel}"></span>
                                                             <span>
-                                                                <apex:outputText value="{!IF((col.value == null), '[empty]', col.value) }"/>
+                                                                <apex:outputText value="{!IF((col.value == null), '[' + $Label.lblEmpty+ ']', col.value) }"/>
                                                             </span>
                                                         </label>
                                                     </td>


### PR DESCRIPTION
[WI-9534456](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000PuIvYAK/view)

# Critical Changes
  
# Changes
 - Accessibility improvement: We updated the NPSP Contact Merge page to make a screen reader announcement when a user selects an empty field.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata
- New Custom Label
     - lblEmpty

# Deleted Metadata
