### PR TITLE
[Bug Bounty / H1] read only user without Opportunity permission can edit opportunity rollups via /apex/STG_PanelOppRollups

### DIFF
--- a/force-app/main/default/pages/STG_PanelOppRollups.page
+++ b/force-app/main/default/pages/STG_PanelOppRollups.page
@@ -1,5 +1,27 @@
 <apex:page controller="STG_PanelOppRollups_CTRL" docType="html-5.0" standardStylesheets="false">
-    <apex:form id="form" styleClass="slds-m-around_x-large">
+    <apex:includeLightning />
+    <script>
+        if ({!NOT(isRunningUserIsAdmin)}) {
+            $Lightning.use("{!namespace}" + ":RD2_EnablementApp", function () {
+                $Lightning.createComponent("{!namespace}" + ":utilIllustration",
+                    {
+                        title: "{!$Label.commonAdminPermissionErrorTitle}",
+                        message: "{!$Label.commonPermissionErrorMessage}",
+                        size: 'small',
+                        variant: 'no-access',
+                        illustrationClass: "slds-p-top_x-large slds-m-top_x-large"
+                    },
+                    "stgPanelErrIllustration",
+                    function () {
+                    }
+                );
+            });
+        }
+    </script>
+    <apex:outputPanel rendered="{!NOT(isRunningUserIsAdmin)}">
+        <div id="stgPanelErrIllustration"/>
+    </apex:outputPanel>
+    <apex:form id="form" styleClass="slds-m-around_x-large" rendered="{!isRunningUserIsAdmin}">
         <c:STG_PageHeader sectionLabel="{!$Label.stgNavDonations}" pageLabel="{!$Label.stgNavDonorStatistics}" />
         <c:UTIL_PageMessages />
         <div class="slds-grid slds-grid_align-center slds-grid_vertical-align-center slds-p-around_large">


### PR DESCRIPTION
Add an admin check on the STG_PanelOppRollups visualforce page so the page cannot be directly accessed by an unauthorized user

[W-8934971](https://gus.lightning.force.com/lightning/r/a07B00000097SpfIAE/view)

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
