### PR TITLE
Fix for Manage HH Page when Undeliverable Address permissions are missing

### DIFF
--- a/force-app/main/adapter/in/sobjects/account/AccountAdapter.cls
+++ b/force-app/main/adapter/in/sobjects/account/AccountAdapter.cls
@@ -185,9 +185,12 @@ public inherited sharing class AccountAdapter extends fflib_SObjects {
                 }
             } else {
                 NPSP_HouseholdAccount npspHouseholdAccount = new NPSP_HouseholdAccount(
-                        accountsById.get(npspNewAddress.householdId())
+                        accountsById.get(npspNewAddress.householdId()),
+                        accounts.oldMap.get(npspNewAddress.householdId())
                 );
-                npspNewAddress.setUndeliverable(npspHouseholdAccount.undeliverableAddressStatus());
+                if (npspHouseholdAccount.isUndeliverableStatusChanged()) {
+                    npspNewAddress.setUndeliverable(npspHouseholdAccount.undeliverableAddressStatus());
+                }
                 dmlWrapper.objectsToInsert.add(npspNewAddress.getRecord());
             }
         }

--- a/force-app/main/default/aura/HH_Container/HH_ContainerHelper.js
+++ b/force-app/main/default/aura/HH_Container/HH_ContainerHelper.js
@@ -476,7 +476,10 @@
         con.MailingState = addr.MailingState__c;
         con.MailingPostalCode = addr.MailingPostalCode__c;
         con.MailingCountry = addr.MailingCountry__c;
-        con.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
+        // If Undeliverable Address information was passed from Apex for both objects, show the status
+        if(con.hasOwnProperty('Undeliverable_Address__c') && addr.hasOwnProperty('Undeliverable__c')){
+            con.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
+        }
     },
 
     /*******************************************************************************************************

--- a/force-app/main/default/aura/HH_Container/HH_ContainerHelper.js
+++ b/force-app/main/default/aura/HH_Container/HH_ContainerHelper.js
@@ -442,9 +442,7 @@
             hh.BillingState = addr.MailingState__c;
             hh.BillingPostalCode = addr.MailingPostalCode__c;
             hh.BillingCountry = addr.MailingCountry__c;
-            if(hh.hasOwnProperty('Undeliverable_Address__c') && addr.hasOwnProperty('Undeliverable__c')){
-                hh.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
-            }
+            hh.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
         } else {
             hh.npo02__MailingStreet__c = addr.MailingStreet__c;
             if (addr.MailingStreet2__c)

--- a/force-app/main/default/aura/HH_Container/HH_ContainerHelper.js
+++ b/force-app/main/default/aura/HH_Container/HH_ContainerHelper.js
@@ -440,7 +440,9 @@
             hh.BillingState = addr.MailingState__c;
             hh.BillingPostalCode = addr.MailingPostalCode__c;
             hh.BillingCountry = addr.MailingCountry__c;
-            hh.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
+            if(hh.hasOwnProperty('Undeliverable_Address__c') && addr.hasOwnProperty('Undeliverable__c')){
+                hh.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
+            }
         } else {
             hh.npo02__MailingStreet__c = addr.MailingStreet__c;
             if (addr.MailingStreet2__c)
@@ -474,7 +476,9 @@
         con.MailingState = addr.MailingState__c;
         con.MailingPostalCode = addr.MailingPostalCode__c;
         con.MailingCountry = addr.MailingCountry__c;
-        con.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
+        if(con.hasOwnProperty('Undeliverable_Address__c') && addr.hasOwnProperty('Undeliverable__c')){
+            con.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
+        }
     },
 
     /*******************************************************************************************************

--- a/force-app/main/default/aura/HH_Container/HH_ContainerHelper.js
+++ b/force-app/main/default/aura/HH_Container/HH_ContainerHelper.js
@@ -478,9 +478,7 @@
         con.MailingState = addr.MailingState__c;
         con.MailingPostalCode = addr.MailingPostalCode__c;
         con.MailingCountry = addr.MailingCountry__c;
-        if(con.hasOwnProperty('Undeliverable_Address__c') && addr.hasOwnProperty('Undeliverable__c')){
-            con.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
-        }
+        con.Undeliverable_Address__c = addr.Undeliverable__c === undefined ? false : addr.Undeliverable__c;
     },
 
     /*******************************************************************************************************

--- a/force-app/main/default/classes/CON_ContactMerge_CTRL.cls
+++ b/force-app/main/default/classes/CON_ContactMerge_CTRL.cls
@@ -712,16 +712,20 @@ public with sharing class CON_ContactMerge_CTRL {
 
     private List<String> buildSortedCustomFieldList(Map<String, DescribeFieldResult> customFieldMap) {
         List<String> customFields = new List<String>();
-        String undeliverableFieldName = String.valueOf(Contact.Undeliverable_Address__c).toLowerCase();
+        DescribeFieldResult undeliverableFieldDescribeResult = Contact.Undeliverable_Address__c.getDescribe();
 
         for (String fieldName : customFieldMap.keySet()) {
-            if (fieldName == undeliverableFieldName) {
+            if (fieldName == undeliverableFieldDescribeResult.getName()) {
                 continue;
             }
             customFields.add(fieldName);
         }
+
         customFields.sort();
-        customFields.add(0, undeliverableFieldName);
+        if (UTIL_Permissions.canRead(undeliverableFieldDescribeResult, false) &&
+                UTIL_Permissions.canUpdate(undeliverableFieldDescribeResult, false)) {
+            customFields.add(0, undeliverableFieldDescribeResult.getName().toLowerCase());
+        }
 
         return customFields;
     }

--- a/force-app/main/default/classes/HH_Container_LCTRL.cls
+++ b/force-app/main/default/classes/HH_Container_LCTRL.cls
@@ -325,7 +325,7 @@ public with sharing class HH_Container_LCTRL {
     * @return void
     */
     private static void addContactUndeliverableAddressField(Set<String> fieldNames) {   
-        if (canReadContactUndeliverable) {
+        if (canUpdateAddressUndeliverable && canReadContactUndeliverable) {
             fieldNames.add(undeliverableAddressField);
         }
     }

--- a/force-app/main/default/classes/HH_Container_LCTRL.cls
+++ b/force-app/main/default/classes/HH_Container_LCTRL.cls
@@ -448,8 +448,9 @@ public with sharing class HH_Container_LCTRL {
             UTIL_Describe.copyObjectFLS(strObject, hh, hhCopy, new List<String>(householdFieldsToEdit));
 
             // Update Undeliverable field on Account to ensure correct syncing
-            hhCopy.put(UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'), selectedAddressIsUndeliverable);
-            
+            if (isHHAccount) {
+                hhCopy.put(UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'), selectedAddressIsUndeliverable);
+            }
             // we've already saved the data for the contacts in the household.
             // now we only need to save the account fields an update, and we don't want
             // any of the normal account trigger work to run again.  specifically,
@@ -502,6 +503,7 @@ public with sharing class HH_Container_LCTRL {
     public static void saveHouseholdPage(SObject hh, List<Contact> listCon, List<Contact> listConRemove, List<Account>listHHMerge) {
         // We need to determine if the new Default Address is Undeliverable
         Address__c defaultAddress = getAddressFromAccount(hh.Id, hh);
+        defaultAddress.Household_Account__c = hh.Id;
         Map<Address__c, Address__c> addressMatch = Addresses.getExistingAddresses(new List<Address__c>{defaultAddress});
         if(addressMatch.containsKey(defaultAddress) && addressMatch.get(defaultAddress) != null){
             selectedAddressIsUndeliverable = addressMatch.get(defaultAddress)?.Undeliverable__c;
@@ -607,8 +609,14 @@ public with sharing class HH_Container_LCTRL {
         }
     }
 
-    private static Address__c getAddressFromAccount(Id householdId, SObject household){
-        Address__c address = new Address__c(Household_Account__c = householdId);
+    /*******************************************************************************************************
+    * @description Return an Address record with fields copied from the Account
+    * @param householdId The Household Id
+    * @param household An SObject representing the Household
+    * @return Address__c
+    */
+    private static Address__c getAddressFromAccount(Id householdId, SObject household) {
+        Address__c address = new Address__c();
         if (UTIL_Describe.isObjectIdThisType(householdId, 'Account')) {
             // can't use our utility routine, because we specifically are not querying for StateCode & CountryCode
             // to avoid those saved codes from interfering with the user's changes (that won't include the codes)

--- a/force-app/main/default/classes/HH_Container_LCTRL.cls
+++ b/force-app/main/default/classes/HH_Container_LCTRL.cls
@@ -39,14 +39,20 @@ public with sharing class HH_Container_LCTRL {
     /** @description our exception object for Field Level & Object Security errors. */
     private class permsException extends Exception {}
 
+    private static final String accountObject = Schema.SObjectType.Account.getName();
+    private static final String contactObject = Schema.SObjectType.Contact.getName();
+    private static final String addressObject = Schema.SObjectType.Address__c.getName();
+    private static final String undeliverableField = UTIL_Namespace.StrTokenNSPrefix('Undeliverable__c');
+    private static final String undeliverableAddressField = UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c');
+
     private static Boolean canReadContactUndeliverable = 
-        UTIL_Permissions.canRead(Contact.Undeliverable_Address__c.getDescribe(), false);
+        UTIL_Permissions.canRead(contactObject, undeliverableAddressField, false);
     private static Boolean canReadAccountUndeliverable = 
-        UTIL_Permissions.canRead(Account.Undeliverable_Address__c.getDescribe(), false);
+        UTIL_Permissions.canRead(accountObject, undeliverableAddressField, false);
     private static Boolean canUpdateAddressUndeliverable = 
-        UTIL_Permissions.canRead(Address__c.Undeliverable__c.getDescribe(), false)
-            && UTIL_Permissions.canUpdate(Address__c.Undeliverable__c.getDescribe(), false);
-    private static Boolean selectedAddressIsUndeliverable = false; 
+        UTIL_Permissions.canRead(addressObject, undeliverableField, false)
+            && UTIL_Permissions.canUpdate(addressObject, undeliverableField, false);
+    private static Boolean selectedAddressIsUndeliverable = false;
 
     /*******************************************************************************************************
     * @description trick the packaging spider to pickup references to custom labels only used by our
@@ -136,7 +142,7 @@ public with sharing class HH_Container_LCTRL {
                 'BillingStreet', 'BillingCity', 'BillingState', 'BillingPostalCode',
                 'BillingCountry', 'BillingLatitude', 'BillingLongitude'});
             if (canReadAccountUndeliverable) {
-                householdFieldsToEdit.add(String.valueOf(Account.Undeliverable_Address__c));
+                householdFieldsToEdit.add(undeliverableAddressField);
             }
         } else {
             householdFieldsToEdit.addAll(new Set<String>{
@@ -320,7 +326,7 @@ public with sharing class HH_Container_LCTRL {
     */
     private static void addContactUndeliverableAddressField(Set<String> fieldNames) {   
         if (canReadContactUndeliverable) {
-            fieldNames.add(String.valueOf(Contact.Undeliverable_Address__c));
+            fieldNames.add(undeliverableAddressField);
         }
     }
 
@@ -449,7 +455,7 @@ public with sharing class HH_Container_LCTRL {
 
             // Update Undeliverable field on Account to ensure correct syncing
             if (isHHAccount) {
-                hhCopy.put(UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'), selectedAddressIsUndeliverable);
+                hhCopy.put(undeliverableAddressField, selectedAddressIsUndeliverable);
             }
             // we've already saved the data for the contacts in the household.
             // now we only need to save the account fields an update, and we don't want
@@ -553,14 +559,9 @@ public with sharing class HH_Container_LCTRL {
 
     @AuraEnabled
     public static Map<String, String> getFieldLabels() {
-        String undeliverableAddressLabel = canReadContactUndeliverable ?
-            UTIL_Describe.getFieldLabel(String.valueOf(Contact.SObjectType), String.valueOf(Contact.Undeliverable_Address__c)) : '';
-        String undeliverableLabel = canUpdateAddressUndeliverable ?
-            UTIL_Describe.getFieldLabel(String.valueOf(Address__c.SObjectType), String.valueOf(Address__c.Undeliverable__c)) : '';
-
         Map<String, String> fieldLabelsBySObject = new Map<String, String> {
-            'Undeliverable_Address__c' => undeliverableAddressLabel,
-            'Undeliverable__c' => undeliverableLabel
+            undeliverableAddressField => UTIL_Describe.getFieldLabel(contactObject, undeliverableAddressField),
+            undeliverableField => UTIL_Describe.getFieldLabel(addressObject, undeliverableField)
         };
 
         return fieldLabelsBySObject;
@@ -628,8 +629,7 @@ public with sharing class HH_Container_LCTRL {
             address.MailingPostalCode__c = (String)household.get('BillingPostalCode');
             address.MailingCountry__c = (String)household.get('BillingCountry');
             if (canUpdateAddressUndeliverable && canReadAccountUndeliverable) {
-                address.Undeliverable__c = (Boolean)household.get(
-                    UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'));
+                address.Undeliverable__c = (Boolean)household.get(undeliverableAddressField);
             }
         } else {
             address.MailingStreet__c = (String)household.get('npo02__MailingStreet__c');
@@ -676,12 +676,14 @@ public with sharing class HH_Container_LCTRL {
             // if the householdId matches.  Same with listCon.
             SObject household = getHousehold(householdId);
             List<Contact> listCon = getContacts(householdId);
+            Address__c defaultAddress;
 
             // copy the household's address
             Address__c address = getAddressFromAccount(householdId, household);
 
             if (existingAddresses == null || existingAddresses.size() == 0) {
                 address.Default_Address__c = true;
+                defaultAddress = address;
             }  // the HH address is the default.
             String strKey = new NPSP_Address(address).getAddrKey();
             if (setAddrKey.add(strKey)) {
@@ -723,7 +725,7 @@ public with sharing class HH_Container_LCTRL {
                 
                 for (String strF : setFields) {
                     // check field level security
-                    DescribeFieldResult dfr = UTIL_Describe.getFieldDescribe(UTIL_Namespace.StrTokenNSPrefix('Address__c'), UTIL_Namespace.StrTokenNSPrefix(strF));
+                    DescribeFieldResult dfr = UTIL_Describe.getFieldDescribe(addressObject, UTIL_Namespace.StrTokenNSPrefix(strF));
                     if (dfr == null || !dfr.isAccessible()) {
                         throw (new permsException(String.format(Label.flsError, new string[]{
                                 'Address__c' + '.' + strF
@@ -745,6 +747,10 @@ public with sharing class HH_Container_LCTRL {
                     strKey = new NPSP_Address(addrT).getAddrKey();
                     if (setAddrKey.add(strKey)) {
                         listAddr.add(addrT);
+                    } else if (canUpdateAddressUndeliverable && addrT.Default_Address__c) {
+                        // Since the Default address was set via the Household, we need to update it
+                        // directly in case the User only has access to the Address Undeliverable field
+                        defaultAddress.Undeliverable__c = addrT.Undeliverable__c;
                     }
                 }
             }

--- a/force-app/main/default/classes/HH_Container_LCTRL.cls
+++ b/force-app/main/default/classes/HH_Container_LCTRL.cls
@@ -38,7 +38,14 @@ public with sharing class HH_Container_LCTRL {
 
     /** @description our exception object for Field Level & Object Security errors. */
     private class permsException extends Exception {}
-    
+
+    private static Boolean canReadContactUndeliverable = 
+        UTIL_Permissions.canRead(Contact.Undeliverable_Address__c.getDescribe(), false);
+    private static Boolean canReadAccountUndeliverable = 
+        UTIL_Permissions.canRead(Account.Undeliverable_Address__c.getDescribe(), false);
+    private static Boolean canReadAddressUndeliverable = 
+        UTIL_Permissions.canRead(Address__c.Undeliverable__c.getDescribe(), false);
+
     /*******************************************************************************************************
     * @description trick the packaging spider to pickup references to custom labels only used by our
     * lightning components.
@@ -125,8 +132,10 @@ public with sharing class HH_Container_LCTRL {
         if (isHousehold) {
             householdFieldsToEdit.addAll(new Set<String>{
                 'BillingStreet', 'BillingCity', 'BillingState', 'BillingPostalCode',
-                 String.valueOf(Account.Undeliverable_Address__c), 'BillingCountry',
-                'BillingLatitude', 'BillingLongitude'});
+                'BillingCountry', 'BillingLatitude', 'BillingLongitude'});
+            if (canReadAccountUndeliverable) {
+                householdFieldsToEdit.add(String.valueOf(Account.Undeliverable_Address__c));
+            }
         } else {
             householdFieldsToEdit.addAll(new Set<String>{
                 'npo02__MailingStreet__c', 'npo02__MailingCity__c', 'npo02__MailingState__c', 
@@ -252,11 +261,11 @@ public with sharing class HH_Container_LCTRL {
                 'MailingCountry', 
                 'MailingLatitude', 
                 'MailingLongitude', 
-                'CreatedDate',
-                String.valueOf(Contact.Undeliverable_Address__c)
+                'CreatedDate'
             };
 
             addContactMiddleNameField(contactFields);
+            addContactUndeliverableAddressField(contactFields);
 
                 /*** until we support these, we don't want them to interfere with what the user specifies.
                 if (OrgSettings.isStateCountryPicklistsEnabled)
@@ -293,12 +302,24 @@ public with sharing class HH_Container_LCTRL {
             'MailingPostalCode', 
             'MailingCountry', 
             'MailingLatitude', 
-            'MailingLongitude',
-            String.valueOf(Contact.Undeliverable_Address__c)};
+            'MailingLongitude'
+        };
 
         addContactMiddleNameField(setContactFields);
+        addContactUndeliverableAddressField(setContactFields);
 
         return setContactFields;
+    }
+
+    /*******************************************************************************************************
+    * @description Adds Undeliverable Address field into the set of field names
+    * @param fieldNames Set of field names 
+    * @return void
+    */
+    private static void addContactUndeliverableAddressField(Set<String> fieldNames) {   
+        if (canReadContactUndeliverable) {
+            fieldNames.add(String.valueOf(Contact.Undeliverable_Address__c));
+        }
     }
 
     /*******************************************************************************************************
@@ -514,12 +535,16 @@ public with sharing class HH_Container_LCTRL {
 
     @AuraEnabled
     public static Map<String, String> getFieldLabels() {
+        String undeliverableAddressLabel = canReadContactUndeliverable ?
+            UTIL_Describe.getFieldLabel(String.valueOf(Contact.SObjectType), String.valueOf(Contact.Undeliverable_Address__c)) : '';
+        String undeliverableLabel = canReadAddressUndeliverable ?
+            UTIL_Describe.getFieldLabel(String.valueOf(Address__c.SObjectType), String.valueOf(Address__c.Undeliverable__c)) : '';
+
         Map<String, String> fieldLabelsBySObject = new Map<String, String> {
-            String.valueOf(Contact.Undeliverable_Address__c) => UTIL_Describe.getFieldLabel(
-                    String.valueOf(Contact.SObjectType), String.valueOf(Contact.Undeliverable_Address__c)),
-            String.valueOf(Address__c.Undeliverable__c) => UTIL_Describe.getFieldLabel(
-                    String.valueOf(Address__c.SObjectType), String.valueOf(Address__c.Undeliverable__c))
+            'Undeliverable_Address__c' => undeliverableAddressLabel,
+            'Undeliverable__c' => undeliverableLabel
         };
+
         return fieldLabelsBySObject;
     }
 
@@ -615,8 +640,10 @@ public with sharing class HH_Container_LCTRL {
                 address.MailingState__c = (String)household.get('BillingState');
                 address.MailingPostalCode__c = (String)household.get('BillingPostalCode');
                 address.MailingCountry__c = (String)household.get('BillingCountry');
-                address.Undeliverable__c = (Boolean)household.get(
-                    UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'));
+                if (canReadAddressUndeliverable && canReadAccountUndeliverable) {
+                    address.Undeliverable__c = (Boolean)household.get(
+                        UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'));
+                }
             } else {
                 address.MailingStreet__c = (String)household.get('npo02__MailingStreet__c');
                 address.MailingCity__c = (String)household.get('npo02__MailingCity__c');
@@ -644,7 +671,9 @@ public with sharing class HH_Container_LCTRL {
                 address.MailingState__c = con.MailingState;
                 address.MailingPostalCode__c = con.MailingPostalCode;
                 address.MailingCountry__c = con.MailingCountry;
-                address.Undeliverable__c = con.Undeliverable_Address__c;
+                if (canReadAddressUndeliverable && canReadContactUndeliverable) {
+                    address.Undeliverable__c = con.Undeliverable_Address__c;
+                }
                 strKey = new NPSP_Address(address).getAddrKey();
                 if (setAddrKey.add(strKey)) {
                     listAddr.add(address);
@@ -655,8 +684,11 @@ public with sharing class HH_Container_LCTRL {
             if (UTIL_Describe.isObjectIdThisType(householdId, 'Account')) {
 
                 Set<String> setFields = new Set<String>{'MailingStreet__c', 'MailingStreet2__c',
-                        'Undeliverable__c', 'MailingCity__c', 'MailingState__c',
-                        'MailingPostalCode__c', 'MailingCountry__c', 'Default_Address__c'};
+                        'MailingCity__c', 'MailingState__c', 'MailingPostalCode__c', 
+                        'MailingCountry__c', 'Default_Address__c'};
+                if (canReadAddressUndeliverable) {
+                    setFields.add('Undeliverable__c');
+                }
                 String strSoql = 'select ';
                 String strComma = '';
                 

--- a/force-app/main/default/classes/HH_Container_LCTRL.cls
+++ b/force-app/main/default/classes/HH_Container_LCTRL.cls
@@ -46,6 +46,7 @@ public with sharing class HH_Container_LCTRL {
     private static Boolean canUpdateAddressUndeliverable = 
         UTIL_Permissions.canRead(Address__c.Undeliverable__c.getDescribe(), false)
             && UTIL_Permissions.canUpdate(Address__c.Undeliverable__c.getDescribe(), false);
+    private static Boolean selectedAddressIsUndeliverable = false; 
 
     /*******************************************************************************************************
     * @description trick the packaging spider to pickup references to custom labels only used by our
@@ -378,6 +379,10 @@ public with sharing class HH_Container_LCTRL {
                 // Due to the complexity of working in both the Household and Account Household models,
                 // we need to skip the security check on the Household field.
                 con2.npo02__Household__c = con.npo02__Household__c;
+                // To perform data syncing, we need to skip the security check on Undeliverable Address
+                if (!con2.is_Address_Override__c) {
+                    con2.Undeliverable_Address__c = selectedAddressIsUndeliverable;
+                }
                 if (con.Id != null) {
                     listUpdate.add(con2);
                 } else {
@@ -417,8 +422,8 @@ public with sharing class HH_Container_LCTRL {
     * @param hh The Household
     * @return void
     */
-    @AuraEnabled
-    public static void updateHousehold(SObject hh) {
+    @TestVisible
+    private static void updateHousehold(SObject hh) {
         try {
             // Check object permissions
             Boolean isHHAccount = UTIL_Describe.isObjectIdThisType(hh.Id, 'Account');
@@ -441,6 +446,9 @@ public with sharing class HH_Container_LCTRL {
             // do FLS and only copy the fields we allow to be touched in our UI
             Set<String> householdFieldsToEdit = getHouseholdFieldsToEdit(isHHAccount, strObject);
             UTIL_Describe.copyObjectFLS(strObject, hh, hhCopy, new List<String>(householdFieldsToEdit));
+
+            // Update Undeliverable field on Account to ensure correct syncing
+            hhCopy.put(UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'), selectedAddressIsUndeliverable);
             
             // we've already saved the data for the contacts in the household.
             // now we only need to save the account fields an update, and we don't want
@@ -492,6 +500,13 @@ public with sharing class HH_Container_LCTRL {
     */
     @AuraEnabled
     public static void saveHouseholdPage(SObject hh, List<Contact> listCon, List<Contact> listConRemove, List<Account>listHHMerge) {
+        // We need to determine if the new Default Address is Undeliverable
+        Address__c defaultAddress = getAddressFromAccount(hh.Id, hh);
+        Map<Address__c, Address__c> addressMatch = Addresses.getExistingAddresses(new List<Address__c>{defaultAddress});
+        if(addressMatch.containsKey(defaultAddress) && addressMatch.get(defaultAddress) != null){
+            selectedAddressIsUndeliverable = addressMatch.get(defaultAddress)?.Undeliverable__c;
+        }
+
         updateHousehold(hh);
         
         // need to merge any households (Accounts only) before we save contacts
@@ -592,6 +607,32 @@ public with sharing class HH_Container_LCTRL {
         }
     }
 
+    private static Address__c getAddressFromAccount(Id householdId, SObject household){
+        Address__c address = new Address__c(Household_Account__c = householdId);
+        if (UTIL_Describe.isObjectIdThisType(householdId, 'Account')) {
+            // can't use our utility routine, because we specifically are not querying for StateCode & CountryCode
+            // to avoid those saved codes from interfering with the user's changes (that won't include the codes)
+            //Addresses.copyAddressStdSObjAddr(household, 'Billing', address, null);
+            address.MailingStreet__c = (String)household.get('BillingStreet');
+            Addresses.handleMultilineStreet(address);
+            address.MailingCity__c = (String)household.get('BillingCity');
+            address.MailingState__c = (String)household.get('BillingState');
+            address.MailingPostalCode__c = (String)household.get('BillingPostalCode');
+            address.MailingCountry__c = (String)household.get('BillingCountry');
+            if (canUpdateAddressUndeliverable && canReadAccountUndeliverable) {
+                address.Undeliverable__c = (Boolean)household.get(
+                    UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'));
+            }
+        } else {
+            address.MailingStreet__c = (String)household.get('npo02__MailingStreet__c');
+            address.MailingCity__c = (String)household.get('npo02__MailingCity__c');
+            address.MailingState__c = (String)household.get('npo02__MailingState__c');
+            address.MailingPostalCode__c = (String)household.get('npo02__MailingPostalCode__c');
+            address.MailingCountry__c = (String)household.get('npo02__MailingCountry__c');
+        }
+        return address;
+    }
+
     /*******************************************************************************************************
     * @description returns the Addresses for the given Household.  note that it returns Address objects,
     * even when dealing with Household Objects (in which case it creates in memory address objects for each
@@ -629,29 +670,8 @@ public with sharing class HH_Container_LCTRL {
             List<Contact> listCon = getContacts(householdId);
 
             // copy the household's address
-            Address__c address = new Address__c();
-            if (UTIL_Describe.isObjectIdThisType(householdId, 'Account')) {
-                address = new Address__c();
-                // can't use our utility routine, because we specifically are not querying for StateCode & CountryCode
-                // to avoid those saved codes from interfering with the user's changes (that won't include the codes)
-                //Addresses.copyAddressStdSObjAddr(household, 'Billing', address, null);
-                address.MailingStreet__c = (String)household.get('BillingStreet');
-                Addresses.handleMultilineStreet(address);
-                address.MailingCity__c = (String)household.get('BillingCity');
-                address.MailingState__c = (String)household.get('BillingState');
-                address.MailingPostalCode__c = (String)household.get('BillingPostalCode');
-                address.MailingCountry__c = (String)household.get('BillingCountry');
-                if (canUpdateAddressUndeliverable && canReadAccountUndeliverable) {
-                    address.Undeliverable__c = (Boolean)household.get(
-                        UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'));
-                }
-            } else {
-                address.MailingStreet__c = (String)household.get('npo02__MailingStreet__c');
-                address.MailingCity__c = (String)household.get('npo02__MailingCity__c');
-                address.MailingState__c = (String)household.get('npo02__MailingState__c');
-                address.MailingPostalCode__c = (String)household.get('npo02__MailingPostalCode__c');
-                address.MailingCountry__c = (String)household.get('npo02__MailingCountry__c');
-            }
+            Address__c address = getAddressFromAccount(householdId, household);
+
             if (existingAddresses == null || existingAddresses.size() == 0) {
                 address.Default_Address__c = true;
             }  // the HH address is the default.

--- a/force-app/main/default/classes/HH_Container_LCTRL.cls
+++ b/force-app/main/default/classes/HH_Container_LCTRL.cls
@@ -386,7 +386,8 @@ public with sharing class HH_Container_LCTRL {
                 // we need to skip the security check on the Household field.
                 con2.npo02__Household__c = con.npo02__Household__c;
                 // To perform data syncing, we need to skip the security check on Undeliverable Address
-                if (!con2.is_Address_Override__c) {
+                // We only want to do this for Contacts without Address Override that are still part of the Household
+                if (!con2.is_Address_Override__c && con2.AccountId != null) {
                     con2.Undeliverable_Address__c = selectedAddressIsUndeliverable;
                 }
                 if (con.Id != null) {
@@ -747,7 +748,7 @@ public with sharing class HH_Container_LCTRL {
                     strKey = new NPSP_Address(addrT).getAddrKey();
                     if (setAddrKey.add(strKey)) {
                         listAddr.add(addrT);
-                    } else if (canUpdateAddressUndeliverable && addrT.Default_Address__c) {
+                    } else if (defaultAddress != null && canUpdateAddressUndeliverable && addrT.Default_Address__c) {
                         // Since the Default address was set via the Household, we need to update it
                         // directly in case the User only has access to the Address Undeliverable field
                         defaultAddress.Undeliverable__c = addrT.Undeliverable__c;

--- a/force-app/main/default/classes/HH_Container_LCTRL.cls
+++ b/force-app/main/default/classes/HH_Container_LCTRL.cls
@@ -43,8 +43,9 @@ public with sharing class HH_Container_LCTRL {
         UTIL_Permissions.canRead(Contact.Undeliverable_Address__c.getDescribe(), false);
     private static Boolean canReadAccountUndeliverable = 
         UTIL_Permissions.canRead(Account.Undeliverable_Address__c.getDescribe(), false);
-    private static Boolean canReadAddressUndeliverable = 
-        UTIL_Permissions.canRead(Address__c.Undeliverable__c.getDescribe(), false);
+    private static Boolean canUpdateAddressUndeliverable = 
+        UTIL_Permissions.canRead(Address__c.Undeliverable__c.getDescribe(), false)
+            && UTIL_Permissions.canUpdate(Address__c.Undeliverable__c.getDescribe(), false);
 
     /*******************************************************************************************************
     * @description trick the packaging spider to pickup references to custom labels only used by our
@@ -537,7 +538,7 @@ public with sharing class HH_Container_LCTRL {
     public static Map<String, String> getFieldLabels() {
         String undeliverableAddressLabel = canReadContactUndeliverable ?
             UTIL_Describe.getFieldLabel(String.valueOf(Contact.SObjectType), String.valueOf(Contact.Undeliverable_Address__c)) : '';
-        String undeliverableLabel = canReadAddressUndeliverable ?
+        String undeliverableLabel = canUpdateAddressUndeliverable ?
             UTIL_Describe.getFieldLabel(String.valueOf(Address__c.SObjectType), String.valueOf(Address__c.Undeliverable__c)) : '';
 
         Map<String, String> fieldLabelsBySObject = new Map<String, String> {
@@ -640,7 +641,7 @@ public with sharing class HH_Container_LCTRL {
                 address.MailingState__c = (String)household.get('BillingState');
                 address.MailingPostalCode__c = (String)household.get('BillingPostalCode');
                 address.MailingCountry__c = (String)household.get('BillingCountry');
-                if (canReadAddressUndeliverable && canReadAccountUndeliverable) {
+                if (canUpdateAddressUndeliverable && canReadAccountUndeliverable) {
                     address.Undeliverable__c = (Boolean)household.get(
                         UTIL_Namespace.StrTokenNSPrefix('Undeliverable_Address__c'));
                 }
@@ -671,7 +672,7 @@ public with sharing class HH_Container_LCTRL {
                 address.MailingState__c = con.MailingState;
                 address.MailingPostalCode__c = con.MailingPostalCode;
                 address.MailingCountry__c = con.MailingCountry;
-                if (canReadAddressUndeliverable && canReadContactUndeliverable) {
+                if (canUpdateAddressUndeliverable && canReadContactUndeliverable) {
                     address.Undeliverable__c = con.Undeliverable_Address__c;
                 }
                 strKey = new NPSP_Address(address).getAddrKey();
@@ -686,7 +687,7 @@ public with sharing class HH_Container_LCTRL {
                 Set<String> setFields = new Set<String>{'MailingStreet__c', 'MailingStreet2__c',
                         'MailingCity__c', 'MailingState__c', 'MailingPostalCode__c', 
                         'MailingCountry__c', 'Default_Address__c'};
-                if (canReadAddressUndeliverable) {
+                if (canUpdateAddressUndeliverable) {
                     setFields.add('Undeliverable__c');
                 }
                 String strSoql = 'select ';

--- a/force-app/main/default/classes/HH_Container_TEST.cls
+++ b/force-app/main/default/classes/HH_Container_TEST.cls
@@ -692,14 +692,17 @@ private class HH_Container_TEST {
 
         System.runAs(adminUser) {
             initTestData();
+            List<Address__c> addresses = buildAddresses(new List<Account>{hhA});
+            insert addresses;
 
             Map<String, String> fieldLabels = HH_Container_LCTRL.getFieldLabels();
             System.assert(String.isBlank(fieldLabels.get('Undeliverable__c')), 'The Label should be blank');
 
             List<Address__c> listAddrA = HH_Container_LCTRL.getAddresses(hhA.Id, null);
-            System.assertEquals(2, listAddrA.size());
+            System.assertEquals(3, listAddrA.size());
 
-            System.assertNotEquals(null, HH_Container_LCTRL.getHousehold(hhA.Id));
+            hhA = (Account)HH_Container_LCTRL.getHousehold(hhA.Id);
+            System.assertNotEquals(null, hha);
             List<Contact> hhContacts = HH_Container_LCTRL.getContacts(hhA.Id);
             System.assertEquals(1, hhContacts.size());
 

--- a/force-app/main/default/classes/HH_Container_TEST.cls
+++ b/force-app/main/default/classes/HH_Container_TEST.cls
@@ -692,9 +692,9 @@ private class HH_Container_TEST {
 
         System.runAs(adminUser) {
             initTestData();
-
+            String undeliverableField = UTIL_Namespace.StrTokenNSPrefix('Undeliverable__c');
             Map<String, String> fieldLabels = HH_Container_LCTRL.getFieldLabels();
-            System.assert(String.isBlank(fieldLabels.get('Undeliverable__c')), 'The Label should be blank');
+            System.assert(String.isBlank(fieldLabels.get(undeliverableField)), 'The Label should be blank');
 
             List<Address__c> listAddrA = HH_Container_LCTRL.getAddresses(hhA.Id, null);
             System.assertEquals(2, listAddrA.size());

--- a/force-app/main/default/classes/HH_Container_TEST.cls
+++ b/force-app/main/default/classes/HH_Container_TEST.cls
@@ -662,6 +662,53 @@ private class HH_Container_TEST {
         System.assertEquals(2, records.size(), 'Expected records when Contact.Name is encrypted and the search query is valid: ' + records);
     }
 
+    /*********************************************************************************************************
+    * @description Verifies required methods can be run as a User without Undeliverable Address permissions
+    */
+    public static testMethod void testPageLoadsWithoutUndeliverableAddressPermissions() {
+        User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
+        Id adminProfileId = [SELECT Id FROM Profile WHERE Name = :UTIL_Profile.SYSTEM_ADMINISTRATOR LIMIT 1].Id;
+        
+        String addressUndeliverableField = 
+            String.valueOf(Address__c.SObjectType) + '.' + String.valueOf(Address__c.Undeliverable__c);
+        String contactUndeliverableField = 
+            String.valueOf(Contact.SObjectType) + '.' + String.valueOf(Contact.Undeliverable_Address__c);
+        String accountUndeliverableField = 
+            String.valueOf(Account.SObjectType) + '.' + String.valueOf(Account.Undeliverable_Address__c);
+        List<FieldPermissions> fieldPermissions = [
+            SELECT Id, PermissionsRead, PermissionsEdit
+            FROM FieldPermissions
+            WHERE Parent.ProfileId = :adminProfileId
+            AND (Field = :addressUndeliverableField
+                OR Field =: contactUndeliverableField
+                OR Field = : accountUndeliverableField
+            )
+        ];
+        for(FieldPermissions fieldPermission : fieldPermissions){
+            fieldPermission.PermissionsRead = false;
+            fieldPermission.PermissionsEdit = false;
+        }
+        update fieldPermissions;
+
+        System.runAs(adminUser) {
+            initTestData();
+
+            Map<String, String> fieldLabels = HH_Container_LCTRL.getFieldLabels();
+            System.assert(String.isBlank(fieldLabels.get('Undeliverable__c')), 'The Label should be blank');
+
+            List<Address__c> listAddrA = HH_Container_LCTRL.getAddresses(hhA.Id, null);
+            System.assertEquals(2, listAddrA.size());
+
+            System.assertNotEquals(null, HH_Container_LCTRL.getHousehold(hhA.Id));
+            List<Contact> hhContacts = HH_Container_LCTRL.getContacts(hhA.Id);
+            System.assertEquals(1, hhContacts.size());
+
+            HH_Container_LCTRL.saveHouseholdPage(hhA, hhContacts, new List<Contact>(), null);
+
+            Account[] actualAccounts = getAccounts();
+            System.assertEquals(2, actualAccounts.size(), 'There should still be 2 Accounts');
+        }
+    }
 
     // Helpers
     ////////////

--- a/force-app/main/default/classes/HH_Container_TEST.cls
+++ b/force-app/main/default/classes/HH_Container_TEST.cls
@@ -692,14 +692,12 @@ private class HH_Container_TEST {
 
         System.runAs(adminUser) {
             initTestData();
-            List<Address__c> addresses = buildAddresses(new List<Account>{hhA});
-            insert addresses;
 
             Map<String, String> fieldLabels = HH_Container_LCTRL.getFieldLabels();
             System.assert(String.isBlank(fieldLabels.get('Undeliverable__c')), 'The Label should be blank');
 
             List<Address__c> listAddrA = HH_Container_LCTRL.getAddresses(hhA.Id, null);
-            System.assertEquals(3, listAddrA.size());
+            System.assertEquals(2, listAddrA.size());
 
             hhA = (Account)HH_Container_LCTRL.getHousehold(hhA.Id);
             System.assertNotEquals(null, hha);
@@ -711,6 +709,64 @@ private class HH_Container_TEST {
             Account[] actualAccounts = getAccounts();
             System.assertEquals(2, actualAccounts.size(), 'There should still be 2 Accounts');
         }
+    }
+
+    /*********************************************************************************************************
+    * @description Verifies Undeliverable status syncs correctly as a User without Undeliverable Address permissions
+    */
+    public static testMethod void testSyncWithoutUndeliverableAddressPermissions() {
+        User adminUser = UTIL_UnitTestData_TEST.createUserWithoutInsert(UTIL_Profile.SYSTEM_ADMINISTRATOR);
+        Id adminProfileId = [SELECT Id FROM Profile WHERE Name = :UTIL_Profile.SYSTEM_ADMINISTRATOR LIMIT 1].Id;
+        
+        String addressUndeliverableField = 
+            String.valueOf(Address__c.SObjectType) + '.' + String.valueOf(Address__c.Undeliverable__c);
+        String contactUndeliverableField = 
+            String.valueOf(Contact.SObjectType) + '.' + String.valueOf(Contact.Undeliverable_Address__c);
+        List<FieldPermissions> fieldPermissions = [
+            SELECT Id, PermissionsRead, PermissionsEdit
+            FROM FieldPermissions
+            WHERE Parent.ProfileId = :adminProfileId
+            AND (Field = :addressUndeliverableField
+                OR Field =: contactUndeliverableField
+            )
+        ];
+        for(FieldPermissions fieldPermission : fieldPermissions){
+            fieldPermission.PermissionsRead = false;
+            fieldPermission.PermissionsEdit = false;
+        }
+        update fieldPermissions;
+
+        System.runAs(adminUser) {
+            initTestData();
+
+            String strUndeliverable = 'Undeliverable';
+            List<Address__c> addresses = buildAddresses(new List<Account>{hhA});
+            Address__c newDefaultAddress = addresses[0];
+            Address__c newUndeliverableAddress = newDefaultAddress.clone();
+            newUndeliverableAddress.Undeliverable__c = true;
+            newUndeliverableAddress.Default_Address__c = false;
+            newUndeliverableAddress.MailingCity__c = strUndeliverable;
+            addresses.add(newUndeliverableAddress);
+            insert addresses;
+
+            List<Address__c> listAddrA = HH_Container_LCTRL.getAddresses(hhA.Id, null);
+            System.assertEquals(4, listAddrA.size());
+
+            hhA = (Account)HH_Container_LCTRL.getHousehold(hhA.Id);
+            System.assertNotEquals(null, hha);
+            List<Contact> hhContacts = HH_Container_LCTRL.getContacts(hhA.Id);
+            System.assertEquals(1, hhContacts.size());
+
+            // Simulate setting a new Default Address that is Undeliverable
+            copyAddressToAccount(newUndeliverableAddress, hhA);
+            copyAddressToContact(newUndeliverableAddress, hhContacts[0]);
+            HH_Container_LCTRL.saveHouseholdPage(hhA, hhContacts, new List<Contact>(), null);
+        }
+
+        hhA = (Account)HH_Container_LCTRL.getHousehold(hhA.Id);
+        System.assertEquals(true, hhA.get(String.valueOf(Account.Undeliverable_Address__c)), 
+            'The Household should now be set as Undeliverable');
+
     }
 
     // Helpers
@@ -788,6 +844,20 @@ private class HH_Container_TEST {
         c.MailingState = addr.MailingState__c;
         c.MailingPostalCode = addr.MailingPostalCode__c;
         c.MailingCountry = addr.MailingCountry__c;
+    }
+
+    /*********************************************************************************************************
+    * @description Populates Account's Billing Address from the source Address
+    * @param addr Address
+    * @param a Account
+    * @return void
+    **********************************************************************************************************/
+    private static void copyAddressToAccount(Address__c addr, Account a) {
+        a.BillingStreet = addr.MailingStreet__c;
+        a.BillingCity = addr.MailingCity__c;
+        a.BillingState = addr.MailingState__c;
+        a.BillingPostalCode = addr.MailingPostalCode__c;
+        a.BillingCountry = addr.MailingCountry__c;
     }
 
     /*********************************************************************************************************

--- a/force-app/main/default/classes/HH_Container_TEST.cls
+++ b/force-app/main/default/classes/HH_Container_TEST.cls
@@ -694,7 +694,7 @@ private class HH_Container_TEST {
             initTestData();
             String undeliverableField = UTIL_Namespace.StrTokenNSPrefix('Undeliverable__c');
             Map<String, String> fieldLabels = HH_Container_LCTRL.getFieldLabels();
-            System.assert(String.isBlank(fieldLabels.get(undeliverableField)), 'The Label should be blank');
+            System.assert(!String.isBlank(fieldLabels.get(undeliverableField)), 'The Label should not be blank');
 
             List<Address__c> listAddrA = HH_Container_LCTRL.getAddresses(hhA.Id, null);
             System.assertEquals(2, listAddrA.size());


### PR DESCRIPTION
# Critical Changes

# Changes

- We fixed an issue with the Manage Household page where the page wouldn't load without permissions to Undeliverable Address fields.

# Issues Closed

Fixes #6733 

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
