### PR TITLE
Relationships Viewer - Handle Platform Encryption on Name Field

### DIFF
--- a/force-app/main/default/classes/RelationshipSelector.cls
+++ b/force-app/main/default/classes/RelationshipSelector.cls
@@ -35,18 +35,19 @@
 public with sharing class RelationshipSelector {
 
     public List<npe4__Relationship__c> getContactRelations(Id contactId) {
-        return [
-                SELECT Id,
-                        npe4__Relationship_Explanation__c,
-                        npe4__RelatedContact__c,
-                        toLabel(npe4__Type__c),
-                        npe4__RelatedContact__r.Account.Name,
-                        npe4__RelatedContact__r.Name,
-                        npe4__RelatedContact__r.Title
-                FROM npe4__Relationship__c
-                WHERE npe4__Contact__c = :contactId
-                WITH SECURITY_ENFORCED
-                ORDER BY npe4__RelatedContact__r.Name
-        ];
+        UTIL_Query query = new UTIL_Query()
+                .withSelectFields(new Set<String>{
+                        'npe4__Relationship_Explanation__c',
+                        'npe4__RelatedContact__c',
+                        'toLabel(npe4__Type__c)',
+                        'npe4__RelatedContact__r.Account.Name',
+                        'npe4__RelatedContact__r.Name',
+                        'npe4__RelatedContact__r.Title'
+                })
+                .withFrom(npe4__Relationship__c.SObjectType)
+                .withWhere('npe4__Contact__c = :contactId')
+                .withOrderByEncryptable(Contact.Name, 'npe4__RelatedContact__r.Name')
+                .withSecurityEnforced();
+        return Database.query(query.build());
     }
 }

--- a/force-app/main/default/classes/RelationshipSelector.cls
+++ b/force-app/main/default/classes/RelationshipSelector.cls
@@ -46,7 +46,7 @@ public with sharing class RelationshipSelector {
                 })
                 .withFrom(npe4__Relationship__c.SObjectType)
                 .withWhere('npe4__Contact__c = :contactId')
-                .withOrderByEncryptable(Contact.Name, 'npe4__RelatedContact__r.Name')
+                .withOrderBy(Contact.Name, 'npe4__RelatedContact__r.Name')
                 .withSecurityEnforced();
         return Database.query(query.build());
     }

--- a/force-app/main/default/classes/UTIL_Describe.cls
+++ b/force-app/main/default/classes/UTIL_Describe.cls
@@ -799,6 +799,10 @@ public class UTIL_Describe {
         return objectName;
     }
 
+    public Boolean isFieldSortable(Schema.SObjectField field) {
+        return field.getDescribe().isSortable();
+    }
+
     /** @description our exception object for Field Level & Object Security errors. */
     private class permsException extends Exception {}
 

--- a/force-app/main/default/classes/UTIL_Query.cls
+++ b/force-app/main/default/classes/UTIL_Query.cls
@@ -34,6 +34,17 @@
 * @description SOQL Builder
 */
 public with sharing class UTIL_Query {
+    @TestVisible
+    private UTIL_Describe describe {
+        get {
+            if(describe == null) {
+                describe = new UTIL_Describe();
+            }
+            return describe;
+        }
+        set;
+    }
+
     /** @description Exception raised by the Query builder */
     public class UTIL_QueryException extends Exception {}
 
@@ -107,6 +118,20 @@ public with sharing class UTIL_Query {
     */
     public UTIL_Query withOrderBy(String orderBy) {
         this.orderBy = orderBy;
+        return this;
+    }
+
+    /**
+     * @description Registers an ORDER BY field only if that field is unencrypted and sortable.
+     * @param field A reference to the field being sorted on
+     * @param clause The order by clause to add to the query
+     *
+     * @return UTIL_Query The instance of the Query builder
+     */
+    public UTIL_Query withOrderByEncryptable(Schema.SObjectField field, String orderByClause) {
+        if(describe.isFieldSortable(field)) {
+            this.orderBy = orderByClause;
+        }
         return this;
     }
 

--- a/force-app/main/default/classes/UTIL_Query.cls
+++ b/force-app/main/default/classes/UTIL_Query.cls
@@ -128,7 +128,7 @@ public with sharing class UTIL_Query {
      *
      * @return UTIL_Query The instance of the Query builder
      */
-    public UTIL_Query withOrderByEncryptable(Schema.SObjectField field, String orderByClause) {
+    public UTIL_Query withOrderBy(Schema.SObjectField field, String orderByClause) {
         if(describe.isFieldSortable(field)) {
             this.orderBy = orderByClause;
         }

--- a/force-app/main/default/classes/UTIL_Query.cls
+++ b/force-app/main/default/classes/UTIL_Query.cls
@@ -124,7 +124,7 @@ public with sharing class UTIL_Query {
     /**
      * @description Registers an ORDER BY field only if that field is unencrypted and sortable.
      * @param field A reference to the field being sorted on
-     * @param clause The order by clause to add to the query
+     * @param orderByClause The order by clause to add to the query
      *
      * @return UTIL_Query The instance of the Query builder
      */

--- a/force-app/main/default/classes/UTIL_Query_TEST.cls
+++ b/force-app/main/default/classes/UTIL_Query_TEST.cls
@@ -448,11 +448,11 @@ private class UTIL_Query_TEST {
 
         query.withFrom(Contact.SObjectType)
                 .withSelectFields(new List<String>{'Id', 'FirstName', 'LastName'})
-                .withOrderByEncryptable(Contact.LastName, 'LastName');
+                .withOrderBy(Contact.LastName, 'LastName');
         String queryStr = query.build();
         System.assert(!queryStr.contains('ORDER BY LastName'));
 
-        query.withOrderByEncryptable(Contact.FirstName, 'FirstName');
+        query.withOrderBy(Contact.FirstName, 'FirstName');
         queryStr = query.build();
         System.assert(queryStr.contains('ORDER BY FirstName'));
     }

--- a/force-app/main/default/classes/UTIL_Query_TEST.cls
+++ b/force-app/main/default/classes/UTIL_Query_TEST.cls
@@ -436,4 +436,55 @@ private class UTIL_Query_TEST {
 
         System.assertEquals(expectedSoql, soql, 'SOQL should include offset');
     }
+
+    @IsTest
+    static void shouldExcludeEncryptedFields() {
+        UTIL_DescribeMock describeMock = new UTIL_DescribeMock()
+                .sortable(Contact.FirstName)
+                .unsortable(Contact.LastName);
+        UTIL_Query query = new UTIL_Query();
+        query.describe = (UTIL_Describe)Test.createStub(UTIL_Describe.class, describeMock);
+        query.describe.isFieldSortable(Contact.LastName);
+
+        query.withFrom(Contact.SObjectType)
+                .withSelectFields(new List<String>{'Id', 'FirstName', 'LastName'})
+                .withOrderByEncryptable(Contact.LastName, 'LastName');
+        String queryStr = query.build();
+        System.assert(!queryStr.contains('ORDER BY LastName'));
+
+        query.withOrderByEncryptable(Contact.FirstName, 'FirstName');
+        queryStr = query.build();
+        System.assert(queryStr.contains('ORDER BY FirstName'));
+    }
+
+
+    private class UTIL_DescribeMock implements StubProvider {
+        Map<Schema.SObjectField, Boolean> fieldSortableMap;
+
+        public UTIL_DescribeMock() {
+            fieldSortableMap = new Map<Schema.SObjectField, Boolean>();
+        }
+
+        public UTIL_DescribeMock sortable(Schema.SObjectField field) {
+            this.fieldSortableMap.put(field, true);
+            return this;
+        }
+
+        public UTIL_DescribeMock unsortable(Schema.SObjectField field) {
+            this.fieldSortableMap.put(field, false);
+            return this;
+        }
+
+        public Object handleMethodCall(Object stubbedObject, String stubbedMethodName,
+                Type returnType, List<Type> listOfParamTypes, List<String> listOfParamNames,
+                List<Object> listOfArgs) {
+
+            switch on stubbedMethodName {
+                when 'isFieldSortable' {
+                    return fieldSortableMap.get((Schema.SObjectField)listOfArgs[0]);
+                }
+            }
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
WI: https://gus.lightning.force.com/lightning/r/ADM_Sprint__c/a0lEE0000001M6lYAE/view

Fixes an issue in relationship viewer where we're not able to sort the returned results by Name in an org with platform encryption enabled.
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
