### PR TITLE
Regression Fix: W-1179558 -- Missing State value when State & Country Picklists are enabled

### DIFF
--- a/force-app/main/default/classes/NPSP_Address.cls
+++ b/force-app/main/default/classes/NPSP_Address.cls
@@ -341,6 +341,13 @@ public inherited sharing class NPSP_Address implements IAddress {
         address.Geolocation__Latitude__s = (Decimal) getSObjectField(sobjSrc, fieldPrefixSrc, 'Latitude');
         address.Geolocation__Longitude__s = (Decimal) getSObjectField(sobjSrc, fieldPrefixSrc, 'Longitude');
 
+        if (orgConfig.isStateCountryPicklistsEnabled()) {
+            if (address.MailingCountry__c == null && getSObjectField(sobjSrc, fieldPrefixSrc, 'CountryCode') != null) {
+                address.MailingState__c = (String) getSObjectField(sobjSrc, fieldPrefixSrc, 'StateCode');
+                address.MailingCountry__c = (String) getSObjectField(sobjSrc, fieldPrefixSrc, 'CountryCode');
+            }
+        }
+
         // if specified, also include Address Type
         if (addrType != null) {
             address.Address_Type__c = addrType;

--- a/force-app/main/default/classes/NPSP_Address.cls
+++ b/force-app/main/default/classes/NPSP_Address.cls
@@ -342,12 +342,8 @@ public inherited sharing class NPSP_Address implements IAddress {
         address.Geolocation__Longitude__s = (Decimal) getSObjectField(sobjSrc, fieldPrefixSrc, 'Longitude');
 
         if (orgConfig.isStateCountryPicklistsEnabled()) {
-            if (address.MailingCountry__c == null && getSObjectField(sobjSrc, fieldPrefixSrc, 'CountryCode') != null) {
-                address.MailingCountry__c = (String) getSObjectField(sobjSrc, fieldPrefixSrc, 'CountryCode');
-            }
-            if (getSObjectField(sobjSrc, fieldPrefixSrc, 'StateCode') != null) {
-                address.MailingState__c = (String) getSObjectField(sobjSrc, fieldPrefixSrc, 'StateCode');
-            }
+            populateAddressCountryFromCountryCode(sobjSrc, fieldPrefixSrc);
+            populateAddressStateFromStateCode(sobjSrc, fieldPrefixSrc);
         }
 
         // if specified, also include Address Type
@@ -396,6 +392,66 @@ public inherited sharing class NPSP_Address implements IAddress {
         if (Integer.valueOf(d) < 10)
             return Decimal.valueOf(m + '.0' + d); else
                 return Decimal.valueOf(m + '.' + d);
+    }
+
+    /*******************************************************************************************************
+    * @description Updates the Address record's MailingCountry field when it is empty
+    *              with the Account's BillingCountryCode or Contact's MailingCountryCode value.
+    * @param sobjSrc the source Account or Contact
+    * @param fieldPrefixSrc the address field to copy from, ie., Mailing, Other, Billing, Shipping
+    * @param addr the Address object to update accordingly
+    * @return void
+    */
+    @TestVisible
+    private void populateAddressCountryFromCountryCode(SObject sobjSrc, String fieldPrefixSrc) {
+        String countryCode = (String) sobjSrc.get(fieldPrefixSrc + 'CountryCode');
+        if (String.isBlank(countryCode)) {
+            return;
+        }
+
+        if (String.isEmpty(address.MailingCountry__c)) {
+            address.MailingCountry__c = orgConfig.validCountriesByCode().get(countryCode
+                    .toUpperCase());
+        }
+    }
+
+    /*******************************************************************************************************
+    * @description Updates the Address record's MailingState field when it is empty
+    *              or does not match the Account's BillingStateCode or Contact's MailingStateCode value.
+    * @param sobjSrc the source Account or Contact
+    * @param fieldPrefixSrc the address field to copy from, ie., Mailing, Other, Billing, Shipping
+    * @return void
+    */
+    @TestVisible
+    private void populateAddressStateFromStateCode(SObject sobjSrc, String fieldPrefixSrc) {
+        String stateCode = (String) sobjSrc.get(fieldPrefixSrc + 'StateCode');
+        if (String.isBlank(stateCode)) {
+            return;
+        }
+
+        if (String.isEmpty(address.MailingState__c) || !isMatchingStateCode(stateCode)) {
+            // Assume it's a valid statecode since we can't map from Code to State Name
+            address.MailingState__c = stateCode;
+        }
+    }
+
+    /*******************************************************************************************************
+    * @description Determines if the Account's BillingStateCode or Contact's MailingStateCode matches the
+    *              Address record's Mailing State.
+    * @param stateCode the BillingStateCode or MailingStateCode
+    * @return void
+    */
+    @TestVisible
+    private Boolean isMatchingStateCode(String stateCode) {
+        if (String.isBlank(address.MailingState__c)) {
+            return false;
+        }
+
+        String mappedMailingState = (orgConfig.validStatesByLabel() == null)
+                ? ''
+                : orgConfig.validStatesByLabel().get(address.MailingState__c.toUpperCase());
+
+        return stateCode.equalsIgnoreCase(mappedMailingState);
     }
 
     /*******************************************************************************************************

--- a/force-app/main/default/classes/NPSP_Address.cls
+++ b/force-app/main/default/classes/NPSP_Address.cls
@@ -343,8 +343,10 @@ public inherited sharing class NPSP_Address implements IAddress {
 
         if (orgConfig.isStateCountryPicklistsEnabled()) {
             if (address.MailingCountry__c == null && getSObjectField(sobjSrc, fieldPrefixSrc, 'CountryCode') != null) {
-                address.MailingState__c = (String) getSObjectField(sobjSrc, fieldPrefixSrc, 'StateCode');
                 address.MailingCountry__c = (String) getSObjectField(sobjSrc, fieldPrefixSrc, 'CountryCode');
+            }
+            if (getSObjectField(sobjSrc, fieldPrefixSrc, 'StateCode') != null) {
+                address.MailingState__c = (String) getSObjectField(sobjSrc, fieldPrefixSrc, 'StateCode');
             }
         }
 

--- a/force-app/main/default/classes/OrgConfig.cls
+++ b/force-app/main/default/classes/OrgConfig.cls
@@ -40,6 +40,9 @@ public inherited sharing class OrgConfig {
     private static Map<String, String> validCountriesByLabel = new Map<String, String>();
 
     public Map<String, String> validCountriesByLabel() {
+        if (validCountriesByLabel.isEmpty()) {
+            initValidStateCountryCodes();
+        }
         return validCountriesByLabel;
     }
 
@@ -49,6 +52,9 @@ public inherited sharing class OrgConfig {
     private static Map<String, String> validStatesByLabel = new Map<String, String>();
 
     public Map<String, String> validStatesByLabel() {
+        if (validStatesByLabel.isEmpty()) {
+            initValidStateCountryCodes();
+        }
         return validStatesByLabel;
     }
 
@@ -58,6 +64,9 @@ public inherited sharing class OrgConfig {
     private static Map<String, String> validCountriesByCode = new Map<String, String>();
 
     public Map<String, String> validCountriesByCode() {
+        if (validCountriesByCode.isEmpty()) {
+            initValidStateCountryCodes();
+        }
         return validCountriesByCode;
     }
 
@@ -72,7 +81,7 @@ public inherited sharing class OrgConfig {
     private static Boolean isStateCountryPicklistsEnabled {
         get {
             if (isStateCountryPicklistsEnabled == null) {
-                isStateCountryPicklistsEnabled = initValidStateCountryCodes();
+                isStateCountryPicklistsEnabled = stateAndCountryPicklistsEnabled();
             }
             return isStateCountryPicklistsEnabled;
         }
@@ -111,5 +120,12 @@ public inherited sharing class OrgConfig {
             }
         }
         return isCodesEnabled;
+    }
+
+    private static Boolean stateAndCountryPicklistsEnabled() {
+        fflib_SObjectDescribe accountDescribe =
+                fflib_SObjectDescribe.getDescribe(Account.SObjectType);
+        SObjectField sObjectField = accountDescribe.getField('BillingStateCode');
+        return sObjectField != null;
     }
 }

--- a/force-app/main/default/classes/OrgConfig.cls
+++ b/force-app/main/default/classes/OrgConfig.cls
@@ -34,6 +34,33 @@
 */
 public inherited sharing class OrgConfig {
 
+    /*******************************************************************************************************
+    * @description map from Country name (UPPER CASE) to Country Code
+    */
+    private static Map<String, String> validCountriesByLabel = new Map<String, String>();
+
+    public Map<String, String> validCountriesByLabel() {
+        return validCountriesByLabel;
+    }
+
+    /*******************************************************************************************************
+    * @description map from State name (UPPER CASE) to State Code
+    */
+    private static Map<String, String> validStatesByLabel = new Map<String, String>();
+
+    public Map<String, String> validStatesByLabel() {
+        return validStatesByLabel;
+    }
+
+    /*******************************************************************************************************
+    * @description map from Country Code to Country Name
+    */
+    private static Map<String, String> validCountriesByCode = new Map<String, String>();
+
+    public Map<String, String> validCountriesByCode() {
+        return validCountriesByCode;
+    }
+
     public Boolean isPersonAccountsEnabled() {
         return UTIL_Describe.isValidField(String.valueOf(Account.SObjectType), 'isPersonAccount');
     }
@@ -45,7 +72,7 @@ public inherited sharing class OrgConfig {
     private static Boolean isStateCountryPicklistsEnabled {
         get {
             if (isStateCountryPicklistsEnabled == null) {
-                isStateCountryPicklistsEnabled = stateAndCountryPicklistsEnabled();
+                isStateCountryPicklistsEnabled = initValidStateCountryCodes();
             }
             return isStateCountryPicklistsEnabled;
         }
@@ -56,10 +83,33 @@ public inherited sharing class OrgConfig {
         return isStateCountryPicklistsEnabled;
     }
 
-    private static Boolean stateAndCountryPicklistsEnabled() {
-        fflib_SObjectDescribe accountDescribe =
-                fflib_SObjectDescribe.getDescribe(Account.SObjectType);
-        SObjectField sObjectField = accountDescribe.getField('BillingStateCode');
-        return sObjectField != null;
+    /*******************************************************************************************************
+    * @description utility to determine if the "State and Country Picklist" field feature is enabled in Salesforce
+    * @return true if enabled; Fills 4 sets<> with a list of value codes and labels for each field
+    */
+    private static Boolean initValidStateCountryCodes() {
+        // If State & Country Picklists are enabled in the org, build maps of the
+        // valid Labels and Codes for each field to use for validation
+        Map<String, Schema.SObjectField> acctFields = Account.getSObjectType().getDescribe().fields.getMap();
+        Boolean isCodesEnabled = acctFields.containsKey('BillingCountryCode');
+        if (isCodesEnabled) {
+            List<Schema.PicklistEntry> countryPLValues = acctFields.get('BillingCountryCode').getDescribe().getPicklistValues();
+            for (Schema.PicklistEntry p : countryPLValues) {
+                if (p.isActive()) {
+                    validCountriesByLabel.put(p.getLabel().toUpperCase(), p.getValue());
+                    validCountriesByCode.put(p.getValue(), p.getLabel());
+                }
+            }
+            List<Schema.PicklistEntry> statePLValues = acctFields.get('BillingStateCode').getDescribe().getPicklistValues();
+            for (Schema.PicklistEntry p : statePLValues) {
+                if (p.isActive()) {
+                    validStatesByLabel.put(p.getLabel().toUpperCase(), p.getValue());
+                    // we can't have an accurate map of valid StateCodes, because they are not unique.
+                    // ideally we would have a map of CountryCode + StateCode -> StateLabel
+                    // but Salesforce provides us no way of figuring out picklist dependencies efficiently.
+                }
+            }
+        }
+        return isCodesEnabled;
     }
 }

--- a/force-app/main/default/classes/OrgConfig.cls
+++ b/force-app/main/default/classes/OrgConfig.cls
@@ -94,9 +94,8 @@ public inherited sharing class OrgConfig {
 
     /*******************************************************************************************************
     * @description utility to determine if the "State and Country Picklist" field feature is enabled in Salesforce
-    * @return true if enabled; Fills 4 sets<> with a list of value codes and labels for each field
     */
-    private static Boolean initValidStateCountryCodes() {
+    private static void initValidStateCountryCodes() {
         // If State & Country Picklists are enabled in the org, build maps of the
         // valid Labels and Codes for each field to use for validation
         Map<String, Schema.SObjectField> acctFields = Account.getSObjectType().getDescribe().fields.getMap();
@@ -119,7 +118,6 @@ public inherited sharing class OrgConfig {
                 }
             }
         }
-        return isCodesEnabled;
     }
 
     private static Boolean stateAndCountryPicklistsEnabled() {

--- a/force-app/main/service/AddressService.cls
+++ b/force-app/main/service/AddressService.cls
@@ -47,9 +47,7 @@ public inherited sharing class AddressService {
 
     /*******************************************************************************************************
     * @description Utility to copy Address fields between Contacts and Accounts (or vice-versa).
-    * Doesn't do anything special when State and Country picklists are enabled (the
-     * platform will fill out State and Country Code values using the values from the
-     * picklist fields), and multiline street addresses.
+    * Handles instances where State and Country picklists are enabled, and multiline street addresses.
     * @param sobjSrc the source Contact or Account
     * @param strFieldPrefixSrc the address fields to copy from, ie., Mailing, Other, Shipping, Billing
     * @param sobjDst the destination Contact or Account
@@ -130,8 +128,7 @@ public inherited sharing class AddressService {
 
     /*******************************************************************************************************
     * @description Utility to copy Address fields from an Address object to a Contact or Account.
-    * Doesn't do anything special when State and Country picklists are enabled (Allows the
-     * platform to populate state and country code values), and multiline street addresses.
+    * Handles instances where State and Country picklists are enabled, and multiline street addresses.
     * @param anAddress the Address object to copy from
     * @param sobjDst the destination Contact or Account
     * @param strFieldPrefix the address fields to copy to, ie., Mailing, Other, Shipping, Billing

--- a/force-app/main/service/AddressService.cls
+++ b/force-app/main/service/AddressService.cls
@@ -63,6 +63,10 @@ public inherited sharing class AddressService {
         sobjDst.put(strFieldPrefixDst + 'Country', sobjSrc.get(strFieldPrefixSrc + 'Country'));
         sobjDst.put(strFieldPrefixDst + 'Latitude', sobjSrc.get(strFieldPrefixSrc + 'Latitude'));
         sobjDst.put(strFieldPrefixDst + 'Longitude', sobjSrc.get(strFieldPrefixSrc + 'Longitude'));
+        if (orgConfig.isStateCountryPicklistsEnabled()) {
+            sobjDst.put(strFieldPrefixDst + 'StateCode', sobjSrc.get(strFieldPrefixSrc + 'StateCode'));
+            sobjDst.put(strFieldPrefixDst + 'CountryCode', sobjSrc.get(strFieldPrefixSrc + 'CountryCode'));
+        }
     }
 
     /*******************************************************************************************************
@@ -151,8 +155,13 @@ public inherited sharing class AddressService {
         sobjDst.put(strFieldPrefix + 'PostalCode', addr.MailingPostalCode__c);
         sobjDst.put(strFieldPrefix + 'Latitude', addr.Geolocation__Latitude__s);
         sobjDst.put(strFieldPrefix + 'Longitude', addr.Geolocation__Longitude__s);
-        sobjDst.put(strFieldPrefix + 'State', addr.MailingState__c);
-        sobjDst.put(strFieldPrefix + 'Country', addr.MailingCountry__c);
+        if (orgConfig.isStateCountryPicklistsEnabled() && addr.MailingCountry__c != null && addr.MailingCountry__c.length() == 2) {
+            sobjDst.put(strFieldPrefix + 'StateCode', addr.MailingState__c);
+            sobjDst.put(strFieldPrefix + 'CountryCode', addr.MailingCountry__c);                
+        } else {
+            sobjDst.put(strFieldPrefix + 'State', addr.MailingState__c);
+            sobjDst.put(strFieldPrefix + 'Country', addr.MailingCountry__c);    
+        }
 
         if (strFieldAddrType != null) {
             sobjDst.put(strFieldAddrType, addr.Address_Type__c);

--- a/force-app/main/service/AddressService.cls
+++ b/force-app/main/service/AddressService.cls
@@ -155,13 +155,18 @@ public inherited sharing class AddressService {
         sobjDst.put(strFieldPrefix + 'PostalCode', addr.MailingPostalCode__c);
         sobjDst.put(strFieldPrefix + 'Latitude', addr.Geolocation__Latitude__s);
         sobjDst.put(strFieldPrefix + 'Longitude', addr.Geolocation__Longitude__s);
-        if (orgConfig.isStateCountryPicklistsEnabled() && addr.MailingCountry__c != null && addr.MailingCountry__c.length() == 2) {
-            sobjDst.put(strFieldPrefix + 'StateCode', addr.MailingState__c);
-            sobjDst.put(strFieldPrefix + 'CountryCode', addr.MailingCountry__c);                
-        } else {
-            sobjDst.put(strFieldPrefix + 'State', addr.MailingState__c);
-            sobjDst.put(strFieldPrefix + 'Country', addr.MailingCountry__c);    
+        String countryField = 'Country';
+        String stateField = 'State';
+        if (orgConfig.isStateCountryPicklistsEnabled()) {
+            if (addr.MailingCountry__c != null && addr.MailingCountry__c.length() <= 3) {
+                countryField = 'CountryCode';
+            }
+            if (addr.MailingState__c != null && addr.MailingState__c.length() == 2) {
+                stateField = 'StateCode';
+            }
         }
+        sobjDst.put(strFieldPrefix + countryField, addr.MailingCountry__c);
+        sobjDst.put(strFieldPrefix + stateField, addr.MailingState__c);
 
         if (strFieldAddrType != null) {
             sobjDst.put(strFieldAddrType, addr.Address_Type__c);

--- a/force-app/main/service/AddressService.cls
+++ b/force-app/main/service/AddressService.cls
@@ -62,6 +62,10 @@ public inherited sharing class AddressService {
         sobjDst.put(strFieldPrefixDst + 'Country', sobjSrc.get(strFieldPrefixSrc + 'Country'));
         sobjDst.put(strFieldPrefixDst + 'Latitude', sobjSrc.get(strFieldPrefixSrc + 'Latitude'));
         sobjDst.put(strFieldPrefixDst + 'Longitude', sobjSrc.get(strFieldPrefixSrc + 'Longitude'));
+        if (orgConfig.isStateCountryPicklistsEnabled()) {
+            sobjDst.put(strFieldPrefixDst + 'StateCode', sobjSrc.get(strFieldPrefixSrc + 'StateCode'));
+            sobjDst.put(strFieldPrefixDst + 'CountryCode', sobjSrc.get(strFieldPrefixSrc + 'CountryCode'));
+        }
     }
 
     /*******************************************************************************************************

--- a/force-app/main/service/AddressService.cls
+++ b/force-app/main/service/AddressService.cls
@@ -155,18 +155,50 @@ public inherited sharing class AddressService {
         sobjDst.put(strFieldPrefix + 'PostalCode', addr.MailingPostalCode__c);
         sobjDst.put(strFieldPrefix + 'Latitude', addr.Geolocation__Latitude__s);
         sobjDst.put(strFieldPrefix + 'Longitude', addr.Geolocation__Longitude__s);
-        String countryField = 'Country';
-        String stateField = 'State';
-        if (orgConfig.isStateCountryPicklistsEnabled()) {
-            if (addr.MailingCountry__c != null && addr.MailingCountry__c.length() <= 3) {
-                countryField = 'CountryCode';
+
+        if (!orgConfig.isStateCountryPicklistsEnabled()) {
+            sobjDst.put(strFieldPrefix + 'State', addr.MailingState__c);
+            sobjDst.put(strFieldPrefix + 'Country', addr.MailingCountry__c);
+        } else {
+            if (addr.MailingCountry__c != null) {
+                if (orgConfig.validCountriesByLabel().containsKey(addr.MailingCountry__c
+                        .toUpperCase()
+                )) {
+                    sobjDst.put(strFieldPrefix + 'Country', addr.MailingCountry__c);
+                    sobjDst.put(strFieldPrefix + 'CountryCode',
+                            orgConfig.validCountriesByLabel().get(
+                                    addr.MailingCountry__c.toUpperCase()));
+                } else if (orgConfig.validCountriesByCode().containsKey(addr.MailingCountry__c
+                        .toUpperCase())) {
+                    sobjDst.put(strFieldPrefix + 'CountryCode', addr.MailingCountry__c.toUpperCase());
+                    sobjDst.put(strFieldPrefix + 'Country',
+                            orgConfig.validCountriesByCode().get(
+                                    addr.MailingCountry__c.toUpperCase()));
+                } else {
+                    // allow the invalid country to be placed in the country field, so Salesforce will generate the error.
+                    sobjDst.put(strFieldPrefix + 'Country', addr.MailingCountry__c);
+                }
+            } else { // MailingCountry = null
+                sobjDst.put(strFieldPrefix + 'CountryCode', null);
+                sobjDst.put(strFieldPrefix + 'Country', null);
             }
-            if (addr.MailingState__c != null && addr.MailingState__c.length() == 2) {
-                stateField = 'StateCode';
+            if (addr.MailingState__c != null) {
+                if (orgConfig.validStatesByLabel().containsKey(addr.MailingState__c
+                        .toUpperCase())) {
+                    sobjDst.put(strFieldPrefix + 'State', addr.MailingState__c);
+                    sobjDst.put(strFieldPrefix + 'StateCode', orgConfig.validStatesByLabel()
+                            .get(addr
+                                    .MailingState__c.toUpperCase()));
+                } else {
+                    // too expensive for us to create the map of CountryCode|StateCode to StateLabel
+                    // so we will just try to save any state that isn't a label as a code.
+                    sobjDst.put(strFieldPrefix + 'StateCode', addr.MailingState__c.toUpperCase());
+                }
+            } else { // MailingState = null
+                sobjDst.put(strFieldPrefix + 'StateCode', null);
+                sobjDst.put(strFieldPrefix + 'State', null);
             }
         }
-        sobjDst.put(strFieldPrefix + countryField, addr.MailingCountry__c);
-        sobjDst.put(strFieldPrefix + stateField, addr.MailingState__c);
 
         if (strFieldAddrType != null) {
             sobjDst.put(strFieldAddrType, addr.Address_Type__c);

--- a/force-app/main/service/AddressService.cls
+++ b/force-app/main/service/AddressService.cls
@@ -61,10 +61,6 @@ public inherited sharing class AddressService {
         sobjDst.put(strFieldPrefixDst + 'Country', sobjSrc.get(strFieldPrefixSrc + 'Country'));
         sobjDst.put(strFieldPrefixDst + 'Latitude', sobjSrc.get(strFieldPrefixSrc + 'Latitude'));
         sobjDst.put(strFieldPrefixDst + 'Longitude', sobjSrc.get(strFieldPrefixSrc + 'Longitude'));
-        if (orgConfig.isStateCountryPicklistsEnabled()) {
-            sobjDst.put(strFieldPrefixDst + 'StateCode', sobjSrc.get(strFieldPrefixSrc + 'StateCode'));
-            sobjDst.put(strFieldPrefixDst + 'CountryCode', sobjSrc.get(strFieldPrefixSrc + 'CountryCode'));
-        }
     }
 
     /*******************************************************************************************************

--- a/force-app/main/service/AddressService.cls
+++ b/force-app/main/service/AddressService.cls
@@ -46,8 +46,9 @@ public inherited sharing class AddressService {
     }
 
     /*******************************************************************************************************
-    * @description Utility to copy Address fields between Contacts and Accounts (or vice-versa).
-    * Handles instances where State and Country picklists are enabled, and multiline street addresses.
+    * Doesn't do anything special when State and Country picklists are enabled (the
+     * platform will fill out State and Country Code values using the values from the
+     * picklist fields), and multiline street addresses.
     * @param sobjSrc the source Contact or Account
     * @param strFieldPrefixSrc the address fields to copy from, ie., Mailing, Other, Shipping, Billing
     * @param sobjDst the destination Contact or Account

--- a/force-app/main/service/AddressServiceTests_TEST.cls
+++ b/force-app/main/service/AddressServiceTests_TEST.cls
@@ -45,16 +45,18 @@ private class AddressServiceTests_TEST {
      * state code depending on the value in the Country (or CountryCode) value.
      */
     @IsTest
-    static void shouldNotDirectlySetStateCodeValue() {
+    static void shouldDirectlySetStateCodeValue() {
         if (!orgConfig.isStateCountryPicklistsEnabled()) {
             return;
         }
 
         // Arrange
+        String stateName = 'Minnesota';
+        String stateCode = 'MN';
         Contact aContact = new Contact();
         IAddress anAddress = new NPSP_Address(
                 new Address__c(
-                        MailingState__c = 'Montana',
+                        MailingState__c = stateName,
                         MailingCountry__c = 'United States'
                 )
         );
@@ -69,8 +71,8 @@ private class AddressServiceTests_TEST {
         );
 
         // Assert
-        System.assertEquals(null, aContact.get('MailingStateCode'),
-                'The copyOntoSObject method should not be setting State Code values.');
+        System.assertEquals(stateCode, aContact.get('MailingStateCode'),
+                'The copyOntoSObject method should be setting State Code values.');
     }
 
     @IsTest

--- a/force-app/test/ADDR_Addresses_TEST.cls
+++ b/force-app/test/ADDR_Addresses_TEST.cls
@@ -1355,7 +1355,6 @@ public with sharing class ADDR_Addresses_TEST {
     @IsTest
     private static void testAddressOverrideCreatesNewAddressWhenStateCodeIsChanged() {
         if (!orgConfig.isStateCountryPicklistsEnabled()) {
-
             return;
         }
 
@@ -1370,7 +1369,7 @@ public with sharing class ADDR_Addresses_TEST {
 
         // Modify the Contact addresses directly, and set override
         Contact con = testContacts[0];
-        con.put('MailingState', state);
+        con.put('MailingStateCode', stateCode);
         con.is_Address_Override__c = true;
 
         Test.startTest();
@@ -1408,7 +1407,7 @@ public with sharing class ADDR_Addresses_TEST {
         System.assertEquals(false, isMatchAddressAccCon(eachContactAccount, listCon[0]));
 
         // Verify the new Address Mailing State matches Contact's MailingStateCode and not set as the Default
-        System.assertEquals('California', newAddress.MailingState__c);
+        System.assertEquals(stateCode, newAddress.MailingState__c);
         System.assertEquals(false, newAddress.Default_Address__c);
     }
 

--- a/force-app/test/ADDR_Addresses_TEST.cls
+++ b/force-app/test/ADDR_Addresses_TEST.cls
@@ -1413,6 +1413,112 @@ public with sharing class ADDR_Addresses_TEST {
 
     /*********************************************************************************************************
     @description
+        Update Address' Mailing Country when it is empty and State & Country Picklists are enabled.
+    verify:
+        Does not populate the Address' Mailing Country if the source sObject's CountryCode is empty
+        Populates the Address' Mailing Country with the source sObject's CountryCode value if the Mailing Country is empty
+    **********************************************************************************************************/
+    @IsTest
+    private static void testEmptyAddressCountryIsPopulatedFromCountryCode() {
+        if (!orgConfig.isStateCountryPicklistsEnabled()) {
+            return;
+        }
+
+        Contact con = new Contact();
+        con.put('MailingCountryCode', null);
+        Address__c addressEmptyCountry = new Address__c(MailingCountry__c = null);
+
+        Test.startTest();
+
+        String countryCode = 'US';
+        String country = 'United States';
+
+        NPSP_Address npspAddressEmptyCountry = new NPSP_Address(addressEmptyCountry);
+        npspAddressEmptyCountry.populateAddressCountryFromCountryCode(con, 'Mailing');
+        System.assertEquals(null, npspAddressEmptyCountry.country());
+
+        con.put('MailingCountryCode', countryCode);
+        npspAddressEmptyCountry.populateAddressCountryFromCountryCode(con, 'Mailing');
+        System.assertEquals(country, npspAddressEmptyCountry.country());
+
+        Test.stopTest();
+    }
+
+
+    /*********************************************************************************************************
+    @description
+        Update the Address' Mailing State when it is empty or does not match the source sObject's StateCode
+        and State & Country Picklists are enabled.
+    verify:
+        Does not populate the Address' Mailing State if the source sObject's StateCode is empty
+        Populate the Address' Mailing State with the source sObject's StateCode value if the Mailing State is empty
+        Populate the Address' Mailing State with the source sObject's StateCode value if the Mailing State does not match the StateCode
+    **********************************************************************************************************/
+    @IsTest
+    private static void testEmptyAddressStateIsPopulatedFromStateCode() {
+        if (!orgConfig.isStateCountryPicklistsEnabled()) {
+            return;
+        }
+
+        Contact con = new Contact();
+        con.put('MailingStateCode', null);
+        Address__c addressEmptyState = new Address__c(MailingState__c = null);
+
+        Test.startTest();
+
+        String stateCode = 'CA';
+
+        NPSP_Address npspAddressEmptyState = new NPSP_Address(addressEmptyState);
+        npspAddressEmptyState.populateAddressStateFromStateCode(con, 'Mailing');
+        System.assertEquals(null, npspAddressEmptyState.state());
+
+        con.put('MailingStateCode', stateCode);
+        npspAddressEmptyState.populateAddressStateFromStateCode(con, 'Mailing');
+        System.assertEquals(stateCode, npspAddressEmptyState.state());
+
+        npspAddressEmptyState.state('NY');
+        npspAddressEmptyState.populateAddressStateFromStateCode(con, 'Mailing');
+        System.assertEquals(stateCode, npspAddressEmptyState.state());
+
+        Test.stopTest();
+    }
+
+
+    /*********************************************************************************************************
+    @description
+        Checks if the Mailing State matches the source sObject's StateCode.
+    verify:
+        Returns false if the Address Mailing State is empty
+        Returns false if the Address Mailing State does not match the StateCode
+        Returns true if the Address Mailing State matches the StateCode
+    **********************************************************************************************************/
+    @IsTest
+    private static void testIsMatchingStateCode() {
+        if (!orgConfig.isStateCountryPicklistsEnabled()) {
+            return;
+        }
+
+        Address__c addressMatch = new Address__c();
+
+        Test.startTest();
+
+        String stateCode = 'CA';
+
+        NPSP_Address npspAddressMatch = new NPSP_Address(addressMatch);
+        npspAddressMatch.state(null);
+        System.assertEquals(false, npspAddressMatch.isMatchingStateCode(stateCode));
+
+        npspAddressMatch.state('Hawaii');
+        System.assertEquals(false, npspAddressMatch.isMatchingStateCode(stateCode));
+
+        npspAddressMatch.state('California');
+        System.assertEquals(true, npspAddressMatch.isMatchingStateCode(stateCode));
+
+        Test.stopTest();
+    }
+
+    /*********************************************************************************************************
+    @description
         update contacts' mailing address to cause an update to default Address object
     verify:
         existing Default Address updated

--- a/force-app/test/ADDR_Contacts_TEST.cls
+++ b/force-app/test/ADDR_Contacts_TEST.cls
@@ -483,6 +483,83 @@ public with sharing class ADDR_Contacts_TEST {
                 'Contact address undeliverable status should match account undeliverable status.');
     }
 
+    /**
+     * @description Validates that the address logic works properly when State and Country Picklsits are enabled in an org
+     */
+    @IsTest
+    private static void shouldCreateAddressForContactWithAllFieldsFilledIn() {
+        //skip the test if Advancement is installed
+        if (ADV_PackageInfo_SVC.useAdv()) {
+            return;
+        }
+
+        OrgConfig orgConfig = new OrgConfig();
+        if (orgConfig.isStateCountryPicklistsEnabled() == false) {
+            return;
+        }
+
+        final String TEST_STREET = '123 Household Street';
+        final String TEST_CITY = 'Seattle';
+        final String TEST_STATE = 'Washington';
+        final String TEST_STATE_CODE = 'WA';
+        final String TEST_POSTAL = '08534';
+        final String TEST_COUNTRY = 'United States';
+        final String TEST_COUNTRY_CODE = 'US';
+
+        Contact testContact = new Contact(
+            FirstName = CAO_Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName = CAO_Constants.CONTACT_LASTNAME_FOR_TESTS + UTIL_UnitTestData_TEST.getUniqueString()
+        );
+        testContact.MailingStreet = TEST_STREET;
+        testContact.MailingCity = TEST_CITY;
+        testContact.MailingStateCode = TEST_STATE_CODE;
+        testContact.MailingPostalCode = TEST_POSTAL;
+        testContact.MailingCountryCode = TEST_COUNTRY_CODE;
+
+        Test.startTest();
+        insert testContact;
+        Test.stopTest();
+
+        testContact = [SELECT Id, AccountId, Current_Address__c, 
+                        MailingStreet, MailingCity, MailingState, MailingPostalCode, MailingCountry, MailingStateCode, MailingCountryCode
+                                    FROM Contact
+                                    WHERE Id = :testContact.Id];
+        Address__c addr = [SELECT MailingStreet__c, MailingCity__c, MailingState__c, MailingPostalCode__c, MailingCountry__c
+                                    FROM Address__c
+                                    WHERE Id = :testContact.Current_Address__c
+                                    LIMIT 1];
+        Account a = [SELECT BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry, BillingStateCode, BillingCountryCode
+                                    FROM Account
+                                    WHERE Id = :testContact.AccountId 
+                                    LIMIT 1];
+
+        System.assertEquals(testContact.MailingStreet, TEST_STREET);
+        System.assertEquals(testContact.MailingCity, TEST_CITY);
+        System.assertEquals(testContact.MailingPostalCode, TEST_POSTAL);
+        System.assertEquals(testContact.MailingState, TEST_STATE);
+        System.assertEquals(testContact.MailingCountry, TEST_COUNTRY);
+        System.assertEquals(testContact.MailingStateCode, TEST_STATE_CODE);
+        System.assertEquals(testContact.MailingCountryCode, TEST_COUNTRY_CODE);
+
+        System.assertEquals(a.BillingStreet, TEST_STREET);
+        System.assertEquals(a.BillingCity, TEST_CITY);
+        System.assertEquals(a.BillingPostalCode, TEST_POSTAL);
+        System.assertEquals(a.BillingState, TEST_STATE);
+        System.assertEquals(a.BillingCountry, TEST_COUNTRY);
+        System.assertEquals(a.BillingStateCode, TEST_STATE_CODE);
+        System.assertEquals(a.BillingCountryCode, TEST_COUNTRY_CODE);
+
+        System.assertEquals(addr.MailingStreet__c, TEST_STREET);
+        System.assertEquals(addr.MailingCity__c, TEST_CITY);
+        System.assertEquals(addr.MailingPostalCode__c, TEST_POSTAL);
+        System.assertEquals(addr.MailingState__c, TEST_STATE);
+        System.assertEquals(addr.MailingCountry__c, TEST_COUNTRY);
+    }
+
+
+    // ====================================================
+    // Helper Methods
+
     private static List<Account> createTestAccountsWithBillingAddress(Integer numberOfAccountsToCreate) {
         List<Account> testAccounts = UTIL_UnitTestData_TEST.createMultipleTestAccounts(
                 numberOfAccountsToCreate, CAO_Constants.HH_ACCOUNT_TYPE);

--- a/force-app/test/ADDR_Contacts_TEST.cls
+++ b/force-app/test/ADDR_Contacts_TEST.cls
@@ -485,6 +485,121 @@ public with sharing class ADDR_Contacts_TEST {
 
     /**
      * @description Validates that the address logic works properly when State and Country Picklsits are enabled in an org
+     * and the OtherAddress fields sync properly from Contact to Account
+     */
+    @IsTest
+    private static void shouldRetainCountyAndStateWhenContactOtherAddressIsUsed() {
+        //skip the test if Advancement is installed
+        if (ADV_PackageInfo_SVC.useAdv()) {
+            return;
+        }
+
+        OrgConfig orgConfig = new OrgConfig();
+        Boolean isStateCountryEnabled = orgConfig.isStateCountryPicklistsEnabled();
+
+        final String TEST_STREET = '123 Household Street';
+        final String TEST_CITY = 'Seattle';
+        final String TEST_STATE = 'Washington';
+        final String TEST_STATE_CODE = 'WA';
+        final String TEST_POSTAL = '08534';
+        final String TEST_COUNTRY = 'United States';
+        final String TEST_COUNTRY_CODE = 'US';
+
+        final String TEST_OTHER_STREET = '321 Work Street';
+        final String TEST_OTHER_COUNTRY = 'Canada';
+        final String TEST_OTHER_COUNTRY_CODE = 'CA';
+        final String TEST_OTHER_STATE = 'Alberta';
+        final String TEST_OTHER_STATE_CODE = 'AB';
+
+        Contact testContact = new Contact(
+            FirstName = CAO_Constants.CONTACT_FIRSTNAME_FOR_TESTS,
+            LastName = CAO_Constants.CONTACT_LASTNAME_FOR_TESTS + UTIL_UnitTestData_TEST.getUniqueString()
+        );
+        testContact.MailingStreet = TEST_STREET;
+        testContact.MailingCity = TEST_CITY;
+        testContact.MailingPostalCode = TEST_POSTAL;
+        testContact.OtherStreet = TEST_OTHER_STREET;
+        if (isStateCountryEnabled) {
+            testContact.put('MailingStateCode', TEST_STATE_CODE);
+            testContact.put('MailingCountryCode', TEST_COUNTRY_CODE);
+            testContact.put('OtherStateCode', TEST_OTHER_STATE_CODE);
+            testContact.put('OtherCountryCode', TEST_OTHER_COUNTRY_CODE);
+        } else {
+            testContact.put('MailingState', TEST_STATE);
+            testContact.put('MailingCountry', TEST_COUNTRY);
+            testContact.put('OtherState', TEST_OTHER_STATE);
+            testContact.put('OtherCountry', TEST_OTHER_COUNTRY);
+        }
+
+        Test.startTest();
+        insert testContact;
+        Test.stopTest();
+
+        String contactSOQL = 'SELECT Id, AccountId, Current_Address__c, ' 
+                        + 'MailingStreet, MailingCity, MailingState, MailingPostalCode, MailingCountry, '
+                        + 'OtherStreet, OtherCity, OtherState, OtherCountry';
+        if (isStateCountryEnabled) {
+            contactSOQL += ', MailingStateCode, MailingCountryCode, OtherStateCode, OtherCountryCode';
+        }
+        contactSOQL += ' FROM Contact WHERE Id = \'' + testContact.Id +'\'';
+        testContact = Database.query(contactSOQL);
+
+        Address__c addr = [SELECT MailingStreet__c, MailingCity__c, MailingState__c, MailingPostalCode__c, MailingCountry__c
+                                    FROM Address__c
+                                    WHERE Id = :testContact.Current_Address__c
+                                    LIMIT 1];
+
+        String accountSOQL = 'SELECT Id, BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry, '
+                        + 'ShippingStreet, ShippingCity, ShippingState, ShippingCountry';
+        if (isStateCountryEnabled) {
+            accountSOQL += ', BillingStateCode, BillingCountryCode, ShippingStateCode, ShippingCountryCode';
+        }
+        accountSOQL += ' FROM Account WHERE Id = \'' + testContact.AccountId +'\'';
+        Account acct = Database.query(accountSOQL);
+
+        System.assertEquals(testContact.MailingStreet, TEST_STREET);
+        System.assertEquals(testContact.MailingCity, TEST_CITY);
+        System.assertEquals(testContact.MailingPostalCode, TEST_POSTAL);
+        System.assertEquals(testContact.MailingState, TEST_STATE, 'The MailingState field should have a value');
+        System.assertEquals(testContact.MailingCountry, TEST_COUNTRY, 'The MailingCountry field should have a value');
+
+        System.assertEquals(testContact.OtherStreet, TEST_OTHER_STREET);
+        System.assertEquals(testContact.OtherState, TEST_OTHER_STATE);
+        System.assertEquals(testContact.OtherCountry, TEST_OTHER_COUNTRY, 'The MailingCountry field should have a value');
+
+        if (isStateCountryEnabled) {
+            System.assertEquals(testContact.get('MailingStateCode'), TEST_STATE_CODE, 'The MailingStateCode field should have a value');
+            System.assertEquals(testContact.get('MailingCountryCode'), TEST_COUNTRY_CODE, 'The MailingCountryCode field should have a value');
+            System.assertEquals(testContact.get('OtherStateCode'), TEST_OTHER_STATE_CODE, 'The OtherStateCode field should have a value');
+            System.assertEquals(testContact.get('OtherCountryCode'), TEST_OTHER_COUNTRY_CODE, 'The OtherCountryCode field should have a value');
+        }
+
+        System.assertEquals(acct.BillingStreet, TEST_STREET);
+        System.assertEquals(acct.BillingCity, TEST_CITY);
+        System.assertEquals(acct.BillingPostalCode, TEST_POSTAL);
+        System.assertEquals(acct.BillingState, TEST_STATE, 'The BillingState field should have a value');
+        System.assertEquals(acct.BillingCountry, TEST_COUNTRY, 'The BillingCountry field should have a value');
+        
+        System.assertEquals(acct.ShippingStreet, TEST_OTHER_STREET);
+        System.assertEquals(acct.ShippingState, TEST_OTHER_STATE);
+        System.assertEquals(acct.ShippingCountry, TEST_OTHER_COUNTRY, 'The ShippingCountry field should have a value');
+
+        if (isStateCountryEnabled) {
+            System.assertEquals(acct.get('BillingStateCode'), TEST_STATE_CODE, 'The BillingStateCode field should have a value');
+            System.assertEquals(acct.get('BillingCountryCode'), TEST_COUNTRY_CODE, 'The BillingCountryCode field should have a value');
+            System.assertEquals(acct.get('ShippingStateCode'), TEST_OTHER_STATE_CODE, 'The ShippingStateCode field should have a value');
+            System.assertEquals(acct.get('ShippingCountryCode'), TEST_OTHER_COUNTRY_CODE, 'The ShippingCountryCode field should have a value');
+        }
+
+        System.assertEquals(addr.MailingStreet__c, TEST_STREET);
+        System.assertEquals(addr.MailingCity__c, TEST_CITY);
+        System.assertEquals(addr.MailingPostalCode__c, TEST_POSTAL);
+        System.assert(addr.MailingState__c != null, 'The MailingState field should have a value');
+        System.assert(addr.MailingCountry__c != null, 'The MailingCountry field should have a value');
+    }
+
+    /**
+     * @description Validates that the address logic works properly when State and Country Picklsits are enabled in an org
      */
     @IsTest
     private static void shouldCreateAddressForContactWithAllFieldsFilledIn() {
@@ -546,28 +661,28 @@ public with sharing class ADDR_Contacts_TEST {
         System.assertEquals(testContact.MailingStreet, TEST_STREET);
         System.assertEquals(testContact.MailingCity, TEST_CITY);
         System.assertEquals(testContact.MailingPostalCode, TEST_POSTAL);
-        System.assertEquals(testContact.MailingState, TEST_STATE, 'The MailingState field should lhave a value');
-        System.assertEquals(testContact.MailingCountry, TEST_COUNTRY, 'The MailingCountry field should lhave a value');
+        System.assertEquals(testContact.MailingState, TEST_STATE, 'The MailingState field should have a value');
+        System.assertEquals(testContact.MailingCountry, TEST_COUNTRY, 'The MailingCountry field should have a value');
         if (isStateCountryEnabled) {
-            System.assertEquals(testContact.get('MailingStateCode'), TEST_STATE_CODE, 'The MailingStateCode field should lhave a value');
-            System.assertEquals(testContact.get('MailingCountryCode'), TEST_COUNTRY_CODE, 'The MailingCountryCode field should lhave a value');
+            System.assertEquals(testContact.get('MailingStateCode'), TEST_STATE_CODE, 'The MailingStateCode field should have a value');
+            System.assertEquals(testContact.get('MailingCountryCode'), TEST_COUNTRY_CODE, 'The MailingCountryCode field should have a value');
         }
 
         System.assertEquals(acct.BillingStreet, TEST_STREET);
         System.assertEquals(acct.BillingCity, TEST_CITY);
         System.assertEquals(acct.BillingPostalCode, TEST_POSTAL);
-        System.assertEquals(acct.BillingState, TEST_STATE, 'The BillingState field should lhave a value');
-        System.assertEquals(acct.BillingCountry, TEST_COUNTRY, 'The BillingCountry field should lhave a value');
+        System.assertEquals(acct.BillingState, TEST_STATE, 'The BillingState field should have a value');
+        System.assertEquals(acct.BillingCountry, TEST_COUNTRY, 'The BillingCountry field should have a value');
         if (isStateCountryEnabled) {
-            System.assertEquals(acct.get('BillingStateCode'), TEST_STATE_CODE, 'The BillingStateCode field should lhave a value');
-            System.assertEquals(acct.get('BillingCountryCode'), TEST_COUNTRY_CODE, 'The BillingCountryCode field should lhave a value');
+            System.assertEquals(acct.get('BillingStateCode'), TEST_STATE_CODE, 'The BillingStateCode field should have a value');
+            System.assertEquals(acct.get('BillingCountryCode'), TEST_COUNTRY_CODE, 'The BillingCountryCode field should have a value');
         }
 
         System.assertEquals(addr.MailingStreet__c, TEST_STREET);
         System.assertEquals(addr.MailingCity__c, TEST_CITY);
         System.assertEquals(addr.MailingPostalCode__c, TEST_POSTAL);
-        System.assert(addr.MailingState__c != null, 'The MailingState field should lhave a value');
-        System.assert(addr.MailingCountry__c != null, 'The MailingCountry field should lhave a value');
+        System.assert(addr.MailingState__c != null, 'The MailingState field should have a value');
+        System.assert(addr.MailingCountry__c != null, 'The MailingCountry field should have a value');
     }
 
 

--- a/force-app/test/ADDR_Contacts_TEST.cls
+++ b/force-app/test/ADDR_Contacts_TEST.cls
@@ -494,9 +494,7 @@ public with sharing class ADDR_Contacts_TEST {
         }
 
         OrgConfig orgConfig = new OrgConfig();
-        if (orgConfig.isStateCountryPicklistsEnabled() == false) {
-            return;
-        }
+        Boolean isStateCountryEnabled = orgConfig.isStateCountryPicklistsEnabled();
 
         final String TEST_STREET = '123 Household Street';
         final String TEST_CITY = 'Seattle';
@@ -512,48 +510,64 @@ public with sharing class ADDR_Contacts_TEST {
         );
         testContact.MailingStreet = TEST_STREET;
         testContact.MailingCity = TEST_CITY;
-        testContact.MailingStateCode = TEST_STATE_CODE;
         testContact.MailingPostalCode = TEST_POSTAL;
-        testContact.MailingCountryCode = TEST_COUNTRY_CODE;
+        if (isStateCountryEnabled) {
+            testContact.put('MailingStateCode', TEST_STATE_CODE);
+            testContact.put('MailingCountryCode', TEST_COUNTRY_CODE);
+        } else {
+            testContact.put('MailingState', TEST_STATE);
+            testContact.put('MailingCountry', TEST_COUNTRY);
+        }
 
         Test.startTest();
         insert testContact;
         Test.stopTest();
 
-        testContact = [SELECT Id, AccountId, Current_Address__c, 
-                        MailingStreet, MailingCity, MailingState, MailingPostalCode, MailingCountry, MailingStateCode, MailingCountryCode
-                                    FROM Contact
-                                    WHERE Id = :testContact.Id];
+        String contactSOQL = 'SELECT Id, AccountId, Current_Address__c, ' 
+                        + 'MailingStreet, MailingCity, MailingState, MailingPostalCode, MailingCountry';
+        if (isStateCountryEnabled) {
+            contactSOQL += ', MailingStateCode, MailingCountryCode';
+        }
+        contactSOQL += ' FROM Contact WHERE Id = \'' + testContact.Id +'\'';
+        testContact = Database.query(contactSOQL);
+
         Address__c addr = [SELECT MailingStreet__c, MailingCity__c, MailingState__c, MailingPostalCode__c, MailingCountry__c
                                     FROM Address__c
                                     WHERE Id = :testContact.Current_Address__c
                                     LIMIT 1];
-        Account a = [SELECT BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry, BillingStateCode, BillingCountryCode
-                                    FROM Account
-                                    WHERE Id = :testContact.AccountId 
-                                    LIMIT 1];
+
+        String accountSOQL = 'SELECT Id, BillingStreet, BillingCity, BillingState, BillingPostalCode, BillingCountry';
+        if (isStateCountryEnabled) {
+            accountSOQL += ', BillingStateCode, BillingCountryCode';
+        }
+        accountSOQL += ' FROM Account WHERE Id = \'' + testContact.AccountId +'\'';
+        Account acct = Database.query(accountSOQL);
 
         System.assertEquals(testContact.MailingStreet, TEST_STREET);
         System.assertEquals(testContact.MailingCity, TEST_CITY);
         System.assertEquals(testContact.MailingPostalCode, TEST_POSTAL);
-        System.assertEquals(testContact.MailingState, TEST_STATE);
-        System.assertEquals(testContact.MailingCountry, TEST_COUNTRY);
-        System.assertEquals(testContact.MailingStateCode, TEST_STATE_CODE);
-        System.assertEquals(testContact.MailingCountryCode, TEST_COUNTRY_CODE);
+        System.assertEquals(testContact.MailingState, TEST_STATE, 'The MailingState field should lhave a value');
+        System.assertEquals(testContact.MailingCountry, TEST_COUNTRY, 'The MailingCountry field should lhave a value');
+        if (isStateCountryEnabled) {
+            System.assertEquals(testContact.get('MailingStateCode'), TEST_STATE_CODE, 'The MailingStateCode field should lhave a value');
+            System.assertEquals(testContact.get('MailingCountryCode'), TEST_COUNTRY_CODE, 'The MailingCountryCode field should lhave a value');
+        }
 
-        System.assertEquals(a.BillingStreet, TEST_STREET);
-        System.assertEquals(a.BillingCity, TEST_CITY);
-        System.assertEquals(a.BillingPostalCode, TEST_POSTAL);
-        System.assertEquals(a.BillingState, TEST_STATE);
-        System.assertEquals(a.BillingCountry, TEST_COUNTRY);
-        System.assertEquals(a.BillingStateCode, TEST_STATE_CODE);
-        System.assertEquals(a.BillingCountryCode, TEST_COUNTRY_CODE);
+        System.assertEquals(acct.BillingStreet, TEST_STREET);
+        System.assertEquals(acct.BillingCity, TEST_CITY);
+        System.assertEquals(acct.BillingPostalCode, TEST_POSTAL);
+        System.assertEquals(acct.BillingState, TEST_STATE, 'The BillingState field should lhave a value');
+        System.assertEquals(acct.BillingCountry, TEST_COUNTRY, 'The BillingCountry field should lhave a value');
+        if (isStateCountryEnabled) {
+            System.assertEquals(acct.get('BillingStateCode'), TEST_STATE_CODE, 'The BillingStateCode field should lhave a value');
+            System.assertEquals(acct.get('BillingCountryCode'), TEST_COUNTRY_CODE, 'The BillingCountryCode field should lhave a value');
+        }
 
         System.assertEquals(addr.MailingStreet__c, TEST_STREET);
         System.assertEquals(addr.MailingCity__c, TEST_CITY);
         System.assertEquals(addr.MailingPostalCode__c, TEST_POSTAL);
-        System.assertEquals(addr.MailingState__c, TEST_STATE);
-        System.assertEquals(addr.MailingCountry__c, TEST_COUNTRY);
+        System.assertEquals(addr.MailingState__c, TEST_STATE, 'The MailingState field should lhave a value');
+        System.assertEquals(addr.MailingCountry__c, TEST_COUNTRY, 'The MailingCountry field should lhave a value');
     }
 
 

--- a/force-app/test/ADDR_Contacts_TEST.cls
+++ b/force-app/test/ADDR_Contacts_TEST.cls
@@ -566,8 +566,8 @@ public with sharing class ADDR_Contacts_TEST {
         System.assertEquals(addr.MailingStreet__c, TEST_STREET);
         System.assertEquals(addr.MailingCity__c, TEST_CITY);
         System.assertEquals(addr.MailingPostalCode__c, TEST_POSTAL);
-        System.assertEquals(addr.MailingState__c, TEST_STATE, 'The MailingState field should lhave a value');
-        System.assertEquals(addr.MailingCountry__c, TEST_COUNTRY, 'The MailingCountry field should lhave a value');
+        System.assert(addr.MailingState__c != null, 'The MailingState field should lhave a value');
+        System.assert(addr.MailingCountry__c != null, 'The MailingCountry field should lhave a value');
     }
 
 


### PR DESCRIPTION
Work Item: [W-1179558](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000xRsWUYA0/view)

# Critical Changes

# Changes

- Fix a bug that caused the BillingState and BillingCountry fields on the Account to appear as null when State & Country Picklists are enabled, and a new Contact with an Address is created.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
