### PR TITLE
W-10707489 - Ignore existing Default GAU Allocations when processing new GAU Allocations in BDI

### DIFF
--- a/force-app/main/default/classes/BDI_GAUAllocationsUtil.cls
+++ b/force-app/main/default/classes/BDI_GAUAllocationsUtil.cls
@@ -150,12 +150,22 @@ public with sharing class BDI_GAUAllocationsUtil {
                         'Opportunity__c,' +
                         'Payment__c,' +
                         'Payment__r.npe01__Opportunity__c '+
-                        'FROM Allocation__c WHERE Opportunity__c IN: opptIds';
+                        'FROM Allocation__c '+
+                        'WHERE (Opportunity__c IN: opptIds';
 
                 if (alloSettings.Payment_Allocations_Enabled__c) {
-                    queryString += ' OR Payment__r.npe01__Opportunity__c IN: opptIds';
+                    queryString += ' OR Payment__r.npe01__Opportunity__c IN: opptIds)';
+                } else {
+                    queryString += ')';
                 }
 
+                String defaultGAUId = alloSettings.Default__c;
+                
+                // Exclude Default GAUs (if enabled) from the search since they will automatically be overwritten.
+                if (alloSettings.Default_Allocations_Enabled__c && defaultGAUId != null) {
+                    queryString += ' AND General_Accounting_Unit__c !=: defaultGAUId';
+                }
+                
                 Allocation__c[] existingAllos = Database.query(queryString);
 
                 if (existingAllos != null) {


### PR DESCRIPTION
Currently in BDI if you have a DI with an existing Oppt or Payment entered that has an existing GAU Allocation linked to it, then BDI will intentionally throw an error since it cannot properly resize existing GAUs. This doesn't need to apply to Default GAU Allocations though since those can be automatically resized.

This ticket basically excludes the default GAU from the check for existing GAU Allocations since it is not relevant and will automatically resize if needed. This will prevent the Error from being thrown in a large number of cases in an org with Default GAU enabled.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
