### PR TITLE
Allow Elevate Widget to Display for Recurring Donation Enabled Data Import Batches

### DIFF
--- a/force-app/main/default/lwc/geFormWidget/geFormWidget.html
+++ b/force-app/main/default/lwc/geFormWidget/geFormWidget.html
@@ -5,13 +5,11 @@
     <template if:true={isElevateTokenizeCard}>
         <!-- Do not render if gift has a schedule -->
         <!-- Alternatively, perhaps render a message similar to the soft credits field bundle -->
-        <template if:false={giftInViewHasSchedule}>
-            <c-ge-form-widget-tokenize-card data-id='widgetComponent'
-                                            has-payment-method-field-in-form={hasPaymentMethodFieldInForm}
-                                            payment-transaction-status-values={paymentTransactionStatusValues}
-                                            widget-data-from-state={widgetDataFromState}>
-            </c-ge-form-widget-tokenize-card>
-        </template>
+        <c-ge-form-widget-tokenize-card data-id='widgetComponent'
+                                        has-payment-method-field-in-form={hasPaymentMethodFieldInForm}
+                                        payment-transaction-status-values={paymentTransactionStatusValues}
+                                        widget-data-from-state={widgetDataFromState}>
+        </c-ge-form-widget-tokenize-card>
     </template>
     <template if:true={isAllocation}>
         <c-ge-form-widget-allocation data-id='widgetComponent'

--- a/force-app/main/default/lwc/geFormWidget/geFormWidget.html
+++ b/force-app/main/default/lwc/geFormWidget/geFormWidget.html
@@ -3,8 +3,6 @@
         <p>{element.componentName} component was not found</p>
     </template>
     <template if:true={isElevateTokenizeCard}>
-        <!-- Do not render if gift has a schedule -->
-        <!-- Alternatively, perhaps render a message similar to the soft credits field bundle -->
         <c-ge-form-widget-tokenize-card data-id='widgetComponent'
                                         has-payment-method-field-in-form={hasPaymentMethodFieldInForm}
                                         payment-transaction-status-values={paymentTransactionStatusValues}


### PR DESCRIPTION
The Elevate widget will now be displayed on the form when the user clicks the "Make Recurring" button on the gift entry form in batch gift entry.

# Critical Changes

# Changes
- We've added the Elevate widget to the Gift Entry form for batch gift entry of recurring donations. [W-11562498](https://gus.my.salesforce.com/a07EE000013UlP3YAK)
# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
