### PR TITLE
Allow Entry in Decimal (Double) Fields

### DIFF
--- a/force-app/main/default/lwc/geFormService/geFormService.js
+++ b/force-app/main/default/lwc/geFormService/geFormService.js
@@ -32,6 +32,7 @@ const inputTypeByDescribeType = {
 const numberFormatterByDescribeType = {
     'PERCENT': 'percent-fixed',
     'CURRENCY': 'currency',
+    'DOUBLE': 'decimal',
     'DECIMAL': 'decimal'
 };
 


### PR DESCRIPTION
[W-10990129](https://gus.lightning.force.com/a07EE00000usCE3YAM)

# Critical Changes

# Changes

# Issues Closed
- [Known Issue](https://trailblazer.salesforce.com/issues_view?id=a1p4V000000pt5kQAA): NPSP Gift Entry Prevents Entry in Decimal (Double) Fields
# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
