### PR TITLE
Fix 404 in relatinships viewer page with URLFOR formula

### DIFF
--- a/force-app/main/default/pages/REL_RelationshipsViewer.page
+++ b/force-app/main/default/pages/REL_RelationshipsViewer.page
@@ -388,7 +388,7 @@
             uriString += 'retURL=' + currentContact.id;
             var encodedNewRel = encodeURI(uriString);
             infoText += '<a href=' + encodedNewRel + ' target="_blank" style="color: white; font-weight: bold;" >[ {!JSINHTMLENCODE($Label.REL_Create_New_Relationship)} ]</a><br />';
-            infoText += '<a href=/apex/REL_RelationshipsViewer?id=' + currentContact.id + ' target="_parent" style="color: white; font-weight: bold;">[ {!JSINHTMLENCODE($Label.REL_RECenter)} ]</a><br />';
+            infoText += '<a href={!URLFOR($Page.REL_RelationshipsViewer)}&id=' + currentContact.id + ' target="_parent" style="color: white; font-weight: bold;">[ {!JSINHTMLENCODE($Label.REL_RECenter)} ]</a><br />';
             infoText +='</strong></p>';     
             return infoText;    
         }

--- a/force-app/main/default/pages/REL_RelationshipsViewer.page
+++ b/force-app/main/default/pages/REL_RelationshipsViewer.page
@@ -199,7 +199,7 @@
                                                 }                                               
                                 
                                                 if (!relatedNode) {
-                                                    relatedNode = particleSystem.addNode(result[i].id, {label:result[i].firstName + ' ' + result[i].lastName, color:colors[childColorIndex]})
+                                                    relatedNode = particleSystem.addNode(result[i].id, {label:result[i].firstName + ' ' + result[i].lastName, color:colors[childColorIndex], colorIndex:childColorIndex, link:result[i].link, id:result[i].id, title:result[i].title, accountName:result[i].accountName})
                                                 }
                                                 // only add edge ifthe relationship is not already drawn
                                                 if (particleSystem.getEdges(currNode, relatedNode).length == 0 && particleSystem.getEdges(relatedNode, currNode).length == 0) {

--- a/force-app/main/default/pages/REL_RelationshipsViewer.page
+++ b/force-app/main/default/pages/REL_RelationshipsViewer.page
@@ -388,7 +388,7 @@
             uriString += 'retURL=' + currentContact.id;
             var encodedNewRel = encodeURI(uriString);
             infoText += '<a href=' + encodedNewRel + ' target="_blank" style="color: white; font-weight: bold;" >[ {!JSINHTMLENCODE($Label.REL_Create_New_Relationship)} ]</a><br />';
-            infoText += '<a href={!URLFOR($Page.REL_RelationshipsViewer)}&id=' + currentContact.id + ' target="_parent" style="color: white; font-weight: bold;">[ {!JSINHTMLENCODE($Label.REL_RECenter)} ]</a><br />';
+            infoText += '<a href=' + getRelationshipViewerURLForContact(currentContact.id) + ' target="_parent" style="color: white; font-weight: bold;">[ {!JSINHTMLENCODE($Label.REL_RECenter)} ]</a><br />';
             infoText +='</strong></p>';     
             return infoText;    
         }
@@ -418,6 +418,20 @@
                 if (fill) {
                     ctx.fill();
                 }
+            }
+
+            function getRelationshipViewerURLForContact(contactId) {
+                const baseUrl = '{!$Site.BaseUrl}';
+                const pageUrl = '{!URLFOR($Page.REL_RelationshipsViewer)}';
+                let urlObject;
+                if(baseUrl !== '') {
+                    // URLFOR in Sites only returns a relative URL, so we must supply a base URL.
+                    urlObject = new URL(pageUrl, baseUrl);
+                } else {
+                    urlObject = new URL(pageUrl);
+                }
+                urlObject.searchParams.append('id', contactId);
+                return urlObject.href;
             }
         </script>
 


### PR DESCRIPTION
WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008EIa1IAG/view
# Critical Changes

# Changes
- We fixed an issue with the Relationship Viewer page where users would receive a 404 error when clicking the "Re-center on this Contact" link

# Issues Closed

Fixes #4063 

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
