### PR TITLE
RD - Handle updating commitments where productMetadata is null

### DIFF
--- a/force-app/main/default/classes/PS_ProductMetadata.cls
+++ b/force-app/main/default/classes/PS_ProductMetadata.cls
@@ -76,9 +76,7 @@ public inherited sharing class PS_ProductMetadata {
             mergedMetadata.putAll(existingMetadata);
         }
 
-        for(String key : updatedMetadata.keySet()) {
-            mergedMetadata.put(key, updatedMetadata.get(key));
-        }
+        mergedMetadata.putAll(updatedMetadata);
 
         return mergedMetadata;
     }

--- a/force-app/main/default/classes/PS_ProductMetadata.cls
+++ b/force-app/main/default/classes/PS_ProductMetadata.cls
@@ -68,14 +68,19 @@ public inherited sharing class PS_ProductMetadata {
         return this.origin?.type != null;
     }
 
-    public Map<String, Object> mergeWithExistingMetadata(Map<String, Object> existingMetadata) {
+    public Map<String, Object> mergeWithExistingMetadata(final Map<String, Object> existingMetadata) {
         Map<String, Object> updatedMetadata = this.toUntypedMap();
+        Map<String, Object> mergedMetadata = new Map<String, Object>();
 
-        for(String key : updatedMetadata.keySet()) {
-            existingMetadata.put(key, updatedMetadata.get(key));
+        if (existingMetadata != null) {
+            mergedMetadata.putAll(existingMetadata);
         }
 
-        return existingMetadata;
+        for(String key : updatedMetadata.keySet()) {
+            mergedMetadata.put(key, updatedMetadata.get(key));
+        }
+
+        return mergedMetadata;
     }
 
     public Map<String, Object> toUntypedMap() {

--- a/force-app/main/default/classes/PS_ProductMetadata_TEST.cls
+++ b/force-app/main/default/classes/PS_ProductMetadata_TEST.cls
@@ -41,7 +41,7 @@ private with sharing class PS_ProductMetadata_TEST {
     */
     @isTest
     private static void shouldCreateUntypedMap() {
-        String campaignId = '701R00000027JNdIAA';
+        String campaignId = UTIL_UnitTestData_TEST.mockId(Campaign.SObjectType);
         String originType = PS_Request.OriginType.CRM.name();
         
         PS_ProductMetadata productMetadata = new PS_ProductMetadata()
@@ -75,7 +75,7 @@ private with sharing class PS_ProductMetadata_TEST {
 
     @IsTest
     static void productMetadataShouldPreserveOrigin() {
-        String newCampaignId = '701R00000027JNdIAA';
+        String newCampaignId = UTIL_UnitTestData_TEST.mockId(Campaign.SObjectType);
         String serializedProductMetadata = '{"origin":{"type":"CRM"},"campaign":{"id":"701R00000027JNdIAM"}}';
         Map<String, Object> untypedMetadata = (Map<String, Object>) JSON.deserializeUntyped(serializedProductMetadata);
 
@@ -90,7 +90,7 @@ private with sharing class PS_ProductMetadata_TEST {
 
     @IsTest
     static void productMetadataShouldPreserveAny() {
-        String newCampaignId = '701R00000027JNdIAA';
+        String newCampaignId = UTIL_UnitTestData_TEST.mockId(Campaign.SObjectType);
         String serializedProductMetadata = '{"origin":{"type":"CRM"},"campaign":{"id":"701R00000027JNdIAM"},"consent":{"message":"Some message","optin":true}}';
         Map<String, Object> untypedMetadata = (Map<String, Object>) JSON.deserializeUntyped(serializedProductMetadata);
 
@@ -109,6 +109,20 @@ private with sharing class PS_ProductMetadata_TEST {
 
         System.assertEquals('Some message', consentMessage);
         System.assertEquals(true, optin);
+    }
+
+    @IsTest
+    static void productMetadataShouldMergeWhenExistingMetadataIsNull() {
+        String newCampaignId = UTIL_UnitTestData_TEST.mockId(Campaign.SObjectType);
+        PS_ProductMetadata productMetadata = new PS_ProductMetadata().withCampaign(newCampaignId);
+
+        Test.startTest();
+        Map<String, Object> updatedUntypedMetadata = productMetadata.mergeWithExistingMetadata(null);
+        Test.stopTest();
+
+        PS_ProductMetadata updatedMetadata = parseUntypedMetadata(updatedUntypedMetadata);
+
+        System.assertEquals(newCampaignId, updatedMetadata.campaign.id);
     }
 
     /**


### PR DESCRIPTION
# Critical Changes

# Changes
- We've fixed an issue where certain Elevate-connected Recurring Donations could not be updated from NPSP.
# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
