### PR TITLE
The Elevate field bundle cannot be used in Sandboxes that have Enhanced Domains enabled

### DIFF
--- a/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
@@ -108,17 +108,17 @@ describe('c-ps-Elevate-Token-Handler', () => {
 
    });
 
-   it('should create four non-namespaced visualforce origin urls', () => {
+   it('should create seven non-namespaced visualforce origin urls', () => {
       const vfURLS = buildVFUrls(mockDomainInfo(), 'c');
-      expect(vfURLS.length).toEqual(4);
+      expect(vfURLS.length).toEqual(7);
       vfURLS.forEach(url => {
          expect(url.value.includes('c')).toBe(true);
       })
    });
 
-   it('should create four namespaced visualforce origin urls', () => {
+   it('should create seven namespaced visualforce origin urls', () => {
       const vfURLS = buildVFUrls(mockDomainInfo(), 'npsp');
-      expect(vfURLS.length).toEqual(4);
+      expect(vfURLS.length).toEqual(7);
       vfURLS.forEach(url => {
          expect(url.value.includes('npsp')).toBe(true);
       })
@@ -168,9 +168,9 @@ describe('c-ps-Elevate-Token-Handler', () => {
 
    });
 
-   it('should create five non-namespaced visualforce origin urls on Experience Sites', () => {
+   it('should create eight non-namespaced visualforce origin urls on Experience Sites', () => {
       const vfURLS = buildVFUrls(mockDomainInfoExperienceSite(), 'c');
-      expect(vfURLS.length).toEqual(5);
+      expect(vfURLS.length).toEqual(8);
       vfURLS.forEach(url => {
          expect(url.value.includes('c')).toBe(true);
       })

--- a/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
@@ -51,13 +51,19 @@ class psElevateTokenHandler {
         const url = `https://${domainInfo.orgDomain}--${namespace}.visualforce.com`;
         const alternateUrl = `https://${domainInfo.orgDomain}--${namespace}.${domainInfo.podName}.visual.force.com`;
         const productionEnhancedUrl = `https://${domainInfo.orgDomain}--${namespace}.vf.force.com`;
+        const productionEnhancedUrlLogin = `https://${domainInfo.orgDomain}--${namespace}.my.salesforce.com`;
         const sandboxEnhancedUrl =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.vf.force.com`;
+        const sandboxEnhancedUrlLogin =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.my.salesforce.com`;
+        const sandboxEnhancedUrlExperience =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.my.site.com`;
 
         const originURLs = [
             {value: url},
             {value: alternateUrl},
             {value: productionEnhancedUrl},
-            {value: sandboxEnhancedUrl}
+            {value: sandboxEnhancedUrl},
+            {value: productionEnhancedUrlLogin},
+            {value: sandboxEnhancedUrlLogin},
+            {value: sandboxEnhancedUrlExperience},
         ];
         if (!isBlank(domainInfo.communityBaseURL)) {
             return [...originURLs, { value: domainInfo.communityBaseURL }];

--- a/tests/__mocks__/psElevateTokenHandler.js
+++ b/tests/__mocks__/psElevateTokenHandler.js
@@ -53,13 +53,19 @@ class psElevateTokenHandler {
         const url = `https://${domainInfo.orgDomain}--${namespace}.visualforce.com`;
         const alternateUrl = `https://${domainInfo.orgDomain}--${namespace}.${domainInfo.podName}.visual.force.com`;
         const productionEnhancedUrl = `https://${domainInfo.orgDomain}--${namespace}.vf.force.com`;
+        const productionEnhancedUrlLogin = `https://${domainInfo.orgDomain}--${namespace}.my.salesforce.com`;
         const sandboxEnhancedUrl =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.vf.force.com`;
+        const sandboxEnhancedUrlLogin =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.my.salesforce.com`;
+        const sandboxEnhancedUrlExperience =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.my.site.com`;
 
         return [
             {value: url},
             {value: alternateUrl},
             {value: productionEnhancedUrl},
-            {value: sandboxEnhancedUrl}
+            {value: sandboxEnhancedUrl},
+            {value: productionEnhancedUrlLogin},
+            {value: sandboxEnhancedUrlLogin},
+            {value: sandboxEnhancedUrlExperience},
         ];
     }
 


### PR DESCRIPTION
[W-11652305](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001515XIYAY/view)
Added some urls for origin urls based on this documentation for [enhanced URL changes].(https://help.salesforce.com/s/articleView?id=sf.domain_name_url_format_changes_enable_enhanced.htm&type=5). 
# Critical Changes
# Changes
# Issues Closed
- [Known Issue](https://trailblazer.salesforce.com/issues_view?id=a1p4V000000qzXhQAI): SFDO Elevate: The Elevate field bundle cannot be used in Sandboxes that have Enhanced Domains enabled.
# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
