### PR TITLE
Regression fixes for 238 Release

### DIFF
--- a/force-app/main/default/classes/HH_Container_LCTRL.cls
+++ b/force-app/main/default/classes/HH_Container_LCTRL.cls
@@ -522,6 +522,7 @@ public with sharing class HH_Container_LCTRL {
         // so we avoid deleting a household if that contact was the last one in the hh.
         if (isNotEmpty(listHHMerge)) {
             mergeHouseholds((Account)hh, listHHMerge);
+            updateWinnerHouseholdSustainerAfterMerge((Account)hh);
         }
 
         List<Contact> contacts = new List<Contact>(listCon);
@@ -531,7 +532,25 @@ public with sharing class HH_Container_LCTRL {
         if (isNotEmpty(listHHMerge)) {
             cleanupAddresses(new List<Id>{ (Id) hh.get('Id') });
         }          
-    }    
+    }
+
+    private static void updateWinnerHouseholdSustainerAfterMerge(Account winnerHousehold) {
+        DescribeFieldResult sustainerFieldDescribeResult = Account.Sustainer__c.getDescribe();
+
+        if (UTIL_Permissions.canRead(sustainerFieldDescribeResult, false)
+            && UTIL_Permissions.canUpdate(sustainerFieldDescribeResult, false)
+        ) {
+            List<Account> winnerWithSustainerChanged = new RD2_SustainerEvaluationService()
+            .withAccounts(new List<Account>{winnerHousehold})
+            .getAccountsWithSustainerChanged();
+
+            if (winnerWithSustainerChanged.size() != 0) {
+                RD2_SustainerEvaluationService.setSustainerUpdateEnabled(true);
+                UTIL_DMLService.updateRecords(winnerWithSustainerChanged);
+                RD2_SustainerEvaluationService.setSustainerUpdateEnabled(false);
+            }
+        }
+    }
 
     /*******************************************************************************************************
     * @description Checks if the Account list is not empty

--- a/force-app/main/default/classes/HH_Container_TEST.cls
+++ b/force-app/main/default/classes/HH_Container_TEST.cls
@@ -769,6 +769,56 @@ private class HH_Container_TEST {
 
     }
 
+    @IsTest
+    private static void shouldUpdateHouseholdSustainerAfterMergingContacts() {
+        //skip the test if Advancement is installed
+        if(ADV_PackageInfo_SVC.useAdv()) return;
+        RD2_EnablementService_TEST.setRecurringDonations2Enabled();
+
+        List<Account> householdAccounts = buildAccounts(2);
+        insert householdAccounts;
+
+        List<Contact> contacts = buildContacts(householdAccounts, 1);
+        insert contacts;
+
+        insert new List<npe03__Recurring_Donation__c> {
+            TEST_RecurringDonationBuilder.constructEnhancedBuilder()
+            .withDefaultValues()
+            .withStatusClosed()
+            .withContact(contacts[0].Id)
+            .withAmount(1)
+            .build(),
+
+            TEST_RecurringDonationBuilder.constructEnhancedBuilder()
+            .withDefaultValues()
+            .withStatusActive()
+            .withContact(contacts[1].Id)
+            .withAmount(1)
+            .build()
+        };
+    
+        householdAccounts[0] = (Account) HH_Container_LCTRL.getHousehold(householdAccounts[0].Id);
+
+        for (Contact contact : contacts) {
+            contact.AccountId = householdAccounts[0].Id;
+        }
+
+        Test.startTest();
+        HH_Container_LCTRL.saveHouseholdPage(householdAccounts[0], contacts, new List<Contact>(), new List<Account>{householdAccounts[1]});
+        Test.stopTest();
+
+        List<npe03__Recurring_Donation__c> rds = [SELECT npe03__Organization__c, npe03__Contact__c FROM npe03__Recurring_Donation__c];
+        List<Account> accounts = getAccounts();
+
+        for (npe03__Recurring_Donation__c rd : rds) {
+            System.assertEquals(householdAccounts[0].Id, rd.npe03__Organization__c,
+                'All Recurring Donations should be reparent to the winning household if the old household is merged');
+        }
+
+        System.assertEquals(RD2_SustainerEvaluationService.SustainerType.Active.name(), accounts[0].Sustainer__c,
+            'The winning household Account should be mark as Active Sustainer when there is an Active RD attached to it.');
+    }
+
     // Helpers
     ////////////
 
@@ -906,7 +956,7 @@ private class HH_Container_TEST {
     private static Account[] getAccounts() {
         return [
             SELECT Name, BillingStreet, BillingCity,
-                BillingState, BillingPostalCode, BillingCountry
+                BillingState, BillingPostalCode, BillingCountry, Sustainer__c
             FROM Account
         ];
     }

--- a/force-app/main/default/classes/PS_ProductMetadata.cls
+++ b/force-app/main/default/classes/PS_ProductMetadata.cls
@@ -76,9 +76,7 @@ public inherited sharing class PS_ProductMetadata {
             mergedMetadata.putAll(existingMetadata);
         }
 
-        for(String key : updatedMetadata.keySet()) {
-            mergedMetadata.put(key, updatedMetadata.get(key));
-        }
+        mergedMetadata.putAll(updatedMetadata);
 
         return mergedMetadata;
     }

--- a/force-app/main/default/classes/PS_ProductMetadata.cls
+++ b/force-app/main/default/classes/PS_ProductMetadata.cls
@@ -68,14 +68,19 @@ public inherited sharing class PS_ProductMetadata {
         return this.origin?.type != null;
     }
 
-    public Map<String, Object> mergeWithExistingMetadata(Map<String, Object> existingMetadata) {
+    public Map<String, Object> mergeWithExistingMetadata(final Map<String, Object> existingMetadata) {
         Map<String, Object> updatedMetadata = this.toUntypedMap();
+        Map<String, Object> mergedMetadata = new Map<String, Object>();
 
-        for(String key : updatedMetadata.keySet()) {
-            existingMetadata.put(key, updatedMetadata.get(key));
+        if (existingMetadata != null) {
+            mergedMetadata.putAll(existingMetadata);
         }
 
-        return existingMetadata;
+        for(String key : updatedMetadata.keySet()) {
+            mergedMetadata.put(key, updatedMetadata.get(key));
+        }
+
+        return mergedMetadata;
     }
 
     public Map<String, Object> toUntypedMap() {

--- a/force-app/main/default/classes/PS_ProductMetadata_TEST.cls
+++ b/force-app/main/default/classes/PS_ProductMetadata_TEST.cls
@@ -41,7 +41,7 @@ private with sharing class PS_ProductMetadata_TEST {
     */
     @isTest
     private static void shouldCreateUntypedMap() {
-        String campaignId = '701R00000027JNdIAA';
+        String campaignId = UTIL_UnitTestData_TEST.mockId(Campaign.SObjectType);
         String originType = PS_Request.OriginType.CRM.name();
         
         PS_ProductMetadata productMetadata = new PS_ProductMetadata()
@@ -75,7 +75,7 @@ private with sharing class PS_ProductMetadata_TEST {
 
     @IsTest
     static void productMetadataShouldPreserveOrigin() {
-        String newCampaignId = '701R00000027JNdIAA';
+        String newCampaignId = UTIL_UnitTestData_TEST.mockId(Campaign.SObjectType);
         String serializedProductMetadata = '{"origin":{"type":"CRM"},"campaign":{"id":"701R00000027JNdIAM"}}';
         Map<String, Object> untypedMetadata = (Map<String, Object>) JSON.deserializeUntyped(serializedProductMetadata);
 
@@ -90,7 +90,7 @@ private with sharing class PS_ProductMetadata_TEST {
 
     @IsTest
     static void productMetadataShouldPreserveAny() {
-        String newCampaignId = '701R00000027JNdIAA';
+        String newCampaignId = UTIL_UnitTestData_TEST.mockId(Campaign.SObjectType);
         String serializedProductMetadata = '{"origin":{"type":"CRM"},"campaign":{"id":"701R00000027JNdIAM"},"consent":{"message":"Some message","optin":true}}';
         Map<String, Object> untypedMetadata = (Map<String, Object>) JSON.deserializeUntyped(serializedProductMetadata);
 
@@ -109,6 +109,20 @@ private with sharing class PS_ProductMetadata_TEST {
 
         System.assertEquals('Some message', consentMessage);
         System.assertEquals(true, optin);
+    }
+
+    @IsTest
+    static void productMetadataShouldMergeWhenExistingMetadataIsNull() {
+        String newCampaignId = UTIL_UnitTestData_TEST.mockId(Campaign.SObjectType);
+        PS_ProductMetadata productMetadata = new PS_ProductMetadata().withCampaign(newCampaignId);
+
+        Test.startTest();
+        Map<String, Object> updatedUntypedMetadata = productMetadata.mergeWithExistingMetadata(null);
+        Test.stopTest();
+
+        PS_ProductMetadata updatedMetadata = parseUntypedMetadata(updatedUntypedMetadata);
+
+        System.assertEquals(newCampaignId, updatedMetadata.campaign.id);
     }
 
     /**

--- a/force-app/main/default/classes/RD2_SaveRequest.cls
+++ b/force-app/main/default/classes/RD2_SaveRequest.cls
@@ -57,6 +57,7 @@ public with sharing class RD2_SaveRequest {
     @AuraEnabled public String cardLastFour {get; set;}
     @AuraEnabled public String cardExpirationMonth {get; set;}
     @AuraEnabled public String cardExpirationYear {get; set;}
+    @AuraEnabled public String changeType {get; set;}
     @AuraEnabled public Map<String, Object> customFieldValues {get; set;}
 
     public npe03__Recurring_Donation__c toRecord() {
@@ -89,6 +90,7 @@ public with sharing class RD2_SaveRequest {
         rd.CardExpirationYear__c = cardExpirationYear;
         rd.CardLast4__c = cardLastFour;
         rd.ACH_Last_4__c = achLastFour;
+        rd.ChangeType__c = changeType;
 
         if (customFieldValues != null) {
             for (String fieldApiName : customFieldValues.keySet()) {

--- a/force-app/main/default/lwc/rd2EntryForm/__tests__/rd2EntryForm.test.js
+++ b/force-app/main/default/lwc/rd2EntryForm/__tests__/rd2EntryForm.test.js
@@ -226,6 +226,7 @@ describe("c-rd2-entry-form", () => {
                     cardExpirationYear: null,
                     cardLastFour: null,
                     campaignId: null,
+                    changeType: "",
                     commitmentId: null,
                     currencyIsoCode: null,
                     dayOfMonth: "15",
@@ -368,6 +369,7 @@ describe("c-rd2-entry-form", () => {
                 cardExpirationMonth: null,
                 cardExpirationYear: null,
                 cardLastFour: null,
+                changeType: "",
                 campaignId: null,
                 commitmentId: "ffd252d6-7ffc-46a0-994f-00f7582263d2",
                 currencyIsoCode: null,
@@ -687,6 +689,7 @@ describe("c-rd2-entry-form", () => {
                 cardExpirationYear: null,
                 cardLastFour: null,
                 campaignId: null,
+                changeType: "",
                 commitmentId: "ffd252d6-7ffc-46a0-994f-00f7582263d2",
                 currencyIsoCode: null,
                 dayOfMonth: "6",
@@ -764,6 +767,7 @@ describe("c-rd2-entry-form", () => {
                 cardExpirationMonth: "05",
                 cardExpirationYear: "2023",
                 cardLastFour: "1111",
+                changeType: "",
                 campaignId: null,
                 commitmentId: "ffd252d6-7ffc-46a0-994f-00f7582263d2",
                 currencyIsoCode: null,
@@ -849,14 +853,14 @@ describe("c-rd2-entry-form", () => {
         it("open donation, when form loads, change type picklist is empty", async () => {
             const changeTypePicklist = controller.changeTypePicklist();
             expect(changeTypePicklist).toBeTruthy();
-            expect(changeTypePicklist.value).toBe("");
+            expect(changeTypePicklist.getValue()).toBe("");
         });
 
         it("open donation, when amount increased, sets change type to upgrade", async () => {
             controller.amount().changeValue(5);
             await flushPromises();
             const changeTypePicklist = controller.changeTypePicklist();
-            expect(changeTypePicklist.value).toBe("Upgrade");
+            expect(changeTypePicklist.getValue()).toBe("Upgrade");
         });
 
         it("open donation, when frequency changed from monthly to weekly, sets change type to upgrade", async () => {
@@ -865,14 +869,14 @@ describe("c-rd2-entry-form", () => {
             controller.installmentPeriod().changeValue("Weekly");
             await flushPromises();
             const changeTypePicklist = controller.changeTypePicklist();
-            expect(changeTypePicklist.value).toBe("Upgrade");
+            expect(changeTypePicklist.getValue()).toBe("Upgrade");
         });
 
         it("open donation, when amount decreased, sets change type to downgrade", async () => {
             controller.amount().changeValue(0.25);
             await flushPromises();
             const changeTypePicklist = controller.changeTypePicklist();
-            expect(changeTypePicklist.value).toBe("Downgrade");
+            expect(changeTypePicklist.getValue()).toBe("Downgrade");
         });
 
         it("open donation, when amount changed and recurring type changed to fixed, blanks change type picklist", async () => {
@@ -880,11 +884,53 @@ describe("c-rd2-entry-form", () => {
             await flushPromises();
 
             const changeTypePicklist = controller.changeTypePicklist();
-            expect(changeTypePicklist.value).toBe("Upgrade");
+            expect(changeTypePicklist.getValue()).toBe("Upgrade");
             controller.recurringType().changeValue("Fixed");
             await flushPromises();
 
-            expect(changeTypePicklist.value).toBe("");
+            expect(changeTypePicklist.getValue()).toBe("");
+        });
+
+        it("open donation, persists manual change to change type picklist", async () => {
+            controller.amount().changeValue(5);
+            await flushPromises();
+
+            const changeTypePicklist = controller.changeTypePicklist();
+            expect(changeTypePicklist.getValue()).toBe("Upgrade");
+
+            changeTypePicklist.changeValue("Downgrade");
+            controller.dayOfMonth().changeValue(3);
+            await flushPromises();
+
+            controller.saveButton().click();
+            expect(saveRecurringDonation).toHaveBeenCalled();
+            const saveRequest = {
+                achLastFour: null,
+                accountId: "00163000010jyT6AAI",
+                cardExpirationMonth: null,
+                cardExpirationYear: null,
+                cardLastFour: null,
+                changeType: "Downgrade",
+                campaignId: null,
+                commitmentId: null,
+                currencyIsoCode: null,
+                customFieldValues: {},
+                dayOfMonth: 3,
+                paymentToken: null,
+                recordId: "a09S000000HAfRHIA1",
+                recordName: "",
+                recurringFrequency: 1,
+                recurringType: "Open",
+                recurringStatus: "Active",
+                startDate: "2021-04-29",
+                donationValue: 5,
+                contactId: "001fakeContactId",
+                dateEstablished: "2021-04-29",
+                recurringPeriod: "Monthly",
+                plannedInstallments: null,
+                statusReason: null,
+            };
+            expect(saveRecurringDonation).toHaveBeenCalledWith({ saveRequest });
         });
     });
 
@@ -930,7 +976,7 @@ describe("c-rd2-entry-form", () => {
             await flushPromises();
             const changeTypePicklist = controller.changeTypePicklist();
 
-            expect(changeTypePicklist.value).toBe("Upgrade");
+            expect(changeTypePicklist.getValue()).toBe("Upgrade");
         });
 
         it("fixed donation, when number of planned installments decreased, sets change type to downgrade", async () => {
@@ -938,7 +984,7 @@ describe("c-rd2-entry-form", () => {
             await flushPromises();
             const changeTypePicklist = controller.changeTypePicklist();
 
-            expect(changeTypePicklist.value).toBe("Downgrade");
+            expect(changeTypePicklist.getValue()).toBe("Downgrade");
         });
     });
 });

--- a/force-app/main/default/lwc/rd2EntryForm/__tests__/rd2EntryFormTestHelpers.js
+++ b/force-app/main/default/lwc/rd2EntryForm/__tests__/rd2EntryFormTestHelpers.js
@@ -228,7 +228,8 @@ export class RD2FormController {
     }
 
     changeTypePicklist() {
-        return this.element.shadowRoot.querySelector('lightning-input-field[data-id="changeType"]');
+        const field = this.element.shadowRoot.querySelector('lightning-input-field[data-id="changeType"]');
+        return new RD2FormField(field);
     }
 
     errorPageLevelMessage() {

--- a/force-app/main/default/lwc/rd2EntryForm/rd2EntryForm.js
+++ b/force-app/main/default/lwc/rd2EntryForm/rd2EntryForm.js
@@ -301,7 +301,7 @@ export default class rd2EntryForm extends LightningElement {
     handleChangeTypeChange(event) {
         this.perform({
             type: ACTIONS.SET_CHANGE_TYPE,
-            payload: event.detail,
+            payload: event.detail.value,
         });
     }
 

--- a/force-app/main/default/lwc/rd2Service/model.js
+++ b/force-app/main/default/lwc/rd2Service/model.js
@@ -7,6 +7,7 @@ import {
     SET_CONTACT_DETAILS,
     SET_CURRENCY,
     SET_ACCOUNT_DETAILS,
+    SET_CHANGE_TYPE,
     SET_DAY_OF_MONTH,
     SET_DONATION_AMOUNT,
     SET_DONOR_TYPE,
@@ -146,7 +147,7 @@ const getChangeType = (state) => {
         return CHANGE_TYPE_UPGRADE;
     }
 
-    return "";
+    return state.changeType;
 };
 
 const isAdvancedPeriod = (state) => {
@@ -257,6 +258,13 @@ const setAccountDetails = (state, { accountName, lastName }) => {
         ...state,
         accountName,
         contactLastName: lastName,
+    };
+};
+
+const setChangeType = (state, changeType) => {
+    return {
+        ...state,
+        changeType,
     };
 };
 
@@ -446,6 +454,8 @@ export const nextState = (state = DEFAULT_INITIAL_STATE, action = {}) => {
             return setCurrency(state, action.payload);
         case SET_ACCOUNT_DETAILS:
             return setAccountDetails(state, action.payload);
+        case SET_CHANGE_TYPE:
+            return setChangeType(state, action.payload);
         case SET_DAY_OF_MONTH:
             return setDayOfMonth(state, action.payload);
         case SET_DONATION_AMOUNT:

--- a/force-app/main/default/lwc/rd2Service/rd2Service.js
+++ b/force-app/main/default/lwc/rd2Service/rd2Service.js
@@ -167,6 +167,7 @@ class Rd2Service {
             cardExpirationMonth,
             cardExpirationYear,
             paymentMethod,
+            changeType,
         } = rd2State;
 
         const plannedInstallments = this.getPlannedInstallments(rd2State);
@@ -197,6 +198,7 @@ class Rd2Service {
             cardExpirationYear,
             paymentMethod,
             customFieldValues,
+            changeType,
         };
     }
 


### PR DESCRIPTION
- Regression fixes for 238 Release
- Fixed an issue where Recurring Donation Change Type cannot be manually set
- Fixed an issue where Sustainer evaluation does not get triggered from Manage Household Page

# Critical Changes

# Changes

- We've fixed an issue where certain Elevate-connected Recurring Donations could not be updated from NPSP.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
