### PR TITLE
Add 2GP testing flow with trial config

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -857,6 +857,17 @@ flows:
             3:
                 task: update_admin_profile
 
+    ci_feature_2gp_trial:
+        steps:
+            1: 
+                flow: install_2gp_commit
+            2:
+                flow: config_apextest
+            3:
+                flow: config_trial
+            4:
+                task: run_tests
+
     config_trial:
         steps:
             1:


### PR DESCRIPTION
# Critical Changes

# Changes
Adds `ci_feature_2gp_trial` to `cumulusci.yml`, a flow that installs the 2gp beta package version for a commit, runs Apex tests, and runs Trial configuration.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
