### PR TITLE
Use without sharing when querying protected payment services configuration object

### DIFF
--- a/force-app/main/default/classes/PaymentServicesConfigurationSelector.cls
+++ b/force-app/main/default/classes/PaymentServicesConfigurationSelector.cls
@@ -34,7 +34,7 @@
 * @description Selector class for Payment Services Configuration
 */
 
-public with sharing class PaymentServicesConfigurationSelector {
+public without sharing class PaymentServicesConfigurationSelector {
 
    public List<Payment_Services_Configuration__c> getConfigRecordsByName(List<String> serviceNames) {
       return [


### PR DESCRIPTION
Now that the payment services config protected object is also being queried for community users who use the new constituent experience product, we found that sharing is being enforced when querying the protected payment services config records, causing the Elevate iframe not to display in the community portal. We are changing to without sharing instead to avoid sharing settings enforcement when querying this object.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
