### PR TITLE
Update YAML file to use install managed task instead of 2GP flow

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -893,11 +893,10 @@ flows:
 
     config_trial_org:
         steps:
-            # TODO: Update once we can test with a Beta instead of 2GP
-            #1:
-            #    flow: dependencies
+            1:
+                flow: dependencies
             2:
-                flow: install_2gp_commit #task: install_managed
+                task: install_managed
             3:
                 task: deploy_post
             4:


### PR DESCRIPTION
For our feature enablement flows in CCI, we need to update the cumulus.yml to use the `install_managed` task instead of the `install_2gp_commit` flow so that we can now pull the 238 release version.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
