### PR TITLE
(CAB) Fixing scenario where a new Contact with no Address fields creates an Address

### DIFF
--- a/force-app/main/adapter/in/sobjects/contact/ContactAdapter.cls
+++ b/force-app/main/adapter/in/sobjects/contact/ContactAdapter.cls
@@ -477,7 +477,7 @@ public inherited sharing class ContactAdapter extends fflib_SObjects {
         for (Integer i = 0; i < getRecords().size(); i++) {
             Contact newRecord = (Contact) getRecords()[i];
 
-            if (contactService.isContactAddressChanged(newRecord, oldVersionOf(newRecord))) {
+            if (new NPSP_Contact(newRecord, oldVersionOf(newRecord)).isAddressChanged()) {
                 UTIL_Address.normalizeLineBreak(newRecord);
             }
         }

--- a/force-app/main/default/classes/NPSP_Contact.cls
+++ b/force-app/main/default/classes/NPSP_Contact.cls
@@ -110,7 +110,7 @@ public inherited sharing class NPSP_Contact {
     public Boolean isAddressChanged() {
         return isNewContact() ? !isAddressEmpty() : 
             addressService.isSObjectAddressDifferent(oldContact, mailingAddress()) ||
-            primaryAddressTypeChanged();
+            (!isAddressEmpty() && primaryAddressTypeChanged());
     }
 
     public Boolean isAddressEmpty() {

--- a/force-app/main/default/classes/NPSP_Contact.cls
+++ b/force-app/main/default/classes/NPSP_Contact.cls
@@ -109,7 +109,8 @@ public inherited sharing class NPSP_Contact {
 
     public Boolean isAddressChanged() {
         return isNewContact() ? !isAddressEmpty() : 
-            mailingAddressIsDifferentFrom(new NPSP_Address(oldContact));
+            addressService.isSObjectAddressDifferent(oldContact, mailingAddress()) ||
+            primaryAddressTypeChanged();
     }
 
     public Boolean isAddressEmpty() {
@@ -122,6 +123,10 @@ public inherited sharing class NPSP_Contact {
 
     public Boolean currentAddressChanged() {
         return contact.Current_Address__c != oldContact?.Current_Address__c;
+    }
+
+    public Boolean primaryAddressTypeChanged() {
+        return primaryAddressType(contact) != primaryAddressType(oldContact);
     }
 
     public Boolean hasAccount() {

--- a/force-app/main/default/classes/NPSP_Contact.cls
+++ b/force-app/main/default/classes/NPSP_Contact.cls
@@ -108,7 +108,8 @@ public inherited sharing class NPSP_Contact {
     }
 
     public Boolean isAddressChanged() {
-        return contactService.isContactAddressChanged(contact, oldContact);
+        return isNewContact() ? !isAddressEmpty() : 
+            mailingAddressIsDifferentFrom(new NPSP_Address(oldContact));
     }
 
     public Boolean isAddressEmpty() {

--- a/force-app/main/default/classes/NPSP_Contact_TEST.cls
+++ b/force-app/main/default/classes/NPSP_Contact_TEST.cls
@@ -55,4 +55,15 @@ private class NPSP_Contact_TEST {
 
         System.assertNotEquals(null, npspContact.mailingAddress());
     }
+
+    @IsTest
+    static void givenAContactWithOnlyPrimaryAddressType_thenAddressNotMarkedChanged() {
+        //Todo: replace with dummy contact with address
+        NPSP_Contact npspContact = new NPSP_Contact(
+                new Contact(LastName='Tester',FirstName='Test',npe01__Primary_Address_Type__c='Home')
+        );
+
+        System.assertEquals(false, npspContact.isAddressChanged());
+    }
+
 }

--- a/force-app/main/service/ContactService.cls
+++ b/force-app/main/service/ContactService.cls
@@ -69,53 +69,6 @@ public with sharing class ContactService {
     }
 
     /*******************************************************************************************************
-    * @description compares two contacts' addresses
-    * @param con1 a Contact
-    * @param con2 a Contact
-    * @return boolean. true if the Mailing Address fields have changed
-    ********************************************************************************************************/
-    public Boolean isContactAddressChanged(Contact con1, Contact con2) {
-        // if both null, no change
-        if (con1 == null && con2 == null) {
-            return false;
-        }
-
-        // if one null, make sure other has at least one address field set
-        if (con1 == null || con2 == null) {
-            if (con1 == null) {
-                con1 = con2;
-            }
-            return !isContactAddressEmpty(con1);
-        }
-
-        // both provided, so look for at least one change between address fields
-        Boolean isChanged =
-                !addressServiceInstance.equalsCaseSensitive(con1.MailingStreet, con2.MailingStreet) ||
-                        !addressServiceInstance.equalsCaseSensitive(con1.MailingCity, con2
-                                .MailingCity) ||
-                        !addressServiceInstance.equalsCaseSensitive(con1.MailingState, con2
-                                .MailingState) ||
-                        !addressServiceInstance.equalsCaseSensitive(con1.MailingPostalCode, con2
-                                .MailingPostalCode) ||
-                        !addressServiceInstance.equalsCaseSensitive(con1.MailingCountry, con2
-                                .MailingCountry) ||
-                        !addressServiceInstance.equalsCaseSensitive(con1
-                                .npe01__Primary_Address_Type__c,
-                                con2
-                                .npe01__Primary_Address_Type__c);
-
-        if (!isChanged && orgConfig.isStateCountryPicklistsEnabled()) {
-            isChanged =
-                    !addressServiceInstance.equalsCaseSensitive(String.valueOf(con1.get
-                            ('MailingStateCode')),
-                            String.valueOf(con2.get('MailingStateCode'))) ||
-                            !addressServiceInstance.equalsCaseSensitive(String.valueOf(con1.get
-                                    ('MailingCountryCode')), String.valueOf(con2.get('MailingCountryCode')));
-        }
-        return isChanged;
-    }
-
-    /*******************************************************************************************************
     * @description returns whether the contact's mailing address is empty
     * @param con1 a Contact
     * @return boolean. true if the Mailing Address fields are all empty

--- a/force-app/main/service/ContactService.cls
+++ b/force-app/main/service/ContactService.cls
@@ -85,8 +85,7 @@ public with sharing class ContactService {
             if (con1 == null) {
                 con1 = con2;
             }
-            return (!isContactAddressEmpty(con1) ||
-                    con1.npe01__Primary_Address_Type__c != null);
+            return !isContactAddressEmpty(con1);
         }
 
         // both provided, so look for at least one change between address fields

--- a/force-app/tdtm/classes/TDTM_DMLgt200_TEST.cls
+++ b/force-app/tdtm/classes/TDTM_DMLgt200_TEST.cls
@@ -363,14 +363,14 @@ private class TDTM_DMLgt200_TEST {
         UTIL_UnitTestData_TEST.disableRelationshipTriggers();
         UTIL_UnitTestData_TEST.disableMergeTriggers();
 
-        Test.startTest();
-
         // Create more than 200 Contact records and then validate that all of the Household Accounts were created
         List<Contact> contacts = createMultipleTestContacts(insertCnt);
         insertWithAllowDupes(contacts);
 
         System.assertEquals(insertCnt, [SELECT Count() FROM Account WHERE npe01__SYSTEM_AccountType__c = :CAO_Constants.HH_ACCOUNT_TYPE],
                 'There should be exactly ' + insertCnt.format() + ' Accounts');
+
+        Test.startTest();
 
         // rename all the Contacts
         Integer n = 0;


### PR DESCRIPTION
- This version of the PR is for a direct merge to main
- If merged, it replaces #6800 

# Critical Changes

# Changes

- We fixed a scenario where inserting or updating a Contact with a Primary Address Type, but no Address fields, would unnecessarily create, then delete, an Address record.

# Issues Closed

Fixes #6759 

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
