### PR TITLE
Removing deprecated button exclusion to fix 236 deployment

### DIFF
--- a/force-app/main/default/objects/DataImport__c/DataImport__c.object-meta.xml
+++ b/force-app/main/default/objects/DataImport__c/DataImport__c.object-meta.xml
@@ -71,7 +71,6 @@
         <excludedStandardButtons>ChangeOwner</excludedStandardButtons>
         <excludedStandardButtons>MassChangeOwner</excludedStandardButtons>
         <excludedStandardButtons>PrintableListView</excludedStandardButtons>
-        <excludedStandardButtons>IsotopeSubscription</excludedStandardButtons>
         <listViewButtons>Process_Data_Import</listViewButtons>
         <listViewButtons>Delete_All_Data_Import_Records</listViewButtons>
         <listViewButtons>Delete_Imported_Data_Import_Records</listViewButtons>


### PR DESCRIPTION
I can't fully test this because I'm seeing "invalid cross reference id" when trying to deploy Apex in the pre-release org, but I believe that has to do with the org and not our code, since I can't manually create an Apex class either!

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
