### PR TITLE
[SFCA -- Trust/Security][Implementation] Address potential security vulnerabilities in NPSP (CRLP)

### DIFF
--- a/force-app/main/default/classes/CMT_FilterRule_SEL.cls
+++ b/force-app/main/default/classes/CMT_FilterRule_SEL.cls
@@ -33,6 +33,7 @@
 * @group CMT Filter Rules
 * @description Selector class for FilterGroups and FilterRule Custom Metadata Type objects
 */
+/* sfge-disable ApexFlsViolationRule */
 public without sharing class CMT_FilterRule_SEL {
 
     /**

--- a/force-app/main/default/classes/CMT_FilterRule_SEL.cls
+++ b/force-app/main/default/classes/CMT_FilterRule_SEL.cls
@@ -33,6 +33,8 @@
 * @group CMT Filter Rules
 * @description Selector class for FilterGroups and FilterRule Custom Metadata Type objects
 */
+// Adding custom rule to avoid this class being scanned by the SFCA scanner since we will not enforce FLS for
+// customizable rollups.
 /* sfge-disable ApexFlsViolationRule */
 public without sharing class CMT_FilterRule_SEL {
 

--- a/force-app/main/default/classes/CRLP_RollupUI_SVC.cls
+++ b/force-app/main/default/classes/CRLP_RollupUI_SVC.cls
@@ -35,6 +35,9 @@
 * @description Lightning Component Server Controller for the Rollups UI page CRLP_Setup.
 */
 
+// Adding custom rule to avoid this class being scanned by the SFCA scanner since we will not enforce FLS for
+// customizable rollups.
+/* sfge-disable ApexFlsViolationRule */
 public with sharing class CRLP_RollupUI_SVC {
 
     private static final String SUCCESS_RESPONSE = 'SUCCESS';


### PR DESCRIPTION
We added a code notation to bypass the customized rollup service when the SFCA scanner is executed on the NPSP code base since we don't want all CRLP operations to execute in a system context regardless of user permissions.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
