### PR TITLE
W-10049109 - [PAYMENT ALLOCATIONS] Payment Allocations Rounding Issue when Creating New Payments

### DIFF
--- a/force-app/main/default/classes/ALLO_AllocationsRecalculateService.cls
+++ b/force-app/main/default/classes/ALLO_AllocationsRecalculateService.cls
@@ -224,13 +224,13 @@ public inherited sharing class ALLO_AllocationsRecalculateService {
                 //Calculate proportional amount for non-percentage based Payment allocations
                 // convertToPercentages must be true, the Percentage null, sourceAmount cannot be null and either Default Allocations are not enabled or the allocation is not for the Default Allocation
                 if (convertToPercentages && allocation.Percent__c == null & sourceAmount != null) {
+                    // Determine Percentage
                     Decimal allocationPercent = ((allocation.Amount__c != null) ? allocation.Amount__c : 0) / sourceAmount * 100;
 
-                    // Do not round the percent yet, we want the most accurate Amount value possible
                     allocation.Amount__c = (amount * allocationPercent * .01).setScale(2);
 
-                    // Round the visible percentage value to 2 decimal places after the amount is calculated
-                    allocation.Percent__c = allocationPercent.setScale(2, System.RoundingMode.HALF_UP);
+                    // Store Percentage as is, so precision is not lost in future calculations
+                    allocation.Percent__c = allocationPercent;
                 }
                 remainder -= (allocation.Amount__c != null) ? allocation.Amount__c : 0;
             }

--- a/force-app/main/default/classes/ALLO_AllocationsRecalculateService_TEST.cls
+++ b/force-app/main/default/classes/ALLO_AllocationsRecalculateService_TEST.cls
@@ -507,6 +507,120 @@ public class ALLO_AllocationsRecalculateService_TEST {
     }
 
     /**
+     * @description Defaults Payment Allocations from Parent Opportunity.  Payment Allocation Percentages are Irrational
+     *              Default Allocations Enabled
+     *              Payment Allocations Enabled
+     *              [ALLO_AllocationsRecalculateService.processPaymentAllocations]
+     *              
+     *              Opportunity Amount $100.01
+     *                  Opportunity Allocation 1 for GAU 1, $50.00
+     *                  Opportunity Allocation 2 for GAU 2, $50.01
+     * 
+     *              No allocations created on payment that is autocreated
+     * 
+     *              Run RecalculateService, confirm Payment Allocations created with Appropriate Irrational Percentages
+     * 
+     */ 
+    @isTest 
+    private static void confirmRecalculateServicePreservesFullPercentageWhenDefaultingPaymentAllocationsFromParent() {
+        ALLO_UnitTestHelper_TEST.AllocationSetupTest alloSetupTest = new ALLO_UnitTestHelper_TEST.AllocationSetupTest()
+            .enableDefaultAllocations()
+            .enablePaymentAllocations()
+            .disableAllocationTriggers()
+            .applyConfiguration();
+
+        List<Contact> ctcs = UTIL_UnitTestData_TEST.createMultipleTestContacts(1);
+        insert ctcs;
+
+        Opportunity opp = new Opportunity(
+            Name = 'Opp-recalcPmtAlloPercentCheck',
+            Amount = 100.01,
+            ContactID = ctcs[0].Id,
+            CloseDate = System.today(),
+            StageName = UTIL_UnitTestData_TEST.getClosedWonStage()
+        );
+        insert opp;
+
+
+        List<General_Accounting_Unit__c> gaus = alloSetupTest.getGAUs();
+        General_Accounting_Unit__c defaultGAU = alloSetupTest.getDefaultGAU();
+
+        // Setup irregular Allocations
+        List<Allocation__c> alloForInsert = new List<Allocation__c>{
+            new Allocation__c (General_Accounting_Unit__c = gaus[0].Id, Opportunity__c = opp.Id, Amount__c = 50, Percent__c = null),
+            new Allocation__c (General_Accounting_Unit__c = gaus[1].Id, Opportunity__c = opp.Id, Amount__c = 50.01, Percent__c = null)
+        };
+        insert alloForInsert;
+
+        List<npe01__OppPayment__c> pmts = [SELECT   Id,
+                                                    Name
+                                           FROM npe01__OppPayment__c
+                                           WHERE    npe01__Opportunity__c = :opp.Id];
+
+        System.assertEquals (1, pmts.size(), '# of Payments Present');
+
+        List<Allocation__c> pmtAllocs = [SELECT     Id,
+                                                    General_Accounting_Unit__c,
+                                                    Percent__c,
+                                                    Amount__c
+                                         FROM Allocation__c
+                                         WHERE Payment__c = :pmts[0].Id];
+        System.assertEquals(0, pmtAllocs.size(), 'No Allocations since allocations triggers are off');
+
+        Set<Id> oppIdsAsSet = new Set<Id>();
+        oppIdsAsSet.add(opp.Id);
+
+        ALLO_AllocationsWrapper allocWrapper = new ALLO_AllocationsRetrievalService()
+                                                .withOpportunities(oppIdsAsSet)
+                                                .retrieveData()
+                                                .allocationsWrapper;
+
+        ALLO_AllocationsReviewService allocReviewSvc = new ALLO_AllocationsReviewService()
+                                                            .withAllocationsWrapper(allocWrapper);
+                                                            
+        ALLO_AllocationsRecalculateService allocRecalcSvc = new ALLO_AllocationsRecalculateService()
+                                                                .withAllocationsWrapper(allocWrapper);
+
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForDelete, 0, 'Before Recalculate - Delete List');
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForInsert, 0, 'Before Recalculate - Insert List');
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForUpdate, 0, 'Before Recalculate - Update List');
+
+        allocRecalcSvc.processOpportunityAllocations();
+
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForDelete, 0, 'After Recalculate - Delete List');
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForInsert, 0, 'After Recalculate - Insert List');
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForUpdate, 0, 'After Recalculate - Update List');
+
+        // Have to process DML before processing the Payment Allocations
+        ALLO_AllocationsDMLService allocDMLSvc = new ALLO_AllocationsDMLService()
+                                                        .withAllocationsWrapper(allocWrapper);
+        allocDMLSvc.processAllocationResults();
+
+        // Manually clearing pending DML
+        allocWrapper.clearPendingDML();
+
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForDelete, 0, 'Before Process Payment Allocations - Delete List');
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForInsert, 0, 'Before Process Payment Allocations - Insert List');
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForUpdate, 0, 'Before Process Payment Allocations - Update List');
+
+        allocRecalcSvc.processPaymentAllocations();
+
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForDelete, 0, 'After Process Payment Allocations - Delete List');
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForInsert, 2, 'After Process Payment Allocations - Insert List');
+        ALLO_UnitTestHelper_TEST.assertSObjectList(allocWrapper.allocationsForUpdate, 0, 'After Process Payment Allocations - Update List');
+
+        Allocation__c pmtAlloc0 = ALLO_UnitTestHelper_TEST.findByGAU(allocWrapper.allocationsForInsert, gaus[0]);
+        Allocation__c pmtAlloc1 = ALLO_UnitTestHelper_TEST.findByGAU(allocWrapper.allocationsForInsert, gaus[1]);
+
+        // Calculate irrational compare percentages
+        Double percentGAU1 = (50.0/100.01) * 100;
+        Double percentGAU2 = (50.01/100.01) * 100;
+
+        ALLO_UnitTestHelper_TEST.assertPaymentAllocation(pmtAlloc0, pmts[0].Id, 50, percentGAU1, gaus[0].Id, 'Payment Allocation For GAU[0]');
+        ALLO_UnitTestHelper_TEST.assertPaymentAllocation(pmtAlloc1, pmts[0].Id, 50.01, percentGAU2, gaus[1].Id, 'Payment Allocation For GAU[1]');
+    }
+
+    /**
      * @description Confirm Recalculate Service creates correct DML changes when
      *              Default Allocations Enabled
      *              Payment Allocations Enabled

--- a/force-app/main/default/classes/ALLO_Allocations_TDTM.cls
+++ b/force-app/main/default/classes/ALLO_Allocations_TDTM.cls
@@ -640,11 +640,12 @@ public class ALLO_Allocations_TDTM extends TDTM_Runnable {
 
             //Calculate proportional amount for non-percentage based Payment allocations
             if (sObj instanceof npe01__OppPayment__c && allo.Percent__c == null) {
-                // Do not round the percent yet, we want the most accurate Amount value possible
+                // Determine Percentage
                 Decimal alloPercent = allo.Amount__c / wrap.parentAmount * 100;
                 allo.Amount__c = (amount * alloPercent * .01).setScale(2);
-                // Round the visible percentage value to 2 decimal places after the amount is calculated
-                allo.Percent__c = alloPercent.setScale(2, System.RoundingMode.HALF_UP);
+                
+                // Store Percentage as is, so precision is not lost in future calculations
+                allo.Percent__c = alloPercent;
             }
 
             //if this is a multicurrency org, recalculate the amount and set the CurrencyIsoCode

--- a/force-app/main/default/classes/ALLO_Allocations_TEST.cls
+++ b/force-app/main/default/classes/ALLO_Allocations_TEST.cls
@@ -208,10 +208,10 @@ private with sharing class ALLO_Allocations_TEST {
     * @description When Payments are created after the Opportunity and Opportunity Allocations exist,
     * ensure that the payment allocation percentages match those from the Opportunity Allocations, and
     * are not overwritten by additional logic in the trigger.
-    * Also check that allocation rounding works correctly and no amounts are allocated to the Default GAU
+    * Also check that no amounts are allocated to the Default GAU
     ********************************************************************************************************/
     @isTest
-    private static void confirmNewPaymentAllocationsMatchExistingOppAllocationRounding() {
+    private static void confirmNewPaymentAllocationsMatchExistingOppAllocationNotRounding() {
         General_Accounting_Unit__c defaultGau = new General_Accounting_Unit__c(Name='default GAU');
         insert defaultGau;
 
@@ -254,14 +254,19 @@ private with sharing class ALLO_Allocations_TEST {
 
         // Check that each allocation has the correct amount and percent
         List<Allocation__c> queryAllo = getAllocationsOrderByPercent(pmt.Id, gau1.Id);
-
+        
+        // We want the unrounded percentages to compare since that is what we are storing.
+        // $25 Fixed amount + $(25% * 100.01) = $50.0025 (Total Amount for GAU 1)
+        Double percentGAU1 = (50.0025/100.01) * 100;
+        Double percentGAU2 = (50.01/100.01) * 100;
+        
         // Make sure the percent value carried through to the Payment Allocation
-        System.assertEquals(50, queryAllo[0].Percent__c, 'The allocation percentage should be 50%.');
+        System.assertEquals(percentGAU1, queryAllo[0].Percent__c, 'The allocation percentage should be 50%.');
         System.assertEquals(50, queryAllo[0].Amount__c, 'The amount of the allocation should be calculated based on the parent Opportunity allocation.');
 
         queryAllo = getAllocationsOrderByPercent(pmt.Id, gau2.Id);
 
-        System.assertEquals(50, queryAllo[0].Percent__c, 'The allocation percentage should be 50%.');
+        System.assertEquals(percentGAU2, queryAllo[0].Percent__c, 'The allocation percentage should be 50%.');
         System.assertEquals(50.01, queryAllo[0].Amount__c, 'The amount of the allocation should be calculated based on the parent Opportunity allocation.');
 
         queryAllo = getAllocationsOrderByPercent(pmt.Id, defaultGau.Id);

--- a/force-app/main/default/classes/ALLO_UnitTestHelper_TEST.cls
+++ b/force-app/main/default/classes/ALLO_UnitTestHelper_TEST.cls
@@ -453,7 +453,7 @@ public class ALLO_UnitTestHelper_TEST {
      * @param gauId Will assert value against General_Accounting_Unit__c
      * @param message The text to put on the front on the assertion message text
      */
-    public static void assertOpportunityAllocation(Allocation__c alloc, Id opportunityId, Decimal amount, Decimal percentage, Id gauId, String message) {
+    public static void assertOpportunityAllocation(Allocation__c alloc, Id opportunityId, Decimal amount, Double percentage, Id gauId, String message) {
         assertAllocation(alloc, opportunityId, null, null, null, amount, percentage, null, gauId, message);
     }
 

--- a/force-app/main/default/classes/ALLO_UnitTestHelper_TEST.cls
+++ b/force-app/main/default/classes/ALLO_UnitTestHelper_TEST.cls
@@ -466,7 +466,7 @@ public class ALLO_UnitTestHelper_TEST {
      * @param gauName Will assert value against General_Accounting_Unit__r.Name
      * @param message The text to put on the front on the assertion message text
      */
-    public static void assertOpportunityAllocation(Allocation__c alloc, Id opportunityId, Decimal amount, Decimal percentage, String gauName, String message) {
+    public static void assertOpportunityAllocation(Allocation__c alloc, Id opportunityId, Decimal amount, Double percentage, String gauName, String message) {
         assertAllocation(alloc, opportunityId, null, null, null, amount, percentage, gauName, null, message);
     }
 
@@ -479,7 +479,7 @@ public class ALLO_UnitTestHelper_TEST {
      * @param gauName Will assert value against General_Accounting_Unit__r.Name
      * @param message The text to put on the front on the assertion message text
      */
-    public static void assertPaymentAllocation(Allocation__c alloc, Id paymentId, Decimal amount, Decimal percentage, String gauName, String message) {
+    public static void assertPaymentAllocation(Allocation__c alloc, Id paymentId, Decimal amount, Double percentage, String gauName, String message) {
         assertAllocation(alloc, null, paymentId, null, null, amount, percentage, gauName, null, message);
     }
 
@@ -492,7 +492,7 @@ public class ALLO_UnitTestHelper_TEST {
      * @param gauId Will assert value against General_Accounting_Unit__c
      * @param message The text to put on the front on the assertion message text
      */
-    public static void assertPaymentAllocation(Allocation__c alloc, Id paymentId, Decimal amount, Decimal percentage, Id gauId, String message) {
+    public static void assertPaymentAllocation(Allocation__c alloc, Id paymentId, Decimal amount, Double percentage, Id gauId, String message) {
         assertAllocation(alloc, null, paymentId, null, null, amount, percentage, null, gauId, message);
     }
 
@@ -505,7 +505,7 @@ public class ALLO_UnitTestHelper_TEST {
      * @param gauName Will assert value against General_Accounting_Unit__r.Name
      * @param message The text to put on the front on the assertion message text
      */
-    public static void assertRecurringDonationAllocation(Allocation__c alloc, Id recurringDonationId, Decimal amount, Decimal percentage, String gauName, String message) {
+    public static void assertRecurringDonationAllocation(Allocation__c alloc, Id recurringDonationId, Decimal amount, Double percentage, String gauName, String message) {
         assertAllocation(alloc, null, null, recurringDonationId, null, amount, percentage, gauName, null, message);
     }
 
@@ -518,7 +518,7 @@ public class ALLO_UnitTestHelper_TEST {
      * @param gauId Will assert value against General_Accounting_Unit__c
      * @param message The text to put on the front on the assertion message text
      */
-    public static void assertRecurringDonationAllocation(Allocation__c alloc, Id recurringDonationId, Decimal amount, Decimal percentage, Id gauId, String message) {
+    public static void assertRecurringDonationAllocation(Allocation__c alloc, Id recurringDonationId, Decimal amount, Double percentage, Id gauId, String message) {
         assertAllocation(alloc, null, null, recurringDonationId, null, amount, percentage, null, gauId, message);
     }
 
@@ -531,7 +531,7 @@ public class ALLO_UnitTestHelper_TEST {
      * @param gauName Will assert value against General_Accounting_Unit__r.Name
      * @param message The text to put on the front on the assertion message text
      */
-    public static void assertCampaignAllocation(Allocation__c alloc, Id campaignId, Decimal amount, Decimal percentage, String gauName, String message) {
+    public static void assertCampaignAllocation(Allocation__c alloc, Id campaignId, Decimal amount, Double percentage, String gauName, String message) {
         assertAllocation(alloc, null, null, null, campaignId, amount, percentage, gauName, null, message);
     }
 
@@ -544,7 +544,7 @@ public class ALLO_UnitTestHelper_TEST {
      * @param gauId Will assert value against General_Accounting_Unit__c
      * @param message The text to put on the front on the assertion message text
      */
-    public static void assertCampaignAllocation(Allocation__c alloc, Id campaignId, Decimal amount, Decimal percentage, Id gauId, String message) {
+    public static void assertCampaignAllocation(Allocation__c alloc, Id campaignId, Decimal amount, Double percentage, Id gauId, String message) {
         assertAllocation(alloc, null, null, null, campaignId, amount, percentage, null, gauId, message);
     }
 
@@ -561,7 +561,7 @@ public class ALLO_UnitTestHelper_TEST {
      * @param gauId If not null, will assert value against General_Accounting_Unit__c
      * @param message The text to put on the front on the assertion message text
      */
-    public static void assertAllocation(Allocation__c alloc, Id opportunityId, Id paymentId, Id recurringDonationId, Id campaignId, Decimal amount, Decimal percentage, String gauName, Id gauId, String message) {
+    public static void assertAllocation(Allocation__c alloc, Id opportunityId, Id paymentId, Id recurringDonationId, Id campaignId, Decimal amount, Double percentage, String gauName, Id gauId, String message) {
         System.assertNotEquals(null, alloc, message + ' - Not Null');
         System.assertEquals(opportunityId, alloc.Opportunity__c, message + ' - Opportunity' );
         System.assertEquals(paymentId, alloc.Payment__c, message + ' - Payment');


### PR DESCRIPTION
- Note: This fix affects Payment Allocations only
- Removed logic from Allocations trigger to round percentage when calculating percentage for Payment Allocations when they are defaulted from the Opportunity
- Updated Test in ALLO_Allocations_TEST to account for change
- Added Test to ALLO_RecalculateService_TEST to confirm behavior there as well, with irrational percentage
- Updated assert methods in ALLO_UnitTestHelper_TEST to use double for percentage to maintain consistency

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
