### PR TITLE
NPSP Push Upgrade Failures Due to Probabilistic Encryption on MailingPostalCode field

### DIFF
--- a/force-app/test/ADDR_Addresses_TEST.cls
+++ b/force-app/test/ADDR_Addresses_TEST.cls
@@ -789,7 +789,7 @@ public with sharing class ADDR_Addresses_TEST {
             overrideAddressToCreate.Address_Type__c = 'Home';
             overrideAddressToCreate.MailingStreet__c = 'Street Override';
             overrideAddressToCreate.MailingCity__c = 'City Override';
-            overrideAddressToCreate.MailingState__c = 'Washington';
+            overrideAddressToCreate.MailingState__c = 'Pennsylvania';
             overrideAddressToCreate.MailingPostalCode__c = 'Zip Override';
             overrideAddressToCreate.MailingCountry__c = 'United States';
             overrideAddressToCreate.Household_Account__c = testAccounts[0].Id;
@@ -800,7 +800,7 @@ public with sharing class ADDR_Addresses_TEST {
             LastName = 'Override',
             is_Address_Override__c = true,
             AccountId = testAccounts[0].Id,
-            MailingState = 'Washington',
+            MailingState = 'Pennsylvania',
             MailingCity = 'City Override',
             MailingStreet = 'Street Override',
             MailingPostalCode = 'Zip Override',
@@ -811,7 +811,7 @@ public with sharing class ADDR_Addresses_TEST {
 
         Address__c overrideAddress = [SELECT Undeliverable__c
                                       FROM Address__c
-                                      WHERE MailingState__c = 'Washington'];
+                                      WHERE MailingState__c = 'Pennsylvania'];
 
         Test.startTest();
             overrideAddress.Undeliverable__c = true;

--- a/force-app/test/ADDR_Addresses_TEST.cls
+++ b/force-app/test/ADDR_Addresses_TEST.cls
@@ -811,7 +811,7 @@ public with sharing class ADDR_Addresses_TEST {
 
         Address__c overrideAddress = [SELECT Undeliverable__c
                                       FROM Address__c
-                                      WHERE MailingPostalCode__c = 'Zip Override'];
+                                      WHERE MailingState__c = 'Washington'];
 
         Test.startTest();
             overrideAddress.Undeliverable__c = true;


### PR DESCRIPTION
[W-10436989](https://gus.lightning.force.com/a07EE00000fNvxFYAS)

# Critical Changes

# Changes

# Issues Closed
- [Known Issue](https://trailblazer.salesforce.com/issues_view?id=a1p4V000002dlA6QAI): Probabilistic Encryption on Contact Fields Results In Installation/Upgrade Failures
# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
