### PR TITLE
[A11y] Override the Button border color on NPSP Settings

### DIFF
--- a/force-app/main/default/pages/STG_SettingsManager.page
+++ b/force-app/main/default/pages/STG_SettingsManager.page
@@ -44,6 +44,10 @@
     .hide {
         display: none;
     }
+
+    .slds-scope .slds-button_neutral {
+        border-color: #C9C9C9;
+    }
 </style>
 
 <script>


### PR DESCRIPTION
- Updating the border color of Neutral buttons on NPSP Settings to improve contrast
- Note: the border color without this override is not up to date with SLDS due to using Aura and Lightning:out

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
