### PR TITLE
Bug fix for multiple clicks on process batch button resulting in multiple opportunities created

### DIFF
--- a/force-app/main/default/lwc/geBatchGiftEntryHeader/__tests__/geBatchGiftEntryHeader.test.js
+++ b/force-app/main/default/lwc/geBatchGiftEntryHeader/__tests__/geBatchGiftEntryHeader.test.js
@@ -122,7 +122,7 @@ describe('c-ge-batch-gift-entry-header', () => {
             expect(handler.mock.calls[0][0].type).toBe('batchdryrun');
         });
 
-        it('should dispatch expected custom event when process batch button is clicked', async () => {
+        it('should dispatch expected custom event and disable header buttons when process batch button is clicked', async () => {
             const batchHeader = setupComponentWithDummy({});
             const handler = jest.fn();
             batchHeader.addEventListener('processbatch', handler);
@@ -136,6 +136,9 @@ describe('c-ge-batch-gift-entry-header', () => {
 
             expect(handler).toHaveBeenCalled();
             expect(handler.mock.calls[0][0].type).toBe('processbatch');
+            expect(buttons[0].disabled).toBe(true);
+            expect(buttons[1].disabled).toBe(true);
+            expect(buttons[2].disabled).toBe(true);
         });
 
         it('should dispatch expected custom event when edit button is clicked', async () => {

--- a/force-app/main/default/lwc/geBatchGiftEntryHeader/__tests__/geBatchGiftEntryHeader.test.js
+++ b/force-app/main/default/lwc/geBatchGiftEntryHeader/__tests__/geBatchGiftEntryHeader.test.js
@@ -136,6 +136,7 @@ describe('c-ge-batch-gift-entry-header', () => {
 
             expect(handler).toHaveBeenCalled();
             expect(handler.mock.calls[0][0].type).toBe('processbatch');
+
             expect(buttons[0].disabled).toBe(true);
             expect(buttons[1].disabled).toBe(true);
             expect(buttons[2].disabled).toBe(true);

--- a/force-app/main/default/lwc/geBatchGiftEntryHeader/geBatchGiftEntryHeader.js
+++ b/force-app/main/default/lwc/geBatchGiftEntryHeader/geBatchGiftEntryHeader.js
@@ -41,6 +41,7 @@ export default class GeBatchGiftEntryHeader extends LightningElement {
                 break;
             case this.ACTIONS.PROCESS_BATCH:
                 this.dispatchEvent(new CustomEvent('processbatch'));
+                this.isGiftBatchProcessing = true;
                 break;
             case this.ACTIONS.EDIT_BATCH:
                 this.editBatch();


### PR DESCRIPTION
[W-10324426](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000YSDjnYAH/view)

# Critical Changes

# Changes

* We fixed an issue around multiple clicks to `Process Batch` button resulting in multiple opportunities being created by ensuring the button is disabled after one click, disallowing the user from clicking multiple times.

# Issues Closed
- [Known Issue](https://trailblazer.salesforce.com/issues_view?id=a1p4V000002dl9gQAA): Gift Entry - Multiple Clicks of "Process Batch" Button Generates Multiple Opportunities

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
