### PR TITLE
W-9871891: Learn More link does not warn it opens in new window

### DIFF
--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -9625,6 +9625,14 @@ If preferred, you can disable Gift Entry and instead use older Batch Gift Entry 
         <value>Learn More</value>
     </labels>
     <labels>
+        <fullName>gsLearnMoreAriaLabel</fullName>
+        <categories>Get Started Page</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Aria Label for theLearn more label for the application status component</shortDescription>
+        <value>Learn More (opens in a new window)</value>
+    </labels>
+    <labels>
         <fullName>gsNoApplicationSubmitted</fullName>
         <categories>Get Started Page</categories>
         <language>en_US</language>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -9629,7 +9629,7 @@ If preferred, you can disable Gift Entry and instead use older Batch Gift Entry 
         <categories>Get Started Page</categories>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Aria Label for theLearn more label for the application status component</shortDescription>
+        <shortDescription>Aria Label for the Learn more label for the application status component</shortDescription>
         <value>Learn More (opens in a new window)</value>
     </labels>
     <labels>

--- a/force-app/main/default/lwc/gsApplicationStatus/gsApplicationStatus.html
+++ b/force-app/main/default/lwc/gsApplicationStatus/gsApplicationStatus.html
@@ -11,7 +11,7 @@
             <lightning-layout horizontal-align="space">
                 <template  if:false={isApplicationSubmitted}>
                     <lightning-layout-item size="12" class="slds-text-align_center slds-size_full slds-p-around_small slds-text-heading_small">
-                        <p class="slds-m-bottom_medium">{labels.gsNoApplicationSubmitted} | <a href="https://sforce.co/2IZygfz" target="_blank" onkeypress={handleKeypress}>{labels.gsLearnMore}</a></p>
+                        <p class="slds-m-bottom_medium">{labels.gsNoApplicationSubmitted} | <a href="https://sforce.co/2IZygfz" target="_blank" onkeypress={handleKeypress} aria-label={labels.gsLearnMoreAriaLabel}>{labels.gsLearnMore}</a></p>
                         <p class="slds-m-bottom_medium daysLeft">{diffInDays} {labels.gsDaysRemainingInFreeTrial}</p>
                         <a role="button" class="slds-button slds-button_brand slds-p-around_medium button-padding" href="https://sforce.co/37MPp4e" target="_blank" onkeypress={handleKeypress}>{labels.gsApplyForFreeLicenses}</a>
                     </lightning-layout-item>

--- a/force-app/main/default/lwc/gsApplicationStatus/gsApplicationStatus.js
+++ b/force-app/main/default/lwc/gsApplicationStatus/gsApplicationStatus.js
@@ -3,6 +3,7 @@ import Resources from '@salesforce/resourceUrl/CumulusStaticResources'
 import getApplicationStatus from '@salesforce/apex/GS_ApplicationStatusController.getApplicationStatus'
 import gsNoApplicationSubmitted from '@salesforce/label/c.gsNoApplicationSubmitted'
 import gsLearnMore from '@salesforce/label/c.gsLearnMore'
+import gsLearnMoreAriaLabel from '@salesforce/label/c.gsLearnMoreAriaLabel'
 import gsDaysRemainingInFreeTrial from '@salesforce/label/c.gsDaysRemainingInFreeTrial'
 import gsApplyForFreeLicenses from '@salesforce/label/c.gsApplyForFreeLicenses'
 import gsApplicationStatus from '@salesforce/label/c.gsApplicationStatus'
@@ -12,8 +13,9 @@ import gsCheckStatus from '@salesforce/label/c.gsCheckStatus'
 import gsApplicationStatusModalHeader from '@salesforce/label/c.gsApplicationStatusModalHeader'
 import gsClose from '@salesforce/label/c.commonClose'
 import gsFollowUpApplicationStatus from '@salesforce/label/c.gsFollowUpApplicationStatus'
+
 export default class GsApplicationStatus extends LightningElement {
-    
+
     @track errorMessage = "";
     @track diffInDays = null;
     @track isApplicationSubmitted = false;
@@ -34,7 +36,8 @@ export default class GsApplicationStatus extends LightningElement {
         gsCheckStatus,
         gsApplicationStatusModalHeader,
         gsClose,
-        gsFollowUpApplicationStatus
+        gsFollowUpApplicationStatus,
+        gsLearnMoreAriaLabel
     }
 
     /**


### PR DESCRIPTION
# Work Item
[W-9871891](https://gus.lightning.force.com/a07EE000005MMYaYAO)

# Changes
Added aria-label attribute to Learn More link in gsApplicationStatus component so it warns users of screen readers that said link opens in a new tab.