### PR TITLE
Mark Household All Members Deceased

### DIFF
--- a/force-app/main/default/layouts/Account-Household Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Account-Household Layout.layout-meta.xml
@@ -29,6 +29,10 @@
                 <behavior>Edit</behavior>
                 <field>npo02__Informal_Greeting__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>All_Members_Deceased__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/layouts/Account-Household Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Account-Household Layout.layout-meta.xml
@@ -29,10 +29,6 @@
                 <behavior>Edit</behavior>
                 <field>npo02__Informal_Greeting__c</field>
             </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>All_Members_Deceased__c</field>
-            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/objects/Account/fields/All_Members_Deceased__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/All_Members_Deceased__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>All_Members_Deceased__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>All members of this household are deceased.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>All members of this household are deceased. This field should not be directly updated. It is updated automatically as a result of updates to the Deceased checkbox on member Contacts.</inlineHelpText>
+    <label>All Household Members Deceased</label>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/Account/fields/All_Members_Deceased__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/All_Members_Deceased__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>All_Members_Deceased__c</fullName>
     <defaultValue>false</defaultValue>
-    <description>If selected, all members of this household are deceased. Do not update this field manually. It's updated automatically by NPSP as a result of updates to the Deceased checkbox on household member Contacts.</description>
+    <description>If selected, all members of this household are deceased. Do not update this field manually. It&apos;s updated automatically by NPSP as a result of updates to the Deceased checkbox on household member Contacts.</description>
     <externalId>false</externalId>
     <inlineHelpText>If selected, all members of this household are deceased. Do not update this field manually. It&apos;s updated automatically by NPSP as a result of updates to the Deceased checkbox on household member Contacts.</inlineHelpText>
     <label>All Household Members Deceased</label>

--- a/force-app/main/default/objects/Account/fields/All_Members_Deceased__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/All_Members_Deceased__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>All_Members_Deceased__c</fullName>
     <defaultValue>false</defaultValue>
-    <description>All members of this household are deceased.</description>
+    <description>If selected, all members of this household are deceased. Do not update this field manually. It's updated automatically by NPSP as a result of updates to the Deceased checkbox on household member Contacts.</description>
     <externalId>false</externalId>
     <inlineHelpText>All members of this household are deceased. This field should not be directly updated. It is updated automatically as a result of updates to the Deceased checkbox on member Contacts.</inlineHelpText>
     <label>All Household Members Deceased</label>

--- a/force-app/main/default/objects/Account/fields/All_Members_Deceased__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/All_Members_Deceased__c.field-meta.xml
@@ -4,7 +4,7 @@
     <defaultValue>false</defaultValue>
     <description>If selected, all members of this household are deceased. Do not update this field manually. It's updated automatically by NPSP as a result of updates to the Deceased checkbox on household member Contacts.</description>
     <externalId>false</externalId>
-    <inlineHelpText>All members of this household are deceased. This field should not be directly updated. It is updated automatically as a result of updates to the Deceased checkbox on member Contacts.</inlineHelpText>
+    <inlineHelpText>If selected, all members of this household are deceased. Do not update this field manually. It&apos;s updated automatically by NPSP as a result of updates to the Deceased checkbox on household member Contacts.</inlineHelpText>
     <label>All Household Members Deceased</label>
     <trackFeedHistory>false</trackFeedHistory>
     <type>Checkbox</type>

--- a/force-app/main/selector/ContactSelector.cls
+++ b/force-app/main/selector/ContactSelector.cls
@@ -83,7 +83,7 @@ public inherited sharing class ContactSelector {
         if (queryForContactNamingFields == null) {
             //we use dynamic soql so we can include all contact fields, since custom naming may refer to any field.
             String[] selectFields = new String[]{
-                    'Id', 'HHId__c', 'npo02__Naming_Exclusions__c', UTIL_Namespace.StrTokenNSPrefix('Deceased__c')
+                    'Id', 'HHId__c', 'npo02__Naming_Exclusions__c', 'Deceased__c'
             };
             selectFields.addAll(
                     new HouseholdNamingService()
@@ -171,7 +171,7 @@ public inherited sharing class ContactSelector {
         List<String> selectFields = new List<String>{
                 'Id', 'npe01__Private__c', 'AccountId', 'Account.npe01__SYSTEMIsIndividual__c',
                 'Account.npe01__SYSTEM_AccountType__c', 'Account.npe01__One2OneContact__c',
-                'npe01__Organization_Type__c', 'Account.Name', UTIL_Namespace.StrTokenNSPrefix('Deceased__c'),
+                'npe01__Organization_Type__c', 'Account.Name', 'Deceased__c',
                 'FirstName', 'LastName', 'OwnerId', 'Salutation', 'npo02__Naming_Exclusions__c',
                 'npo02__Household_Naming_Order__c',
                 'MailingStreet', 'MailingCity', 'MailingState', 'MailingPostalCode',

--- a/force-app/main/selector/ContactSelector.cls
+++ b/force-app/main/selector/ContactSelector.cls
@@ -83,7 +83,7 @@ public inherited sharing class ContactSelector {
         if (queryForContactNamingFields == null) {
             //we use dynamic soql so we can include all contact fields, since custom naming may refer to any field.
             String[] selectFields = new String[]{
-                    'Id', 'HHId__c', 'npo02__Naming_Exclusions__c'
+                    'Id', 'HHId__c', 'npo02__Naming_Exclusions__c', UTIL_Namespace.StrTokenNSPrefix('Deceased__c')
             };
             selectFields.addAll(
                     new HouseholdNamingService()
@@ -171,7 +171,7 @@ public inherited sharing class ContactSelector {
         List<String> selectFields = new List<String>{
                 'Id', 'npe01__Private__c', 'AccountId', 'Account.npe01__SYSTEMIsIndividual__c',
                 'Account.npe01__SYSTEM_AccountType__c', 'Account.npe01__One2OneContact__c',
-                'npe01__Organization_Type__c', 'Account.Name',
+                'npe01__Organization_Type__c', 'Account.Name', UTIL_Namespace.StrTokenNSPrefix('Deceased__c'),
                 'FirstName', 'LastName', 'OwnerId', 'Salutation', 'npo02__Naming_Exclusions__c',
                 'npo02__Household_Naming_Order__c',
                 'MailingStreet', 'MailingCity', 'MailingState', 'MailingPostalCode',

--- a/force-app/main/service/HouseholdNamingService.cls
+++ b/force-app/main/service/HouseholdNamingService.cls
@@ -193,7 +193,7 @@ public without sharing class HouseholdNamingService {
             }
 
             if (originalDeceased != allMembersDeceased) {
-                household.put('All_Members_Deceased__c', allMembersDeceased);
+                household.put(UTIL_Namespace.StrTokenNSPrefix('All_Members_Deceased__c'), allMembersDeceased);
                 unitOfWork.registerDirty(new List<SObject>{household});
             }
         }

--- a/force-app/main/service/HouseholdNamingService.cls
+++ b/force-app/main/service/HouseholdNamingService.cls
@@ -124,6 +124,11 @@ public without sharing class HouseholdNamingService {
             setHouseholdNameFieldValues(householdsOrAccounts, membersByHouseholdId);
         }
         setNumberOfHouseholdMembers(householdsOrAccounts, membersByHouseholdId);
+
+        if (householdsOrAccounts?.get(0).getSObjectType() == Account.SObjectType) {
+            setAllMembersDeceasedFlag(householdsOrAccounts, membersByHouseholdId);
+        }
+
         unitOfWork.save();
 
         TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.flag.HH, false);
@@ -164,6 +169,26 @@ public without sharing class HouseholdNamingService {
                 return currentNumberOfHouseholdMembersValue != householdMembers.size();
             } else {
                 return true;
+            }
+        }
+    }
+
+    public void setAllMembersDeceasedFlag(List<SObject> householdsOrAccounts, Map<Id, List<Contact>> membersByHouseholdId) {
+        for (SObject household : householdsOrAccounts) {
+            Boolean originalDeceased = (Boolean)household.get(UTIL_Namespace.StrTokenNSPrefix('All_Members_Deceased__c'));
+            Boolean allMembersDeceased = true;
+
+            List<Contact> members = membersByHouseholdId.get(idFor(household));
+            for (Contact member : members) {
+                if (member.Deceased__c == false) {
+                    allMembersDeceased = false;
+                    break;
+                }
+            }
+
+            if (originalDeceased != allMembersDeceased) {
+                household.put(UTIL_Namespace.StrTokenNSPrefix('All_Members_Deceased__c'), allMembersDeceased);
+                unitOfWork.registerDirty(new List<SObject>{household});
             }
         }
     }
@@ -219,7 +244,8 @@ public without sharing class HouseholdNamingService {
     private List<SObject> getAccountsFor(List<Id> hhids) {
         return [
                 SELECT Id, Name, npo02__SYSTEM_CUSTOM_NAMING__c, npo02__Formal_Greeting__c,
-                        npo02__Informal_Greeting__c, Number_of_Household_Members__c
+                        npo02__Informal_Greeting__c, Number_of_Household_Members__c,
+                        All_Members_Deceased__c
                 FROM Account
                 WHERE Id IN :hhids
         ];

--- a/force-app/main/service/HouseholdNamingService.cls
+++ b/force-app/main/service/HouseholdNamingService.cls
@@ -125,13 +125,20 @@ public without sharing class HouseholdNamingService {
         }
         setNumberOfHouseholdMembers(householdsOrAccounts, membersByHouseholdId);
 
-        if (!householdsOrAccounts.isEmpty() && householdsOrAccounts?.get(0).getSObjectType() == Account.SObjectType) {
+        if (isListOfAccountIds(householdsOrAccounts)) {
             setAllMembersDeceasedFlag(householdsOrAccounts, membersByHouseholdId);
         }
 
         unitOfWork.save();
 
         TDTM_ProcessControl.setRecursionFlag(TDTM_ProcessControl.flag.HH, false);
+    }
+
+    private Boolean isListOfAccountIds(List<SObject> householdsOrAccounts) {
+        if (householdsOrAccounts.isEmpty()) {
+            return false;
+        }
+        return householdsOrAccounts?.get(0).getSObjectType() == Account.SObjectType;
     }
 
     private void save(List<SObject> householdsOrAccounts) {
@@ -173,8 +180,8 @@ public without sharing class HouseholdNamingService {
         }
     }
 
-    public void setAllMembersDeceasedFlag(List<SObject> householdsOrAccounts, Map<Id, List<Contact>> membersByHouseholdId) {
-        for (Account household : (List<Account>)householdsOrAccounts) {
+    public void setAllMembersDeceasedFlag(List<Account> accounts, Map<Id, List<Contact>> membersByHouseholdId) {
+        for (Account household : accounts) {
             Boolean originalDeceased = household.All_Members_Deceased__c;
             Boolean allMembersDeceased;
 

--- a/force-app/main/service/HouseholdNamingService.cls
+++ b/force-app/main/service/HouseholdNamingService.cls
@@ -174,11 +174,11 @@ public without sharing class HouseholdNamingService {
     }
 
     public void setAllMembersDeceasedFlag(List<SObject> householdsOrAccounts, Map<Id, List<Contact>> membersByHouseholdId) {
-        for (SObject household : householdsOrAccounts) {
-            Boolean originalDeceased = (Boolean)household.get('All_Members_Deceased__c');
+        for (Account household : (List<Account>)householdsOrAccounts) {
+            Boolean originalDeceased = household.All_Members_Deceased__c;
             Boolean allMembersDeceased;
 
-            List<Contact> members = membersByHouseholdId.get(idFor(household));
+            List<Contact> members = membersByHouseholdId.get(household.Id);
             if (members == null) {
                 allMembersDeceased = false;
 
@@ -193,7 +193,7 @@ public without sharing class HouseholdNamingService {
             }
 
             if (originalDeceased != allMembersDeceased) {
-                household.put(UTIL_Namespace.StrTokenNSPrefix('All_Members_Deceased__c'), allMembersDeceased);
+                household.All_Members_Deceased__c = allMembersDeceased;
                 unitOfWork.registerDirty(new List<SObject>{household});
             }
         }

--- a/force-app/main/service/HouseholdNamingService.cls
+++ b/force-app/main/service/HouseholdNamingService.cls
@@ -175,7 +175,7 @@ public without sharing class HouseholdNamingService {
 
     public void setAllMembersDeceasedFlag(List<SObject> householdsOrAccounts, Map<Id, List<Contact>> membersByHouseholdId) {
         for (SObject household : householdsOrAccounts) {
-            Boolean originalDeceased = (Boolean)household.get(UTIL_Namespace.StrTokenNSPrefix('All_Members_Deceased__c'));
+            Boolean originalDeceased = (Boolean)household.get('All_Members_Deceased__c');
             Boolean allMembersDeceased;
 
             List<Contact> members = membersByHouseholdId.get(idFor(household));
@@ -193,7 +193,7 @@ public without sharing class HouseholdNamingService {
             }
 
             if (originalDeceased != allMembersDeceased) {
-                household.put(UTIL_Namespace.StrTokenNSPrefix('All_Members_Deceased__c'), allMembersDeceased);
+                household.put('All_Members_Deceased__c', allMembersDeceased);
                 unitOfWork.registerDirty(new List<SObject>{household});
             }
         }

--- a/force-app/main/service/HouseholdNamingService.cls
+++ b/force-app/main/service/HouseholdNamingService.cls
@@ -178,7 +178,7 @@ public without sharing class HouseholdNamingService {
             Boolean originalDeceased = household.All_Members_Deceased__c;
             Boolean allMembersDeceased;
 
-            List<Contact> members = membersByHouseholdId.get(household.Id);
+            List<Contact> members = membersByHouseholdId?.get(household.Id);
             if (members == null) {
                 allMembersDeceased = false;
 

--- a/force-app/main/service/HouseholdNamingService.cls
+++ b/force-app/main/service/HouseholdNamingService.cls
@@ -176,13 +176,19 @@ public without sharing class HouseholdNamingService {
     public void setAllMembersDeceasedFlag(List<SObject> householdsOrAccounts, Map<Id, List<Contact>> membersByHouseholdId) {
         for (SObject household : householdsOrAccounts) {
             Boolean originalDeceased = (Boolean)household.get(UTIL_Namespace.StrTokenNSPrefix('All_Members_Deceased__c'));
-            Boolean allMembersDeceased = true;
+            Boolean allMembersDeceased;
 
             List<Contact> members = membersByHouseholdId.get(idFor(household));
-            for (Contact member : members) {
-                if (member.Deceased__c == false) {
-                    allMembersDeceased = false;
-                    break;
+            if (members == null) {
+                allMembersDeceased = false;
+
+            } else {
+                allMembersDeceased = true;
+                for (Contact member : members) {
+                    if (member.Deceased__c == false) {
+                        allMembersDeceased = false;
+                        break;
+                    }
                 }
             }
 

--- a/force-app/main/service/HouseholdNamingService.cls
+++ b/force-app/main/service/HouseholdNamingService.cls
@@ -125,7 +125,7 @@ public without sharing class HouseholdNamingService {
         }
         setNumberOfHouseholdMembers(householdsOrAccounts, membersByHouseholdId);
 
-        if (householdsOrAccounts?.get(0).getSObjectType() == Account.SObjectType) {
+        if (!householdsOrAccounts.isEmpty() && householdsOrAccounts?.get(0).getSObjectType() == Account.SObjectType) {
             setAllMembersDeceasedFlag(householdsOrAccounts, membersByHouseholdId);
         }
 

--- a/force-app/test/HouseholdNamingService_TEST.cls
+++ b/force-app/test/HouseholdNamingService_TEST.cls
@@ -749,6 +749,71 @@ public class HouseholdNamingService_TEST {
         System.assert(expectedContactIds.containsAll(hhContactIds), 'Expected Contacts do not match returned list: ' + hhContacts);
     }
 
+    /*********************************************************************************************************
+    @description 2 contacts with deceased true should result in account with all deceased true
+    **********************************************************************************************************/
+    @IsTest
+    private static void shouldSetAllDeceasedTrueWhenAllContactsDeceased() {
+        HouseholdNamingService service = new HouseholdNamingService();
+
+        Account household = UTIL_UnitTestData_TEST.buildHouseholdAccount();
+        household.Id = UTIL_UnitTestData_TEST.mockId(household.getSObjectType());
+        household.All_Members_Deceased__c = false;
+
+        Map<Id, List<Contact>> contactsByIds = new Map<Id, List<Contact>>{
+            household.Id => new List<Contact>{
+                new Contact(Deceased__c = true),
+                new Contact(Deceased__c = true)
+            }
+        };
+
+        service.setAllMembersDeceasedFlag(new List<SObject>{ household }, contactsByIds);
+
+        Account updatedAccount = (Account)service.unitOfWork.objectsToUpdate[0];
+        System.assertEquals(true, updatedAccount.All_Members_Deceased__c, 'All Members Deceased should be true.');
+    }
+
+    /*********************************************************************************************************
+    @description 1 contact with deceased false should result in account with all deceased false
+    **********************************************************************************************************/
+    @IsTest
+    private static void shouldSetAllDeceasedFalseWhenNotAllContactsDeceased() {
+        HouseholdNamingService service = new HouseholdNamingService();
+
+        Account household = UTIL_UnitTestData_TEST.buildHouseholdAccount();
+        household.Id = UTIL_UnitTestData_TEST.mockId(household.getSObjectType());
+        household.All_Members_Deceased__c = true;
+
+        Map<Id, List<Contact>> contactsByIds = new Map<Id, List<Contact>>{
+            household.Id => new List<Contact>{
+                new Contact(Deceased__c = true),
+                new Contact(Deceased__c = false)
+            }
+        };
+
+        service.setAllMembersDeceasedFlag(new List<SObject>{ household }, contactsByIds);
+
+        Account updatedAccount = (Account)service.unitOfWork.objectsToUpdate[0];
+        System.assertEquals(false, updatedAccount.All_Members_Deceased__c, 'All Members Deceased should be false.');
+    }
+
+    /*********************************************************************************************************
+    @description Empty contact list should result in account with all deceased false
+    **********************************************************************************************************/
+    @IsTest
+    private static void shouldSetAllDeceasedFalseWhenNoContacts() {
+        HouseholdNamingService service = new HouseholdNamingService();
+
+        Account household = UTIL_UnitTestData_TEST.buildHouseholdAccount();
+        household.Id = UTIL_UnitTestData_TEST.mockId(household.getSObjectType());
+        household.All_Members_Deceased__c = true;
+
+        service.setAllMembersDeceasedFlag(new List<SObject>{ household }, null);
+
+        Account updatedAccount = (Account)service.unitOfWork.objectsToUpdate[0];
+        System.assertEquals(false, updatedAccount.All_Members_Deceased__c, 'All Members Deceased should be false.');
+    }
+
 
     // Helpers
     ////////////


### PR DESCRIPTION
Added All Members Deceased flag to Account and aggregated the Deceased flag on member households after contact insert, contact delete, contact addition to, and contact removal from a household.

# Critical Changes

# Changes
 - We introduced new feature to help you manage deceased Contacts. When all Contacts within a Household are marked as deceased, NPSP selects the All Members Deceased checkbox on the Household Account. Use this field in report and list view filters to remove deceased members from your mailing lists.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata
Custom Field
- Account.All_Members_Deceased__c

# Deleted Metadata
