### PR TITLE
W-9871893, W-9871890: Get Started page headers not logically nested

### DIFF
--- a/force-app/main/default/lwc/gsChecklistItem/gsChecklistItem.html
+++ b/force-app/main/default/lwc/gsChecklistItem/gsChecklistItem.html
@@ -12,7 +12,7 @@
         </div>
         <div class="card-content">
             <p class="content-time">{item.extraInfo}</p>
-            <h1 class="content-title">{item.title}</h1>
+            <h3 class="content-title">{item.title}</h3>
             <div  class="content-text">
                {item.description}
             </div>

--- a/force-app/main/default/lwc/gsResources/gsResources.html
+++ b/force-app/main/default/lwc/gsResources/gsResources.html
@@ -1,6 +1,6 @@
 <template>
     <div class="container">
-        <h1>{title}</h1>
+        <h2>{title}</h2>
         <div class="resource-list">
             <template for:each={resources} for:item="resource" for:index="index">
                 <div class="resource-item" key={resource.id} >

--- a/force-app/main/default/lwc/gsResources/gsResources.html
+++ b/force-app/main/default/lwc/gsResources/gsResources.html
@@ -1,6 +1,6 @@
 <template>
     <div class="container">
-        <h2>{title}</h2>
+        <h2 class="slds-text-heading_medium">{title}</h2>
         <div class="resource-list">
             <template for:each={resources} for:item="resource" for:index="index">
                 <div class="resource-item" key={resource.id} >


### PR DESCRIPTION
# Work Items
[W-9871893](https://gus.lightning.force.com/a07EE000005MMYcYAO)
[W-9871890](https://gus.lightning.force.com/a07EE000005MMYZYA4)

# Changes
Removing hardcoded h1 from gsResources component

# Issues Closed
Now all the header elements in the Get Started With NPSP pages have logical nesting.
