### PR TITLE
Support unlocked package builds

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -761,8 +761,30 @@ tasks:
         description: Set the BDI Mapping mode to 'Help Text' or 'Data Import Field Mapping'
         class_path: tasks.set_BDI_mapping_mode.SetBDIMappingMode
 
+    prepare_unlocked_package_source:
+        description: Munge source code to be buildable as an Unlocked Package
+        class_path: cumulusci.tasks.util.FindReplace
+        options:
+            find: SfdoLogUtils
+            replace: SfdoLogUtilsUnlocked
+            path: force-app/main
+            file_pattern:
+                - "*.cls"
 
 flows:
+    build_unlocked_test_package:
+        steps:
+            0:
+                task: command
+                options:
+                    command: |
+                        cp unpackaged/config/core_instrumentation_mock_classes/classes/SfdoLogUtils.cls \
+                        force-app/main/default/classes/SfdoLogUtilsUnlocked.cls && \
+                        cp unpackaged/config/core_instrumentation_mock_classes/classes/SfdoLogUtils.cls-meta.xml \
+                        force-app/main/default/classes/SfdoLogUtilsUnlocked.cls-meta.xml
+            0.1:
+                task: prepare_unlocked_package_source
+
     install_regression:
         steps:
             1:
@@ -888,6 +910,11 @@ flows:
                 flow: config_regression
             3:
                 task: update_admin_profile
+
+    qa_org_unlocked:
+        steps:
+            2:
+                flow: config_regression
 
     ci_feature_2gp_trial:
         steps:


### PR DESCRIPTION
This PR has no user-facing impact. It adjusts automation to ensure that NPSP can build and use Unlocked Package versions for testing, including in particular performance testing.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
