### PR TITLE
Update TSO to include 238 Feature Defaults

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -891,18 +891,18 @@ flows:
                 task: test_data_relationships
                 ignore_failure: true
             6:
+                task: deploy_trial_translations
+            7:
+                task: deploy_reports
+            8:
+                flow: enable_rd2
+            9:
+                flow: enable_gift_entry
+            10:
                 task: execute_anon
                 options:
                     path: scripts/trial/TrialCustomSettingsDefaults.cls
                     apex: updateCustomSettingsDefaults();
-            7:
-                task: deploy_trial_translations
-            8:
-                task: deploy_reports
-            9:
-                flow: enable_rd2
-            10:
-                flow: enable_gift_entry
             11:
                 task: update_admin_profile
 

--- a/scripts/trial/TrialCustomSettingsDefaults.cls
+++ b/scripts/trial/TrialCustomSettingsDefaults.cls
@@ -38,7 +38,7 @@ public static void setRecurringDonationDefaults() {
     recurringDonationsSettings.%%%NAMESPACE%%%EnableAutomaticNaming__c = true;
     recurringDonationsSettings.npe03__Record_Type__c = getOppRecordType('Donation');
     recurringDonationsSettings.%%%NAMESPACE%%%StatusAutomationLapsedValue__c = 'Lapsed';
-    recurringDonationsSettings.%%%NAMESPACE%%%SStatusAutomationClosedValue__c = 'Closed';
+    recurringDonationsSettings.%%%NAMESPACE%%%StatusAutomationClosedValue__c = 'Closed';
     settingsToUpdate.add(recurringDonationsSettings);
 }
 

--- a/scripts/trial/TrialCustomSettingsDefaults.cls
+++ b/scripts/trial/TrialCustomSettingsDefaults.cls
@@ -37,7 +37,8 @@ public static void setRecurringDonationDefaults() {
             '{!npe03__Donor_Name__c} {!npe03__Amount__c} - Recurring';
     recurringDonationsSettings.%%%NAMESPACE%%%EnableAutomaticNaming__c = true;
     recurringDonationsSettings.npe03__Record_Type__c = getOppRecordType('Donation');
-
+    recurringDonationsSettings.%%%NAMESPACE%%%StatusAutomationLapsedValue__c = 'Lapsed';
+    recurringDonationsSettings.%%%NAMESPACE%%%SStatusAutomationClosedValue__c = 'Closed';
     settingsToUpdate.add(recurringDonationsSettings);
 }
 

--- a/scripts/trial/TrialCustomSettingsDefaults.cls
+++ b/scripts/trial/TrialCustomSettingsDefaults.cls
@@ -11,7 +11,7 @@ public static void updateCustomSettingsDefaults() {
 
     upsert settingsToUpdate;
 }
-public static void setContactsAndOrgDefaults() {
+private static void setContactsAndOrgDefaults() {
     npe01__Contacts_And_Orgs_Settings__c contactSettings = npe01__Contacts_And_Orgs_Settings__c.getOrgDefaults();
     contactSettings.%%%NAMESPACE%%%Honoree_Opportunity_Contact_Role__c = 'Honoree';
     contactSettings.%%%NAMESPACE%%%Notification_Recipient_Opp_Contact_Role__c = 'Notification Recipient';
@@ -22,14 +22,14 @@ public static void setContactsAndOrgDefaults() {
     settingsToUpdate.add(contactSettings);
 }
 
-public static void setRelationshipDefaults() {
+private static void setRelationshipDefaults() {
     npe4__Relationship_Settings__c relationshipSettings = npe4__Relationship_Settings__c.getOrgDefaults();
     relationshipSettings.npe4__Gender_Field__c = 'Gender__c';
 
     settingsToUpdate.add(relationshipSettings);
 }
 
-public static void setRecurringDonationDefaults() {
+private static void setRecurringDonationDefaults() {
     npe03__Recurring_Donations_Settings__c recurringDonationsSettings =
         npe03__Recurring_Donations_Settings__c.getOrgDefaults();
 
@@ -42,7 +42,7 @@ public static void setRecurringDonationDefaults() {
     settingsToUpdate.add(recurringDonationsSettings);
 }
 
-public static void setErrorNotificationDefaults() {
+private static void setErrorNotificationDefaults() {
     %%%NAMESPACE%%%Error_Settings__c errorSettings = %%%NAMESPACE%%%Error_Settings__c.getOrgDefaults();
     errorSettings.%%%NAMESPACE%%%Respect_Duplicate_Rule_Settings__c = true;
 
@@ -52,7 +52,7 @@ public static void setErrorNotificationDefaults() {
 /**
  * @description Retrieve the specified record type, or the first active RT if that fails
  */
-public static String getOppRecordType(String rtDevName) {
+private static String getOppRecordType(String rtDevName) {
     Recordtypeinfo oppRt = Schema.SObjectType.Opportunity.getRecordTypeInfosByDeveloperName().get(rtDevName);
     if (oppRt == null) {
         oppRt = Schema.SObjectType.Opportunity.getRecordTypeInfosByDeveloperName().get('NPSP_Default');

--- a/unpackaged/config/trial/flexipages/NPSP_Recurring_Donation.flexipage
+++ b/unpackaged/config/trial/flexipages/NPSP_Recurring_Donation.flexipage
@@ -107,8 +107,8 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
-                <componentName>npsp:rdActiveSchedule</componentName>
-                <identifier>npsp_rdActiveSchedule</identifier>
+                <componentName>%%%NAMESPACE_OR_C%%%:rdActiveSchedule</componentName>
+                <identifier>%%%NAMESPACE%%%rdActiveSchedule</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -117,8 +117,8 @@
                     <name>displayNum</name>
                     <value>12</value>
                 </componentInstanceProperties>
-                <componentName>npsp:rdScheduleVisualizer</componentName>
-                <identifier>npsp_rdScheduleVisualizer</identifier>
+                <componentName>%%%NAMESPACE_OR_C%%%:rdScheduleVisualizer</componentName>
+                <identifier>%%%NAMESPACE%%%rdScheduleVisualizer</identifier>
             </componentInstance>
         </itemInstances>
         <name>sidebar</name>

--- a/unpackaged/config/trial/layouts/Account-Organization Lightning Layout.layout
+++ b/unpackaged/config/trial/layouts/Account-Organization Lightning Layout.layout
@@ -80,6 +80,10 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
+                <field>%%%NAMESPACE%%%Sustainer__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>npo02__FirstCloseDate__c</field>
             </layoutItems>
             <layoutItems>

--- a/unpackaged/config/trial/layouts/Account-___NAMESPACE___Household Layout.layout
+++ b/unpackaged/config/trial/layouts/Account-___NAMESPACE___Household Layout.layout
@@ -39,6 +39,10 @@
                 <behavior>Edit</behavior>
                 <field>%%%NAMESPACE%%%Number_of_Household_Members__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>%%%NAMESPACE%%%All_Members_Deceased__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
     </layoutSections>
@@ -80,6 +84,10 @@
         <editHeading>true</editHeading>
         <label>Donation Information</label>
         <layoutColumns>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>%%%NAMESPACE%%%Sustainer__c</field>
+            </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Level__c</field>

--- a/unpackaged/config/trial/layouts/Contact-Contact Lightning Layout.layout
+++ b/unpackaged/config/trial/layouts/Contact-Contact Lightning Layout.layout
@@ -175,6 +175,10 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
+                <field>%%%NAMESPACE%%%Sustainer__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>npo02__FirstCloseDate__c</field>
             </layoutItems>
             <layoutItems>

--- a/unpackaged/config/trial/profiles/Admin.profile
+++ b/unpackaged/config/trial/profiles/Admin.profile
@@ -11,14 +11,14 @@
         <visible>false</visible>
     </applicationVisibilities>
     <layoutAssignments>
-        <layout>Account-%%%NAMESPACE%%%Household Layout</layout>
+        <layout>Account-Household Lightning Layout</layout>
         <recordType>Account.HH_Account</recordType>
     </layoutAssignments>
     <layoutAssignments>
         <layout>Account-%%%NAMESPACE%%%Organization Layout</layout>
     </layoutAssignments>
     <layoutAssignments>
-        <layout>Account-%%%NAMESPACE%%%Organization Layout</layout>
+        <layout>Account-Organization Lightning Layout</layout>
         <recordType>Account.Organization</recordType>
     </layoutAssignments>
     <layoutAssignments>


### PR DESCRIPTION
Added new **Sustainer__c** and **All_Members_Deceased__c** fields on the Account page layout and **Sustainer__c** on the contact page layout in the NPSP Trial org. Also default the RD Status automation value for Lapsed to "Lapsed" and the RD status automation value for Closed to "Closed" in NPSP settings in the trial org.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
