### PR TITLE
W-9871887: "Get Started" page checklist titles not accessible through keyboard

### DIFF
--- a/force-app/main/default/lwc/accordionSection/accordionSection.html
+++ b/force-app/main/default/lwc/accordionSection/accordionSection.html
@@ -10,6 +10,7 @@
                     class="slds-align_absolute-center slds-m-vertical_x-small"
                 >
                     <button
+                        aria-label={title}
                         onclick={handleToggle}
                         aria-controls="accordion-details"
                         aria-expanded={isOpen}

--- a/force-app/main/default/lwc/accordionSection/accordionSection.js
+++ b/force-app/main/default/lwc/accordionSection/accordionSection.js
@@ -6,6 +6,7 @@ import toggleInstructionsWhenClosed from "@salesforce/label/c.accordionSection_T
 
 export default class AccordionSection extends LightningElement {
     @api preventToggle = false;
+    @api title
     @api shadeOnOpen;
 
     @track isOpen = false;

--- a/force-app/main/default/lwc/gsAccordionLabel/gsAccordionLabel.html
+++ b/force-app/main/default/lwc/gsAccordionLabel/gsAccordionLabel.html
@@ -7,7 +7,7 @@
         <div class="slds-media__body slds-m-top_xx-small">
             <div class="slds-media">
                 <div class="slds-setup-assistant__step-summary-content slds-media__body">
-                    <h2 tabindex="0" class="slds-setup-assistant__step-summary-title slds-text-heading_small"
+                    <h2 class="slds-setup-assistant__step-summary-title slds-text-heading_small"
                         onclick={onClickTitle}>
                         {title}
                     </h2>

--- a/force-app/main/default/lwc/gsChecklist/gsChecklist.html
+++ b/force-app/main/default/lwc/gsChecklist/gsChecklist.html
@@ -1,6 +1,6 @@
 <template>
     <article class="slds-setup-assistant__step">
-        <c-accordion-section>
+        <c-accordion-section title={group.title}>
             <div slot="clickableHeaderSection"
                 class="slds-m-left_medium">
                 <c-gs-accordion-label


### PR DESCRIPTION
# Work Item
[W-9871887](https://gus.lightning.force.com/a07EE000005MMYWYA4)

# Changes
Modified "Get Started with NPSP" LWCs so that the page is Accessibility compliant. Now, the keyboard focus does not focus on the title. Instead, it focuses on the c-accordion-section and reads its aria-label, and can now be interacted with through keyboard or click.