### PR TITLE
W-10034496 - Fix Duplicate Oppts when creating RDs in BDI

### DIFF
--- a/force-app/main/default/classes/BDI_DataImportService.cls
+++ b/force-app/main/default/classes/BDI_DataImportService.cls
@@ -2110,9 +2110,36 @@ global with sharing class BDI_DataImportService {
     */
     public static Boolean anyFieldsPopulatedForObjectMapping(DataImport__c di,
                                                             Map<String,String> diFieldToTargetFieldMap) {
+        return anyFieldsPopulatedForObjectMapping(di, diFieldToTargetFieldMap, new String[]{});
+    }
+
+    /*******************************************************************************************************
+    * @description loops through fields provided in Map and determines if any of them have a value.  If at least
+    * one field does, then it returns true.  This variant of the method also allows a list of fields to ignore to be 
+    * passed in since some fields may be mapped to two different object mappings, and others may always have a value.
+    * @param di the data import record to check
+    * @param diFieldToTargetFieldMap the mapping of DI field to target field that will be evaluated.
+    * @param fieldsToIgnore List of fields that should be ignored when checking for values, usually because these fields
+    * are shared with another object mapping, or are always populated.
+    * @return Boolean whether any fields were populated
+    */
+    public static Boolean anyFieldsPopulatedForObjectMapping(DataImport__c di,
+                                                            Map<String,String> diFieldToTargetFieldMap,
+                                                            String[] fieldsToIgnore) {
         Boolean isPopulated = false;
+
+        if (fieldsToIgnore == null) {
+            fieldsToIgnore = new String[]{};
+        } else {
+            // Force all fields to lower case so they can match correctly
+            for (Integer i = 0; i < fieldsToIgnore.size(); i++) {
+                fieldsToIgnore[i] = fieldsToIgnore[i].toLowerCase();
+            }
+        }
+
         for (String diField : diFieldToTargetFieldMap.keySet()){
-            if (di.get(diField) != null) {
+            // Set the is populated flag to true if the field should not be ignored, and it does have a value in the DI
+            if (!fieldsToIgnore.contains(diField.toLowerCase()) && di.get(diField) != null) {
                 isPopulated = true;
                 break;
             }

--- a/force-app/main/default/classes/BDI_DataImportService.cls
+++ b/force-app/main/default/classes/BDI_DataImportService.cls
@@ -2139,7 +2139,7 @@ global with sharing class BDI_DataImportService {
 
         for (String diField : diFieldToTargetFieldMap.keySet()){
             // Set the is populated flag to true if the field should not be ignored, and it does have a value in the DI
-            Boolean shouldAddPopulatedField = !fieldsToIgnore.contains(diField.toLowerCase()) && di.get(diField) != null
+            Boolean shouldAddPopulatedField = !fieldsToIgnore.contains(diField.toLowerCase()) && di.get(diField) != null;
             if (shouldAddPopulatedField) {
                 isPopulated = true;
                 break;

--- a/force-app/main/default/classes/BDI_DataImportService.cls
+++ b/force-app/main/default/classes/BDI_DataImportService.cls
@@ -2139,7 +2139,8 @@ global with sharing class BDI_DataImportService {
 
         for (String diField : diFieldToTargetFieldMap.keySet()){
             // Set the is populated flag to true if the field should not be ignored, and it does have a value in the DI
-            if (!fieldsToIgnore.contains(diField.toLowerCase()) && di.get(diField) != null) {
+            Boolean shouldAddPopulatedField = !fieldsToIgnore.contains(diField.toLowerCase()) && di.get(diField) != null
+            if (shouldAddPopulatedField) {
                 isPopulated = true;
                 break;
             }

--- a/force-app/main/default/classes/BDI_DataImportService_TEST.cls
+++ b/force-app/main/default/classes/BDI_DataImportService_TEST.cls
@@ -201,6 +201,44 @@ private with sharing class BDI_DataImportService_TEST {
         }
     }
 
+    /*******************************************************************************************************************
+    * @description Tests utility methods that determine whether any fields for a given object mapping are populated with
+    * a value.
+    */
+    @isTest
+    private static void shouldReturnWhetherFieldsArePopulated (){
+        DataImport__c testDI1 = new DataImport__c(Donation_Amount__c = 10, 
+                                                    Donation_Date__c = System.Date.today(), 
+                                                    Account1_name__c = null);
+        DataImport__c testDI2 = new DataImport__c(Contact1_lastname__c = 'TestGuy');
+
+        // Using varied capitalizations for the test data to make sure the forcing to lowercase is working correctly.
+        Map<String,String> testFieldMap = new Map<String,String>{'donation_amount__c' =>'amount',
+                                                                'Donation_Date__c' => 'closedate',
+                                                                'donation_stage__c' => 'stagename',
+                                                                'account1_Name__c' => 'Name'};
+        String[] fieldsToIgnore1 = new String[]{'Donation_Amount__c'};
+        String[] fieldsToIgnore2 = new String[]{'Donation_Amount__c','Donation_Date__c'};
+
+        // Should be true since two fields are populated
+        System.assertEquals(true, BDI_DataImportService.anyFieldsPopulatedForObjectMapping(testDI1, testFieldMap));
+
+        // Should be false since none of the fields specified is populated
+        System.assertEquals(false, BDI_DataImportService.anyFieldsPopulatedForObjectMapping(testDI2, testFieldMap));
+
+        // Should still be true since one of the fields not being igorned is populated
+        System.assertEquals(true, 
+                    BDI_DataImportService.anyFieldsPopulatedForObjectMapping(testDI1, testFieldMap, fieldsToIgnore1));
+
+        // Should be false since populated field is not in the field map
+        System.assertEquals(false, 
+                    BDI_DataImportService.anyFieldsPopulatedForObjectMapping(testDI2, testFieldMap, fieldsToIgnore1));
+
+        // Should be false because both populated fields are now being ignored
+        System.assertEquals(false, 
+                    BDI_DataImportService.anyFieldsPopulatedForObjectMapping(testDI1, testFieldMap, fieldsToIgnore2));
+    }
+
     // Helpers
     ////////////
 

--- a/force-app/main/default/classes/BDI_Donations.cls
+++ b/force-app/main/default/classes/BDI_Donations.cls
@@ -37,6 +37,9 @@
 */
 public class BDI_Donations {
 
+    public static final String[] campaignImportedFields = new String[]{'npsp__DonationCampaignImported__c',
+                                                                        'DonationCampaignImported__c'};
+
     /*******************************************************************************************************
     * @description constructor for the BDI Donations helper
     * @param bdi The Batch Data Import Service the helper should use
@@ -311,10 +314,12 @@ public class BDI_Donations {
     */
     private List<DataImport__c> validateDonationsToProcess(String matchBehavior) {
         List<DataImport__c> dataImportDonations = new List<DataImport__c>();
+
         for (DataImport__c dataImport : bdi.listDI) {
-            Boolean anyDonationFieldsPopulated =
+
+            Boolean anyNonCampaignDonationFieldsPopulated =
                     BDI_DataImportService.anyFieldsPopulatedForObjectMapping(dataImport,
-                            dataImportFieldToOpportunityField);
+                            dataImportFieldToOpportunityField,campaignImportedFields);
             Boolean anyPaymentFieldsPopulated =
                     BDI_DataImportService.anyFieldsPopulatedForObjectMapping(dataImport,dataImportFieldToPaymentField);
 
@@ -323,15 +328,16 @@ public class BDI_Donations {
                continue;
             }
 
-            //If there are no Donation Fields or Payment Fields populated and no donation amount populated then
-            //do not continue with donation processing.
-            if (dataImport.Donation_Amount__c == null && !anyDonationFieldsPopulated && !anyPaymentFieldsPopulated) {
+            // If there are no Donation Fields or Payment Fields populated and no donation amount populated then
+            // do not continue with donation processing. The 'Donation Campaign Imported / Source' field doesn't count since 
+            // that could be populated if a user was just creating a Recurring Donation.
+            if (dataImport.Donation_Amount__c == null && !anyNonCampaignDonationFieldsPopulated && !anyPaymentFieldsPopulated) {
                 continue;
             }
 
             // Skip DIs that have no fields populated for donation and no DonationImported Id, which means they are
             // not new Donations and not in the DI to serve as a parent for a new payment.
-            if (dataImport.DonationImported__c == null && !anyDonationFieldsPopulated) {
+            if (dataImport.DonationImported__c == null && !anyNonCampaignDonationFieldsPopulated) {
                 continue;
             }
 

--- a/force-app/main/default/classes/BDI_RecurringDonations.cls
+++ b/force-app/main/default/classes/BDI_RecurringDonations.cls
@@ -247,7 +247,9 @@ public class BDI_RecurringDonations {
             // RD then it is just being provided as an existing parent of a new Opportunity, and doesn't need to be
             // included in the update.
             if (dataImport.RecurringDonationImported__c != null &&
-                    !BDI_DataImportService.anyFieldsPopulatedForObjectMapping(dataImport,dataImportFieldToRDField)) {
+                    !BDI_DataImportService.anyFieldsPopulatedForObjectMapping(dataImport,
+                                                                                dataImportFieldToRDField,
+                                                                                BDI_Donations.campaignImportedFields)) {
                 return null;
 
             }

--- a/force-app/main/default/classes/BDI_SettingsUI_TEST.cls
+++ b/force-app/main/default/classes/BDI_SettingsUI_TEST.cls
@@ -76,14 +76,15 @@ private with sharing class BDI_SettingsUI_TEST {
         Boolean containsImportedField = false;
 
         for (SelectOption option : ctrl.listSODonationFields) {
-            if (option.getValue() == UTIL_Namespace.alignSchemaNSWithEnvironment(
-                    'npsp__donationcampaignimported__c')) {
+
+            String paymentOriginIdField = SObjectType.DataImport__c.fields.Payment_Origin_Id__c.Name.toLowerCase();
+            if (option.getValue() == paymentOriginIdField) {
                 containsImportedField = true;
                 break;
             }
         }
         Test.startTest();
-        System.assert(containsImportedField, 'Help Text Mapping Enabled');
+        System.assert(!containsImportedField, 'Help Text Mapping Enabled');
         Test.stopTest();
     }
 
@@ -98,16 +99,15 @@ private with sharing class BDI_SettingsUI_TEST {
         Boolean containsImportedField = false;
 
         for (SelectOption option : ctrl.listSODonationFields) {
-            if (option.getValue() == UTIL_Namespace.alignSchemaNSWithEnvironment(
-                    'npsp__donationcampaignimported__c')) {
+
+            String paymentOriginIdField = SObjectType.DataImport__c.fields.Payment_Origin_Id__c.Name.toLowerCase();
+            if (option.getValue() == paymentOriginIdField) {
                 containsImportedField = true;
                 break;
             }
         }
         Test.startTest();
-        System.assert(!containsImportedField, 'Advanced Field Mapping Enabled');
+        System.assert(containsImportedField, 'Advanced Field Mapping Enabled');
         Test.stopTest();
     }
-
-
 }

--- a/force-app/main/default/customMetadata/Data_Import_Field_Mapping.Donation_Campaign_Source.md-meta.xml
+++ b/force-app/main/default/customMetadata/Data_Import_Field_Mapping.Donation_Campaign_Source.md-meta.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Donation Campaign Source</label>
+    <protected>true</protected>
+    <values>
+        <field>Data_Import_Field_Mapping_Set__c</field>
+        <value xsi:type="xsd:string">Default_Field_Mapping_Set</value>
+    </values>
+    <values>
+        <field>Is_Deleted__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Required__c</field>
+        <value xsi:type="xsd:string">No</value>
+    </values>
+    <values>
+        <field>Source_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">npsp__DonationCampaignImported__c</value>
+    </values>
+    <values>
+        <field>Target_Field_API_Name__c</field>
+        <value xsi:type="xsd:string">CampaignId</value>
+    </values>
+    <values>
+        <field>Target_Object_Mapping__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+</CustomMetadata>


### PR DESCRIPTION
This fixes an issue where if a Recurring Donation is created in BDI with a campaign defined, but no initial Donation defined it still creates an initial donation. This was occurring because the code that checks to see if any Opportunity Object mapping fields were populated was including the DonationCampaignImported__c field (Which is used by both RD and Oppts) in the populated field check that determines whether or not the Opportunity attempts to be created.

We are creating a field mapping because Donation Campaign Source was missed when we originally converted the help text mappings to the custom metadata "advanced" mappings. It has been getting created automatically during advanced mapping enablement so it hasn't directly caused problems, but the fact that it is missing meant that the unit tests for Recurring Donation didn't catch this bug earlier. Adding it means that the default mapping is more accurate and we can now catch regressions for this bug. It does not need to be added to any install scripts because an equivalent mapping has already been created for all orgs during enablement.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
