### PR TITLE
Use configured Elevate payment gateway to override default

### DIFF
--- a/force-app/main/default/classes/ElevateBatch.cls
+++ b/force-app/main/default/classes/ElevateBatch.cls
@@ -54,9 +54,9 @@ public with sharing class ElevateBatch {
         return elevateBatchService.getElevateBatch();
     }
 
-    public ElevateBatchItem add(ElevateCreateBatchItemRequestDTO batchItemRequestDTO, String gatewayOverride) {
+    public ElevateBatchItem add(ElevateCreateBatchItemRequestDTO batchItemRequestDTO) {
         return elevateBatchService.sendAddRequest(
-            elevateBatchService.buildBatchItemRequestFrom(batchItemRequestDTO, gatewayOverride), elevateBatchId());
+            elevateBatchService.buildBatchItemRequestFrom(batchItemRequestDTO), elevateBatchId());
     }
 
     public ElevateBatchItem remove(String elevateTransactionId) {

--- a/force-app/main/default/classes/ElevateBatchService.cls
+++ b/force-app/main/default/classes/ElevateBatchService.cls
@@ -30,13 +30,12 @@
 public virtual with sharing class ElevateBatchService {
 
     public virtual ElevateBatchItem addToElevateBatch(ElevateCreateBatchItemRequestDTO batchItemRequestDTO,
-                                                      String elevateBatchId, String gatewayOverride) {
-        return new ElevateBatch(elevateBatchId).add(batchItemRequestDTO, gatewayOverride);
+                                                      String elevateBatchId) {
+        return new ElevateBatch(elevateBatchId).add(batchItemRequestDTO);
     }
 
-    public ElevateCreateBatchItemRequest buildBatchItemRequestFrom(ElevateCreateBatchItemRequestDTO batchItemRequestDTO,
-                                                                   String gatewayOverride) {
-        return new ElevateCreateBatchItemRequest(batchItemRequestDTO, gatewayOverride);
+    public ElevateCreateBatchItemRequest buildBatchItemRequestFrom(ElevateCreateBatchItemRequestDTO batchItemRequestDTO) {
+        return new ElevateCreateBatchItemRequest(batchItemRequestDTO);
     }
 
     public virtual ElevateBatchItem removeFromElevateBatch(ElevateBatchItem authorizedGift) {

--- a/force-app/main/default/classes/ElevateBatchServiceInvalidRequest.cls
+++ b/force-app/main/default/classes/ElevateBatchServiceInvalidRequest.cls
@@ -45,7 +45,7 @@ public class ElevateBatchServiceInvalidRequest extends ElevateBatchService {
     }
 
     public override ElevateBatchItem addToElevateBatch(ElevateCreateBatchItemRequestDTO createBatchItemRequestDTO,
-                                                       String elevateBatchId, String gatewayOverride) {
+                                                       String elevateBatchId) {
         ElevateBatchItemCreateResponse giftResponse = ElevateBatchItemCreateResponse.parse(addToElevateBatchErrorResponse());
         elevateBatchService.checkForBatchItemErrorsIn(giftResponse);
 

--- a/force-app/main/default/classes/ElevateBatchServiceValidRequest.cls
+++ b/force-app/main/default/classes/ElevateBatchServiceValidRequest.cls
@@ -60,7 +60,7 @@ public class ElevateBatchServiceValidRequest extends ElevateBatchService {
     }
 
     public override ElevateBatchItem addToElevateBatch(ElevateCreateBatchItemRequestDTO createBatchItemRequestDTO,
-                                                       String elevateBatchId, String gatewayOverride) {
+                                                       String elevateBatchId) {
         ElevateBatchItemCreateResponse giftResponse;
 
         if (batchItemType == ElevateBatchItemType.ONE_TIME) {

--- a/force-app/main/default/classes/ElevateCreateBatchItemRequest.cls
+++ b/force-app/main/default/classes/ElevateCreateBatchItemRequest.cls
@@ -34,33 +34,32 @@ public with sharing class ElevateCreateBatchItemRequest {
     public CommitmentInfo commitmentInfo;
     public PurchaseInfo purchaseInfo;
 
-    public ElevateCreateBatchItemRequest(ElevateCreateBatchItemRequestDTO batchItemRequestDTO, String gatewayOverride) {
+    public ElevateCreateBatchItemRequest(ElevateCreateBatchItemRequestDTO batchItemRequestDTO) {
         if (batchItemRequestDTO.schedule == null || batchItemRequestDTO.schedule.isEmpty()) {
             batchItemType = ElevateBatchItemType.ONE_TIME;
         } else {
             batchItemType = ElevateBatchItemType.COMMITMENT;
         }
 
-        buildRequestBody(batchItemRequestDTO, gatewayOverride);
+        buildRequestBody(batchItemRequestDTO);
     }
 
-    private void buildRequestBody(ElevateCreateBatchItemRequestDTO batchItemRequestDTO, String gatewayOverride) {
+    private void buildRequestBody(ElevateCreateBatchItemRequestDTO batchItemRequestDTO) {
         PS_IntegrationServiceConfig.Service configService = new PS_IntegrationServiceConfig.Service();
 
         if (batchItemType == ElevateBatchItemType.COMMITMENT) {
-            buildCommitmentInfoBody(batchItemRequestDTO, configService, gatewayOverride);
+            buildCommitmentInfoBody(batchItemRequestDTO, configService);
         } else {
-            buildPurchaseInfoBody(batchItemRequestDTO, configService, gatewayOverride);
+            buildPurchaseInfoBody(batchItemRequestDTO, configService);
         }
     }
 
     private void buildPurchaseInfoBody(ElevateCreateBatchItemRequestDTO batchItemRequestDTO,
-                                       PS_IntegrationServiceConfig.Service configService,
-                                       String gatewayOverride) {
+                                       PS_IntegrationServiceConfig.Service configService) {
         purchaseInfo = new ElevateCreateBatchItemRequest.PurchaseInfo();
         purchaseInfo.merchantId = configService.getMerchantIds();
-        if (String.isNotBlank(gatewayOverride)) {
-            purchaseInfo.gatewayId = gatewayOverride;
+        if (String.isNotBlank(batchItemRequestDTO.gatewayOverride)) {
+            purchaseInfo.gatewayId = batchItemRequestDTO.gatewayOverride;
         }
         else {
             purchaseInfo.gatewayId = configService.getGatewayIds();
@@ -74,12 +73,11 @@ public with sharing class ElevateCreateBatchItemRequest {
     }
 
     private void buildCommitmentInfoBody(ElevateCreateBatchItemRequestDTO batchItemRequestDTO,
-                                         PS_IntegrationServiceConfig.Service configService,
-                                         String gatewayOverride) {
+                                         PS_IntegrationServiceConfig.Service configService) {
 
         commitmentInfo = new ElevateCreateBatchItemRequest.CommitmentInfo();
-        if (String.isNotBlank(gatewayOverride)) {
-            commitmentInfo.gatewayId = gatewayOverride;
+        if (String.isNotBlank(batchItemRequestDTO.gatewayOverride)) {
+            commitmentInfo.gatewayId = batchItemRequestDTO.gatewayOverride;
         }
         else {
             commitmentInfo.gatewayId = configService.getGatewayIds();

--- a/force-app/main/default/classes/ElevateCreateBatchItemRequestDTO.cls
+++ b/force-app/main/default/classes/ElevateCreateBatchItemRequestDTO.cls
@@ -39,4 +39,5 @@ public with sharing class ElevateCreateBatchItemRequestDTO {
     @AuraEnabled public String currencyCode {get; set;}
     @AuraEnabled public String paymentMethodToken {get; set;}
     @AuraEnabled public Map<String, Object> schedule {get; set;}
+    @AuraEnabled public String gatewayOverride {get; set;}
 }

--- a/force-app/main/default/classes/GE_GiftEntryController.cls
+++ b/force-app/main/default/classes/GE_GiftEntryController.cls
@@ -339,11 +339,10 @@ public with sharing class GE_GiftEntryController {
 
     @AuraEnabled
     public static ElevateBatchItem addToElevateBatch(ElevateCreateBatchItemRequestDTO batchItemRequestDTO,
-                                                     String elevateBatchId,
-                                                     String gatewayOverride) {
+                                                     String elevateBatchId) {
         ElevateBatchItem batchItem;
         try {
-            batchItem = elevateBatchService.addToElevateBatch(batchItemRequestDTO, elevateBatchId, gatewayOverride);
+            batchItem = elevateBatchService.addToElevateBatch(batchItemRequestDTO, elevateBatchId);
         } catch (AuraHandledException ex) {
           UTIL_AuraEnabledCommon.throwAuraHandledException(ex.getMessage());
         }
@@ -1015,9 +1014,11 @@ public with sharing class GE_GiftEntryController {
 
     private static Map<String, String> getGatewayNameById(List<PS_GatewayService.GatewayTemplateSetting> gatewayTemplateSettings) {
         Map<String, String> gatewayNameById = new Map<String, String>();
+
         for (PS_GatewayService.GatewayTemplateSetting gatewayTemplateSetting : gatewayTemplateSettings) {
             gatewayNameById.put(gatewayTemplateSetting.id, gatewayTemplateSetting.gatewayName);
         }
+
         return gatewayNameById;
     }
 
@@ -1030,11 +1031,24 @@ public with sharing class GE_GiftEntryController {
             gatewayTemplateSettings = (List<PS_GatewayService.GatewayTemplateSetting>)
                     JSON.deserialize(gatewayService.getGatewaysByMerchant(),
                             List<PS_GatewayService.GatewayTemplateSetting>.class);
+
         } catch (Exception e) {
             throw new AuraHandledException(e.getMessage());
         }
 
         return gatewayTemplateSettings;
+    }
+
+    @AuraEnabled
+    public static String getGatewayAssignmentSettingsWithDefaultGatewayName() {
+        List<PS_GatewayService.GatewayTemplateSetting> gatewayTemplateSettings = getGatewayTemplateSettings();
+        Map<String, String> gatewayNameById = getGatewayNameById(gatewayTemplateSettings);
+
+        GatewayAssignmentSettings gaSettings = new GatewayAssignmentSettings();
+        gaSettings.gatewayAssignmentEnabled = getGiftEntrySettings().Enable_Gateway_Assignment__c;
+        gaSettings.defaultGatewayName = gatewayNameById.get(new PS_IntegrationServiceConfig.Service().getGatewayIds());
+
+        return JSON.serialize(gaSettings);
     }
 
     /*******************************************************************************************************
@@ -1380,6 +1394,7 @@ public with sharing class GE_GiftEntryController {
 
     public class GatewayAssignmentSettings {
         String defaultGatewayId;
+        String defaultGatewayName;
         String defaultTemplateId;
         Boolean gatewayAssignmentEnabled;
     }

--- a/force-app/main/default/classes/GE_GiftEntryController.cls
+++ b/force-app/main/default/classes/GE_GiftEntryController.cls
@@ -976,6 +976,57 @@ public with sharing class GE_GiftEntryController {
             formTemplates.add(deserializedFormTemplate);
         }
 
+        if (!getGiftEntrySettings().Enable_Gateway_Assignment__c) {
+            return formTemplates;
+        }
+
+        return getMappedGateways(formTemplates);
+    }
+
+    private static GE_Template.Template[] getMappedGateways(GE_Template.Template[] formTemplates) {
+        // TODO: refactor
+
+        List<PS_GatewayService.GatewayTemplateSetting> gatewayTemplateSettings =
+                new List<PS_GatewayService.GatewayTemplateSetting>();
+
+        try {
+            PS_GatewayService gatewayService = new PS_GatewayService();
+            gatewayTemplateSettings = (List<PS_GatewayService.GatewayTemplateSetting>)
+                JSON.deserialize(gatewayService.getGatewaysByMerchant(),
+                    List<PS_GatewayService.GatewayTemplateSetting>.class);
+        }
+        catch (Exception e) {
+            throw new AuraHandledException(e.getMessage());
+        }
+
+        Map<String, String> gatewayNameById = new Map<String, String>();
+        for (PS_GatewayService.GatewayTemplateSetting gatewayTemplateSetting : gatewayTemplateSettings) {
+            gatewayNameById.put(gatewayTemplateSetting.id, gatewayTemplateSetting.gatewayName);
+        }
+
+        String defaultGatewayId = new PS_IntegrationServiceConfig.Service().getGatewayIds();
+        for (GE_Template.Template formTemplate : formTemplates) {
+            if (String.isNotBlank(formTemplate.elevateSettings?.uniqueKey)) {
+
+                try {
+                    formTemplate.elevateSettings.gatewayName =
+                        gatewayNameById.get(decryptGatewayId(formTemplate.elevateSettings.uniqueKey));
+                    if (String.isBlank(formTemplate.elevateSettings.gatewayName)) {
+                        // TODO: Convert to label
+                        formTemplate.elevateSettings.gatewayName = 'Gateway not found';
+                    }
+
+                } catch (Exception e) {
+                    throw new AuraHandledException(e.getMessage());
+                }
+
+            } else {
+                if (formTemplate.elevateSettings != null) {
+                    formTemplate.elevateSettings.gatewayName = gatewayNameById.get(defaultGatewayId);
+                }
+            }
+        }
+
         return formTemplates;
     }
 

--- a/force-app/main/default/classes/GE_GiftEntryController.cls
+++ b/force-app/main/default/classes/GE_GiftEntryController.cls
@@ -984,25 +984,8 @@ public with sharing class GE_GiftEntryController {
     }
 
     private static GE_Template.Template[] getMappedGateways(GE_Template.Template[] formTemplates) {
-        // TODO: refactor
-
-        List<PS_GatewayService.GatewayTemplateSetting> gatewayTemplateSettings =
-                new List<PS_GatewayService.GatewayTemplateSetting>();
-
-        try {
-            PS_GatewayService gatewayService = new PS_GatewayService();
-            gatewayTemplateSettings = (List<PS_GatewayService.GatewayTemplateSetting>)
-                JSON.deserialize(gatewayService.getGatewaysByMerchant(),
-                    List<PS_GatewayService.GatewayTemplateSetting>.class);
-        }
-        catch (Exception e) {
-            throw new AuraHandledException(e.getMessage());
-        }
-
-        Map<String, String> gatewayNameById = new Map<String, String>();
-        for (PS_GatewayService.GatewayTemplateSetting gatewayTemplateSetting : gatewayTemplateSettings) {
-            gatewayNameById.put(gatewayTemplateSetting.id, gatewayTemplateSetting.gatewayName);
-        }
+        List<PS_GatewayService.GatewayTemplateSetting> gatewayTemplateSettings = getGatewayTemplateSettings();
+        Map<String, String> gatewayNameById = getGatewayNameById(gatewayTemplateSettings);
 
         String defaultGatewayId = new PS_IntegrationServiceConfig.Service().getGatewayIds();
         for (GE_Template.Template formTemplate : formTemplates) {
@@ -1028,6 +1011,30 @@ public with sharing class GE_GiftEntryController {
         }
 
         return formTemplates;
+    }
+
+    private static Map<String, String> getGatewayNameById(List<PS_GatewayService.GatewayTemplateSetting> gatewayTemplateSettings) {
+        Map<String, String> gatewayNameById = new Map<String, String>();
+        for (PS_GatewayService.GatewayTemplateSetting gatewayTemplateSetting : gatewayTemplateSettings) {
+            gatewayNameById.put(gatewayTemplateSetting.id, gatewayTemplateSetting.gatewayName);
+        }
+        return gatewayNameById;
+    }
+
+    private static List<PS_GatewayService.GatewayTemplateSetting> getGatewayTemplateSettings() {
+        List<PS_GatewayService.GatewayTemplateSetting> gatewayTemplateSettings =
+                new List<PS_GatewayService.GatewayTemplateSetting>();
+
+        try {
+            PS_GatewayService gatewayService = new PS_GatewayService();
+            gatewayTemplateSettings = (List<PS_GatewayService.GatewayTemplateSetting>)
+                    JSON.deserialize(gatewayService.getGatewaysByMerchant(),
+                            List<PS_GatewayService.GatewayTemplateSetting>.class);
+        } catch (Exception e) {
+            throw new AuraHandledException(e.getMessage());
+        }
+
+        return gatewayTemplateSettings;
     }
 
     /*******************************************************************************************************

--- a/force-app/main/default/classes/GE_GiftEntryController_TEST.cls
+++ b/force-app/main/default/classes/GE_GiftEntryController_TEST.cls
@@ -216,7 +216,7 @@ public with sharing class GE_GiftEntryController_TEST {
         Datetime startDateTime = Datetime.newInstance(Date.today().year(), Date.today().month(), Date.today().day());
         System.assertEquals(startDateTime.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
                 request.commitmentInfo.schedules[0].firstOccurrenceOnTimestamp, 'The request first occurrence ' +
-                        'timestamp should should match the DTO and be converted to ISO 8601 format.');
+                    'timestamp should should match the DTO and be converted to ISO 8601 format.');
     }
 
     @isTest

--- a/force-app/main/default/classes/GE_GiftEntryController_TEST.cls
+++ b/force-app/main/default/classes/GE_GiftEntryController_TEST.cls
@@ -183,7 +183,7 @@ public with sharing class GE_GiftEntryController_TEST {
             String.valueOf(npe03__Recurring_Donation__c.StartDate__c) => String.valueOf(Date.today())
         };
         Test.startTest();
-            ElevateCreateBatchItemRequest request = new ElevateBatchService().buildBatchItemRequestFrom(dto, null);
+            ElevateCreateBatchItemRequest request = new ElevateBatchService().buildBatchItemRequestFrom(dto);
         Test.stopTest();
 
         System.assertEquals(ElevateBatchItemType.COMMITMENT, request.batchItemType, 'The request batch item type ' +
@@ -232,7 +232,7 @@ public with sharing class GE_GiftEntryController_TEST {
         PS_IntegrationService.setConfiguration(PS_IntegrationServiceConfig_TEST.testConfig);
 
         Test.startTest();
-        ElevateCreateBatchItemRequest request = new ElevateBatchService().buildBatchItemRequestFrom(dto, null);
+        ElevateCreateBatchItemRequest request = new ElevateBatchService().buildBatchItemRequestFrom(dto);
         Test.stopTest();
 
         System.assertEquals(ElevateBatchItemType.ONE_TIME, request.batchItemType, 'The request batch item type ' +
@@ -253,11 +253,12 @@ public with sharing class GE_GiftEntryController_TEST {
         dto.lastName = 'donor';
         dto.currencyCode = 'USD';
         dto.paymentMethodToken = '12345';
+        dto.gatewayOverride = gatewayOverride;
 
         PS_IntegrationService.setConfiguration(PS_IntegrationServiceConfig_TEST.testConfig);
 
         Test.startTest();
-        ElevateCreateBatchItemRequest request = new ElevateBatchService().buildBatchItemRequestFrom(dto, gatewayOverride);
+        ElevateCreateBatchItemRequest request = new ElevateBatchService().buildBatchItemRequestFrom(dto);
         Test.stopTest();
 
         System.assertEquals(ElevateBatchItemType.ONE_TIME, request.batchItemType, 'The request batch item type ' +
@@ -280,7 +281,7 @@ public with sharing class GE_GiftEntryController_TEST {
         Test.startTest();
             try {
                 elevateBatchItem = GE_GiftEntryController.addToElevateBatch(new ElevateCreateBatchItemRequestDTO(),
-                        'test-valid-id', null);
+                        'test-valid-id');
             } catch (AuraHandledException ex) {
                 auraException = ex;
             }
@@ -305,7 +306,7 @@ public with sharing class GE_GiftEntryController_TEST {
         Test.startTest();
         try {
             elevateBatchItem = GE_GiftEntryController.addToElevateBatch(new ElevateCreateBatchItemRequestDTO(),
-                    'test-valid-id', null);
+                    'test-valid-id');
         } catch (AuraHandledException ex) {
             auraException = ex;
         }
@@ -330,7 +331,7 @@ ElevateBatchItemType.ONE_TIME, TEST_PAYMENT_METHOD_CARD);
         Test.startTest();
             try {
                 elevateBatchItem = GE_GiftEntryController.addToElevateBatch(new ElevateCreateBatchItemRequestDTO(),
-                    'test-valid-id', null);
+                    'test-valid-id');
             } catch (AuraHandledException ex) {
                 auraException = ex;
             }
@@ -355,7 +356,7 @@ ElevateBatchItemType.ONE_TIME, TEST_PAYMENT_METHOD_CARD);
         Test.startTest();
         try {
             elevateBatchItem = GE_GiftEntryController.addToElevateBatch(new ElevateCreateBatchItemRequestDTO(),
-                    'test-valid-id', null);
+                    'test-valid-id');
         } catch (AuraHandledException ex) {
             auraException = ex;
         }
@@ -399,7 +400,7 @@ ElevateBatchItemType.ONE_TIME, TEST_PAYMENT_METHOD_CARD);
 
         Test.startTest();
         try {
-            GE_GiftEntryController.addToElevateBatch(new ElevateCreateBatchItemRequestDTO(), 'test-valid-group-id', null);
+            GE_GiftEntryController.addToElevateBatch(new ElevateCreateBatchItemRequestDTO(), 'test-valid-group-id');
         } catch (AuraHandledException ex) {
             auraException = ex;
         }

--- a/force-app/main/default/classes/GE_GiftEntryController_TEST.cls
+++ b/force-app/main/default/classes/GE_GiftEntryController_TEST.cls
@@ -178,12 +178,12 @@ public with sharing class GE_GiftEntryController_TEST {
         dto.currencyCode = 'USD';
         dto.paymentMethodToken = '12345';
         dto.schedule = new Map<String,Object> {
-                String.valueOf(npe03__Recurring_Donation__c.npe03__Installment_Period__c) => 'Monthly',
-                String.valueOf(npe03__Recurring_Donation__c.InstallmentFrequency__c) => '1',
-                String.valueOf(npe03__Recurring_Donation__c.StartDate__c) => String.valueOf(Date.today())
+            String.valueOf(npe03__Recurring_Donation__c.npe03__Installment_Period__c) => 'Monthly',
+            String.valueOf(npe03__Recurring_Donation__c.InstallmentFrequency__c) => '1',
+            String.valueOf(npe03__Recurring_Donation__c.StartDate__c) => String.valueOf(Date.today())
         };
         Test.startTest();
-        ElevateCreateBatchItemRequest request = new ElevateBatchService().buildBatchItemRequestFrom(dto, null);
+            ElevateCreateBatchItemRequest request = new ElevateBatchService().buildBatchItemRequestFrom(dto, null);
         Test.stopTest();
 
         System.assertEquals(ElevateBatchItemType.COMMITMENT, request.batchItemType, 'The request batch item type ' +

--- a/force-app/main/default/classes/GE_GiftEntryController_TEST.cls
+++ b/force-app/main/default/classes/GE_GiftEntryController_TEST.cls
@@ -216,7 +216,7 @@ public with sharing class GE_GiftEntryController_TEST {
         Datetime startDateTime = Datetime.newInstance(Date.today().year(), Date.today().month(), Date.today().day());
         System.assertEquals(startDateTime.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
                 request.commitmentInfo.schedules[0].firstOccurrenceOnTimestamp, 'The request first occurrence ' +
-                    'timestamp should should match the DTO and be converted to ISO 8601 format.');
+                'timestamp should should match the DTO and be converted to ISO 8601 format.');
     }
 
     @isTest

--- a/force-app/main/default/classes/GE_Template.cls
+++ b/force-app/main/default/classes/GE_Template.cls
@@ -320,6 +320,7 @@ public with sharing class GE_Template {
         @AuraEnabled public String uniqueKey;
         @AuraEnabled public Boolean isACHEnabled;
         @AuraEnabled public Boolean isCreditCardEnabled;
+        @AuraEnabled public String gatewayName;
     }
 
     /**

--- a/force-app/main/default/lwc/geBatchWizard/geBatchWizard.html
+++ b/force-app/main/default/lwc/geBatchWizard/geBatchWizard.html
@@ -33,6 +33,9 @@
                                             data-qa-locator={qaLocatorSelectTemplate}
                                             required>
                         </lightning-combobox>
+                        <div class="slds-p-top_medium">
+                            {gatewayNameMessage}
+                        </div>
                     </div>
                     <div class={cssClassStep1}>
                         <template if:true={hasInvalidBatchFields}>
@@ -64,6 +67,10 @@
                             >
                             </c-util-input>
                         </template>
+
+                        <div class="slds-p-top_medium">
+                            {gatewayNameMessage}
+                        </div>
 
                     </div>
                     <div class={cssClassStep2}>

--- a/force-app/main/default/lwc/geBatchWizard/geBatchWizard.js
+++ b/force-app/main/default/lwc/geBatchWizard/geBatchWizard.js
@@ -28,6 +28,7 @@ import GeLabelService from 'c/geLabelService';
 
 import getAllFormTemplates from '@salesforce/apex/GE_GiftEntryController.getAllFormTemplates';
 import getDonationMatchingValues from '@salesforce/apex/GE_GiftEntryController.getDonationMatchingValues';
+import getGatewayAssignmentSettingsWithDefaultGatewayName from '@salesforce/apex/GE_GiftEntryController.getGatewayAssignmentSettingsWithDefaultGatewayName';
 
 import DATA_IMPORT_BATCH_INFO from '@salesforce/schema/DataImportBatch__c';
 import DATA_IMPORT_BATCH_ID_INFO from '@salesforce/schema/DataImportBatch__c.Id';
@@ -74,6 +75,7 @@ export default class geBatchWizard extends NavigationMixin(LightningElement) {
     templateOptions;
     isLoaded = false;
     gatewayName;
+    gatewaySettings = {};
 
     headers = {
         0: this.CUSTOM_LABELS.geHeaderBatchSelectTemplate,
@@ -273,6 +275,10 @@ export default class geBatchWizard extends NavigationMixin(LightningElement) {
 
             if (!GeFormService.fieldMappings) {
                 await GeFormService.getFieldMappings();
+            }
+
+            if (Settings.isElevateCustomer()) {
+                this.gatewaySettings = JSON.parse(await getGatewayAssignmentSettingsWithDefaultGatewayName());
             }
 
             if (!this.recordId) {
@@ -517,8 +523,9 @@ export default class geBatchWizard extends NavigationMixin(LightningElement) {
     }
 
     get gatewayNameMessage() {
-        if (!!this.gatewayName) {
-            return 'Payment Gateway: ' + this.gatewayName;
+        if (this.gatewaySettings?.gatewayAssignmentEnabled) {
+            let gatewayName = this.gatewayName ? this.gatewayName : this.gatewaySettings?.defaultGatewayName;
+            return 'Payment Gateway: ' + gatewayName;
         }
         return '';
     }

--- a/force-app/main/default/lwc/geBatchWizard/geBatchWizard.js
+++ b/force-app/main/default/lwc/geBatchWizard/geBatchWizard.js
@@ -73,6 +73,7 @@ export default class geBatchWizard extends NavigationMixin(LightningElement) {
     templatesById = {};
     templateOptions;
     isLoaded = false;
+    gatewayName;
 
     headers = {
         0: this.CUSTOM_LABELS.geHeaderBatchSelectTemplate,
@@ -316,6 +317,7 @@ export default class geBatchWizard extends NavigationMixin(LightningElement) {
 
     handleTemplateChange(event) {
         this.selectedTemplateId = event.detail.value;
+        this.gatewayName = this.selectedTemplate.elevateSettings?.gatewayName;
         this.selectedBatchHeaderFields = [];
 
         this.selectedBatchHeaderFields = addKeyToCollectionItems(this.selectedTemplate.batchHeaderFields);
@@ -512,6 +514,13 @@ export default class geBatchWizard extends NavigationMixin(LightningElement) {
     resetValidations() {
         this.hasInvalidBatchFields = false;
         this.missingBatchHeaderFieldLabels = [];
+    }
+
+    get gatewayNameMessage() {
+        if (!!this.gatewayName) {
+            return 'Payment Gateway: ' + this.gatewayName;
+        }
+        return '';
     }
 
     /*******************************************************************************

--- a/force-app/main/default/lwc/geElevateBatch/geElevateBatch.js
+++ b/force-app/main/default/lwc/geElevateBatch/geElevateBatch.js
@@ -22,8 +22,7 @@ class ElevateBatch {
             }
 
             return await apexAddToElevateBatch({batchItemRequestDTO: tokenizedGift,
-                                                elevateBatchId: this.elevateBatchId,
-                                                gatewayOverride: GeGatewaySettings.getDecryptedGatewayId()}
+                                                       elevateBatchId: this.elevateBatchId}
             );
         } catch (exception) {
             if (retryOnFailure) {

--- a/force-app/main/default/lwc/geFormRenderer/elevateTokenizeableGift.js
+++ b/force-app/main/default/lwc/geFormRenderer/elevateTokenizeableGift.js
@@ -10,6 +10,7 @@ class ElevateTokenizeabledGift {
         this.currencyCode = CURRENCY;
         this.paymentMethodToken = null;
         this.schedule = schedule;
+        this.gatewayOverride = null;
     }
 
     async tokenize(sections) {

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -543,11 +543,13 @@ export default class GeFormRenderer extends LightningElement{
             }
 
             if (!this.isSingleGiftEntry) {
-                GeGatewaySettings.initDecryptedElevateSettings(formTemplate.elevateSettings);
+                if (Settings.isElevateCustomer) {
+                    GeGatewaySettings.initDecryptedElevateSettings(formTemplate.elevateSettings);
+                }
                 this.sections = this.prepareFormForBatchMode(formTemplate.layout.sections);
                 this.dispatchEvent(new CustomEvent('sectionsretrieved'));
             }
-            else {
+            else if (Settings.isElevateCustomer) {
                 GeGatewaySettings.clearDecryptedElevateSettings();
             }
         }
@@ -862,6 +864,7 @@ export default class GeFormRenderer extends LightningElement{
             let tokenizedGift = null;
             try {
                 if (this.shouldTokenizeCard()) {
+                    // TODO: Should only get gateway override if gateway assignment enabled...
                     tokenizedGift = new ElevateTokenizeableGift(
                         this.cardholderNames,
                         getCurrencyLowestCommonDenominator(

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
@@ -180,7 +180,7 @@
 
                     <lightning-layout-item size='12' class='slds-p-left_small slds-p-top_none slds-p-bottom_small'>
                         <c-ge-gateway-select-widget data-id='gatewaySelectWidget'
-                                                    parent-is-g-e={parentIsGE}>
+                                                    parent-id={parentId}>
                         </c-ge-gateway-select-widget>
                     </lightning-layout-item>
 

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
@@ -179,7 +179,8 @@
                     </lightning-layout-item>
 
                     <lightning-layout-item size='12' class='slds-p-left_small slds-p-top_none slds-p-bottom_small'>
-                        <c-ge-gateway-select-widget data-id='gatewaySelectWidget'>
+                        <c-ge-gateway-select-widget data-id='gatewaySelectWidget'
+                                                    parent-is-g-e={parentIsGE}>
                         </c-ge-gateway-select-widget>
                     </lightning-layout-item>
 

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
@@ -178,12 +178,6 @@
                         </template>
                     </lightning-layout-item>
 
-                    <lightning-layout-item size='12' class='slds-p-left_small slds-p-top_none slds-p-bottom_small'>
-                        <c-ge-gateway-select-widget data-id='gatewaySelectWidget'
-                                                    parent-id={parentId}>
-                        </c-ge-gateway-select-widget>
-                    </lightning-layout-item>
-
                 </lightning-layout>
             </article>
         </lightning-layout-item>

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
@@ -60,6 +60,7 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     alert = {};
     dataImportId;
     isMounted = false;
+    parentIsGE = true;
 
     _displayState;
     _showSpinner = true;

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
@@ -50,7 +50,6 @@ import commonPaymentServices from '@salesforce/label/c.commonPaymentServices';
 import geElevateWidgetPaymentServiceUnavailable from '@salesforce/label/c.geElevateWidgetPaymentServiceUnavailable';
 
 const CONTACT_DONOR_TYPE = 'Contact1';
-const PARENT_ID = 'TOKENIZE';
 
 export default class geFormWidgetTokenizeCard extends LightningElement {
     CUSTOM_LABELS = GeLabelService.CUSTOM_LABELS;
@@ -61,7 +60,6 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     alert = {};
     dataImportId;
     isMounted = false;
-    parentId = PARENT_ID;
 
     _displayState;
     _showSpinner = true;

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
@@ -50,6 +50,7 @@ import commonPaymentServices from '@salesforce/label/c.commonPaymentServices';
 import geElevateWidgetPaymentServiceUnavailable from '@salesforce/label/c.geElevateWidgetPaymentServiceUnavailable';
 
 const CONTACT_DONOR_TYPE = 'Contact1';
+const PARENT_ID = 'TOKENIZE';
 
 export default class geFormWidgetTokenizeCard extends LightningElement {
     CUSTOM_LABELS = GeLabelService.CUSTOM_LABELS;
@@ -60,7 +61,7 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     alert = {};
     dataImportId;
     isMounted = false;
-    parentIsGE = true;
+    parentId = PARENT_ID;
 
     _displayState;
     _showSpinner = true;

--- a/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.html
+++ b/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.html
@@ -12,44 +12,48 @@
             </template>
             <template if:false={isLoading}>
                 <template if:false={isDefaultTemplate}>
-                    <template if:true={isGatewayAssignmentEnabled}>
+                    <template if:true={shouldShowGateways}>
                         <template if:false={isExpanded}>
-                            <div class={cssClassPrefix}>
-                                <lightning-button data-id="ga-show-button"
-                                                  variant="base"
-                                                  label={CUSTOM_LABELS.psShowGatewaysAndMethods}
-                                                  onclick={toggleSelectGatewayControls}
-                                                  class="slds-button hide-card-button expand-collapse-link"
-                                                  data-qa-locator="ga-show-button">
-                                </lightning-button>
-                                <lightning-button-icon data-id="ga-show-button-icon"
-                                                       alternative-text={CUSTOM_LABELS.psShowGatewaysAndMethods}
-                                                       variant="bare"
-                                                       icon-name="utility:chevrondown"
-                                                       onclick={toggleSelectGatewayControls}
-                                                       class="slds-m-left_xxx-small"
-                                                       data-qa-locator="ga-show-button-icon">
-                                </lightning-button-icon>
-                            </div>
+                            <template if:true={shouldShowExpandControls}>
+                                <div class={cssClassPrefix}>
+                                    <lightning-button data-id="ga-show-button"
+                                                      variant="base"
+                                                      label={CUSTOM_LABELS.psShowGatewaysAndMethods}
+                                                      onclick={toggleSelectGatewayControls}
+                                                      class="slds-button hide-card-button expand-collapse-link"
+                                                      data-qa-locator="ga-show-button">
+                                    </lightning-button>
+                                    <lightning-button-icon data-id="ga-show-button-icon"
+                                                           alternative-text={CUSTOM_LABELS.psShowGatewaysAndMethods}
+                                                           variant="bare"
+                                                           icon-name="utility:chevrondown"
+                                                           onclick={toggleSelectGatewayControls}
+                                                           class="slds-m-left_xxx-small"
+                                                           data-qa-locator="ga-show-button-icon">
+                                    </lightning-button-icon>
+                                </div>
+                            </template>
                         </template>
                         <template if:true={isExpanded}>
-                            <div class={cssClassPrefix}>
-                                <lightning-button data-id="ga-hide-button"
-                                                  variant="base"
-                                                  label={CUSTOM_LABELS.psHideGatewaysAndMethods}
-                                                  onclick={toggleSelectGatewayControls}
-                                                  class='slds-button hide-card-button expand-collapse-link'
-                                                  data-qa-locator="ga-hide-button">
-                                </lightning-button>
-                                <lightning-button-icon data-id="ga-hide-button-icon"
-                                                       alternative-text={CUSTOM_LABELS.psHideGatewaysAndMethods}
-                                                       variant="bare"
-                                                       icon-name="utility:chevronup"
-                                                       onclick={toggleSelectGatewayControls}
-                                                       class="slds-m-left_xxx-small"
-                                                       data-qa-locator="ga-hide-button-icon">
-                                </lightning-button-icon>
-                            </div>
+                            <template if:true={shouldShowExpandControls}>
+                                <div class={cssClassPrefix}>
+                                    <lightning-button data-id="ga-hide-button"
+                                                      variant="base"
+                                                      label={CUSTOM_LABELS.psHideGatewaysAndMethods}
+                                                      onclick={toggleSelectGatewayControls}
+                                                      class='slds-button hide-card-button expand-collapse-link'
+                                                      data-qa-locator="ga-hide-button">
+                                    </lightning-button>
+                                    <lightning-button-icon data-id="ga-hide-button-icon"
+                                                           alternative-text={CUSTOM_LABELS.psHideGatewaysAndMethods}
+                                                           variant="bare"
+                                                           icon-name="utility:chevronup"
+                                                           onclick={toggleSelectGatewayControls}
+                                                           class="slds-m-left_xxx-small"
+                                                           data-qa-locator="ga-hide-button-icon">
+                                    </lightning-button-icon>
+                                </div>
+                            </template>
                             <div class="half-reduced">
                                 <lightning-combobox data-id="gateway-combobox"
                                                     value={selectedGateway}
@@ -63,68 +67,74 @@
                             </div>
                         </template>
                     </template>
-                    <template if:false={isGatewayAssignmentEnabled}>
+                    <template if:false={shouldShowGateways}>
                         <template if:false={isExpanded}>
-                            <div class="template-top">
-                                <lightning-button data-id="pm-show-button"
-                                                  variant="base"
-                                                  label={CUSTOM_LABELS.psShowPaymentMethods}
-                                                  onclick={toggleSelectGatewayControls}
-                                                  class='slds-button hide-card-button expand-collapse-link'
-                                                  data-qa-locator="pm-show-button">
-                                </lightning-button>
-                                <lightning-button-icon data-id="pm-show-button-icon"
-                                                       alternative-text={CUSTOM_LABELS.psShowPaymentMethods}
-                                                       variant="bare"
-                                                       icon-name="utility:chevrondown"
-                                                       onclick={toggleSelectGatewayControls}
-                                                       class="slds-m-left_xxx-small"
-                                                       data-qa-locator="pm-show-button-icon">
-                                </lightning-button-icon>
-                            </div>
+                            <template if:true={shouldShowExpandControls}>
+                                <div class="template-top">
+                                    <lightning-button data-id="pm-show-button"
+                                                      variant="base"
+                                                      label={CUSTOM_LABELS.psShowPaymentMethods}
+                                                      onclick={toggleSelectGatewayControls}
+                                                      class='slds-button hide-card-button expand-collapse-link'
+                                                      data-qa-locator="pm-show-button">
+                                    </lightning-button>
+                                    <lightning-button-icon data-id="pm-show-button-icon"
+                                                           alternative-text={CUSTOM_LABELS.psShowPaymentMethods}
+                                                           variant="bare"
+                                                           icon-name="utility:chevrondown"
+                                                           onclick={toggleSelectGatewayControls}
+                                                           class="slds-m-left_xxx-small"
+                                                           data-qa-locator="pm-show-button-icon">
+                                    </lightning-button-icon>
+                                </div>
+                            </template>
                         </template>
                         <template if:true={isExpanded}>
-                            <div class="template-top">
-                                <lightning-button data-id="pm-hide-button"
-                                                  variant="base"
-                                                  label={CUSTOM_LABELS.psHidePaymentMethods}
-                                                  onclick={toggleSelectGatewayControls}
-                                                  class='slds-button hide-card-button expand-collapse-link'
-                                                  data-qa-locator="pm-hide-button">
-                                </lightning-button>
-                                <lightning-button-icon data-id="pm-hide-button-icon"
-                                                       alternative-text={CUSTOM_LABELS.psHidePaymentMethods}
-                                                       variant="bare"
-                                                       icon-name="utility:chevronup"
-                                                       onclick={toggleSelectGatewayControls}
-                                                       class="slds-m-left_xxx-small"
-                                                       data-qa-locator="pm-hide-button-icon">
-                                </lightning-button-icon>
-                            </div>
+                            <template if:true={shouldShowExpandControls}>
+                                <div class="template-top">
+                                    <lightning-button data-id="pm-hide-button"
+                                                      variant="base"
+                                                      label={CUSTOM_LABELS.psHidePaymentMethods}
+                                                      onclick={toggleSelectGatewayControls}
+                                                      class='slds-button hide-card-button expand-collapse-link'
+                                                      data-qa-locator="pm-hide-button">
+                                    </lightning-button>
+                                    <lightning-button-icon data-id="pm-hide-button-icon"
+                                                           alternative-text={CUSTOM_LABELS.psHidePaymentMethods}
+                                                           variant="bare"
+                                                           icon-name="utility:chevronup"
+                                                           onclick={toggleSelectGatewayControls}
+                                                           class="slds-m-left_xxx-small"
+                                                           data-qa-locator="pm-hide-button-icon">
+                                    </lightning-button-icon>
+                                </div>
+                            </template>
                         </template>
                     </template>
                     <template if:true={isExpanded}>
-                        <div class="template-top">
-                            <label class="slds-form-element__label" >{CUSTOM_LABELS.psSelectPaymentMethods}</label>
-                            <lightning-input data-id="checkboxACH"
-                                             label={CUSTOM_LABELS.psACH}
-                                             checked={isACHEnabled}
-                                             disabled={isACHDisabled}
-                                             onchange={handleACHChange}
-                                             variant="standard"
-                                             type="checkbox"
-                                             data-qa-locator="checkboxACH">
-                            </lightning-input>
-                            <lightning-input data-id="checkboxCreditCard"
-                                             label={CUSTOM_LABELS.RD2_Credit_Card_Payment_Method_Label}
-                                             checked={isCreditCardEnabled}
-                                             disabled={isCreditCardDisabled}
-                                             onchange={handleCreditCardChange}
-                                             variant="standard"
-                                             type="checkbox"
-                                             data-qa-locator="checkboxCreditCard">
-                            </lightning-input>
-                        </div>
+                        <template if:true={shouldShowPaymentMethods}>
+                            <div class="template-top">
+                                <label class="slds-form-element__label" >{CUSTOM_LABELS.psSelectPaymentMethods}</label>
+                                <lightning-input data-id="checkboxACH"
+                                                 label={CUSTOM_LABELS.psACH}
+                                                 checked={isACHEnabled}
+                                                 disabled={isACHDisabled}
+                                                 onchange={handleACHChange}
+                                                 variant="standard"
+                                                 type="checkbox"
+                                                 data-qa-locator="checkboxACH">
+                                </lightning-input>
+                                <lightning-input data-id="checkboxCreditCard"
+                                                 label={CUSTOM_LABELS.RD2_Credit_Card_Payment_Method_Label}
+                                                 checked={isCreditCardEnabled}
+                                                 disabled={isCreditCardDisabled}
+                                                 onchange={handleCreditCardChange}
+                                                 variant="standard"
+                                                 type="checkbox"
+                                                 data-qa-locator="checkboxCreditCard">
+                                </lightning-input>
+                            </div>
+                        </template>
                     </template>
                 </template>
             </template>

--- a/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
+++ b/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
@@ -1,4 +1,4 @@
-import { LightningElement, track } from 'lwc';
+import { LightningElement, track, api } from 'lwc';
 import getGatewaysFromElevate from '@salesforce/apex/GE_GiftEntryController.getGatewaysFromElevate';
 import encryptGatewayId from '@salesforce/apex/GE_GiftEntryController.encryptGatewayId';
 import decryptGatewayId from '@salesforce/apex/GE_GiftEntryController.decryptGatewayId';
@@ -36,6 +36,8 @@ export default class GeGatewaySelectWidget extends LightningElement {
     @track isDefaultTemplate = false;
     @track isGatewayAssignmentEnabled = false;
     @track isGatewaySelectionDisabled = false;
+
+    @api parentIsGE = false;
 
     CUSTOM_LABELS = Object.freeze({
         messageLoading,
@@ -93,7 +95,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
             this.isLoading = false;
         }
 
-        if (GeGatewaySettings.getIsGiftEntryBatch()) {
+        if (this.parentIsGE) {
             await this.restoreSavedSettings();
         }
     }
@@ -154,7 +156,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
             this.handleInitialPaymentMethodSelections(elevateSettings);
         }
 
-        if (GeGatewaySettings.getIsGiftEntryBatch()) {
+        if (this.parentIsGE) {
             this.disableAllControls();
         }
 
@@ -321,7 +323,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
     }
 
     get hideInGiftEntryBatch() {
-        if (GeGatewaySettings.getIsGiftEntry()) {
+        if (this.parentIsGE) {
             if (GeGatewaySettings.getIsGiftEntryBatch() && this.isGatewayAssignmentEnabled) {
                 return false;
             }
@@ -331,6 +333,6 @@ export default class GeGatewaySelectWidget extends LightningElement {
     }
 
     get cssClassPrefix() {
-        return GeGatewaySettings.getIsGiftEntry() ? GIFT_ENTRY_CSS_CLASS : TEMPLATE_CSS_CLASS;
+        return this.parentIsGE ? GIFT_ENTRY_CSS_CLASS : TEMPLATE_CSS_CLASS;
     }
 }

--- a/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
+++ b/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
@@ -66,7 +66,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
 
     async init() {
         try {
-            let gatewayAssignmentSettings = JSON.parse(await getGatewayAssignmentSettings());
+            const gatewayAssignmentSettings = JSON.parse(await getGatewayAssignmentSettings());
 
             this._defaultTemplateId = gatewayAssignmentSettings.defaultTemplateId;
             this.isGatewayAssignmentEnabled = gatewayAssignmentSettings.gatewayAssignmentEnabled;
@@ -100,7 +100,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
     async connectedCallback() {
         await this.init();
 
-        if (this._widgetMode !== PAYMENT_METHOD_MODE) {
+        if (this.shouldShowGateways) {
             await this.getElevateGateways();
         }
         else {
@@ -342,7 +342,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
 
     async updateElevateSettings() {
         if (this._widgetMode !== GATEWAY_MANAGEMENT_MODE) {
-            let elevateSettings = {
+            const elevateSettings = {
                 uniqueKey: this.isGatewayAssignmentEnabled ?
                     await encryptGatewayId({gatewayId: this.selectedGateway}) : null,
                 isACHEnabled: this.isACHEnabled,

--- a/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
+++ b/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
@@ -62,11 +62,17 @@ export default class GeGatewaySelectWidget extends LightningElement {
     _defaultGatewayId = null;
 
     async init() {
-        let gatewayAssignmentSettings = JSON.parse(await getGatewayAssignmentSettings());
+        try {
+            let gatewayAssignmentSettings = JSON.parse(await getGatewayAssignmentSettings());
 
-        this._defaultTemplateId = gatewayAssignmentSettings.defaultTemplateId;
-        this.isGatewayAssignmentEnabled = gatewayAssignmentSettings.gatewayAssignmentEnabled;
-        this._defaultGatewayId = gatewayAssignmentSettings.defaultGatewayId;
+            this._defaultTemplateId = gatewayAssignmentSettings.defaultTemplateId;
+            this.isGatewayAssignmentEnabled = gatewayAssignmentSettings.gatewayAssignmentEnabled;
+            this._defaultGatewayId = gatewayAssignmentSettings.defaultGatewayId;
+        }
+        catch (e) {
+            this._firstDisplay = false;
+            this.handleErrors();
+        }
 
         if (this._defaultTemplateId === GeGatewaySettings.getTemplateRecordId()) {
             this.isDefaultTemplate = true;
@@ -101,7 +107,13 @@ export default class GeGatewaySelectWidget extends LightningElement {
             return;
         }
 
-        this._elevateGateways = JSON.parse(await getGatewaysFromElevate());
+        try {
+            this._elevateGateways = JSON.parse(await getGatewaysFromElevate());
+        }
+        catch (e) {
+            this._firstDisplay = false;
+            this.handleErrors();
+        }
 
         if (this._elevateGateways && this._elevateGateways.length > 0 && !(this._elevateGateways.errors)) {
             this.buildOptions();

--- a/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
+++ b/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
@@ -23,6 +23,7 @@ import { isEmpty, showToast } from 'c/utilCommon';
 
 const TEMPLATE_CSS_CLASS = 'template-top';
 const GIFT_ENTRY_CSS_CLASS = 'gift-entry-top';
+const TOKENIZE_ID = 'TOKENIZE';
 
 export default class GeGatewaySelectWidget extends LightningElement {
     @track isExpanded = false;
@@ -37,7 +38,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
     @track isGatewayAssignmentEnabled = false;
     @track isGatewaySelectionDisabled = false;
 
-    @api parentIsGE = false;
+    @api parentId = '';
 
     CUSTOM_LABELS = Object.freeze({
         messageLoading,
@@ -95,7 +96,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
             this.isLoading = false;
         }
 
-        if (this.parentIsGE) {
+        if (this.parentId === TOKENIZE_ID) {
             await this.restoreSavedSettings();
         }
     }
@@ -156,7 +157,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
             this.handleInitialPaymentMethodSelections(elevateSettings);
         }
 
-        if (this.parentIsGE) {
+        if (this.parentId === TOKENIZE_ID) {
             this.disableAllControls();
         }
 
@@ -323,7 +324,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
     }
 
     get hideInGiftEntryBatch() {
-        if (this.parentIsGE) {
+        if (this.parentId === TOKENIZE_ID) {
             if (GeGatewaySettings.getIsGiftEntryBatch() && this.isGatewayAssignmentEnabled) {
                 return false;
             }
@@ -333,6 +334,6 @@ export default class GeGatewaySelectWidget extends LightningElement {
     }
 
     get cssClassPrefix() {
-        return this.parentIsGE ? GIFT_ENTRY_CSS_CLASS : TEMPLATE_CSS_CLASS;
+        return this.parentId === TOKENIZE_ID ? GIFT_ENTRY_CSS_CLASS : TEMPLATE_CSS_CLASS;
     }
 }

--- a/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
+++ b/force-app/main/default/lwc/geGatewaySelectWidget/geGatewaySelectWidget.js
@@ -18,12 +18,13 @@ import psShowPaymentMethods from '@salesforce/label/c.psShowPaymentMethods';
 import psUnableToConnect from '@salesforce/label/c.psUnableToConnect';
 import RD2_Credit_Card_Payment_Method_Label from '@salesforce/label/c.RD2_Credit_Card_Payment_Method_Label';
 import GeGatewaySettings from 'c/geGatewaySettings';
-import { fireEvent } from 'c/pubsubNoPageRef';
+import { fireEvent, registerListener } from 'c/pubsubNoPageRef';
 import { isEmpty, showToast } from 'c/utilCommon';
 
 const TEMPLATE_CSS_CLASS = 'template-top';
 const GIFT_ENTRY_CSS_CLASS = 'gift-entry-top';
 const TOKENIZE_ID = 'TOKENIZE';
+const MANAGEMENT_ID = 'MANAGEMENT';
 
 export default class GeGatewaySelectWidget extends LightningElement {
     @track isExpanded = false;
@@ -89,7 +90,7 @@ export default class GeGatewaySelectWidget extends LightningElement {
     async connectedCallback() {
         await this.init();
 
-        if (this.isGatewayAssignmentEnabled) {
+        if (this.isGatewayAssignmentEnabled || this.parentId === MANAGEMENT_ID) {
             await this.getElevateGateways();
         }
         else {
@@ -98,6 +99,12 @@ export default class GeGatewaySelectWidget extends LightningElement {
 
         if (this.parentId === TOKENIZE_ID) {
             await this.restoreSavedSettings();
+        }
+
+        if (this.parentId === MANAGEMENT_ID) {
+            registerListener('editGatewayManagement', this.enableGatewaySelection, this);
+            registerListener('noEditGatewayManagement', this.disableGatewaySelection, this);
+            await this.toggleSelectGatewayControls();
         }
     }
 
@@ -150,15 +157,20 @@ export default class GeGatewaySelectWidget extends LightningElement {
         }
 
         let elevateSettings = GeGatewaySettings.getElevateSettings();
-        if (this.isGatewayAssignmentEnabled) {
+        if (this.isGatewayAssignmentEnabled || this.parentId === MANAGEMENT_ID) {
             await this.handleInitialGatewaySelection(elevateSettings);
         }
         else {
             this.handleInitialPaymentMethodSelections(elevateSettings);
         }
 
-        if (this.parentId === TOKENIZE_ID) {
+        if (this.parentId === TOKENIZE_ID || this.parentId === MANAGEMENT_ID) {
             this.disableAllControls();
+        }
+
+        if (this.parentId === MANAGEMENT_ID) {
+            this.isExpanded = true;
+            fireEvent(this, 'updateSelectedGateway', this.selectedGateway);
         }
 
         this._firstDisplay = false;
@@ -307,14 +319,27 @@ export default class GeGatewaySelectWidget extends LightningElement {
         this.isGatewaySelectionDisabled = false;
     }
 
+    enableGatewaySelection() {
+        this.isGatewaySelectionDisabled = false;
+    }
+
+    disableGatewaySelection() {
+        this.isGatewaySelectionDisabled = true;
+    }
+
     async updateElevateSettings() {
-        let elevateSettings = {
-            uniqueKey: this.isGatewayAssignmentEnabled ?
-                await encryptGatewayId( {gatewayId: this.selectedGateway}) : null,
-            isACHEnabled: this.isACHEnabled,
-            isCreditCardEnabled: this.isCreditCardEnabled
+        if (this.parentId !== MANAGEMENT_ID) {
+            let elevateSettings = {
+                uniqueKey: this.isGatewayAssignmentEnabled ?
+                    await encryptGatewayId({gatewayId: this.selectedGateway}) : null,
+                isACHEnabled: this.isACHEnabled,
+                isCreditCardEnabled: this.isCreditCardEnabled
+            };
+            fireEvent(this, 'updateElevateSettings', elevateSettings);
         }
-        fireEvent(this, 'updateElevateSettings', elevateSettings);
+        else {
+            fireEvent(this, 'updateSelectedGateway', this.selectedGateway);
+        }
     }
 
     disableAllControls() {
@@ -325,15 +350,25 @@ export default class GeGatewaySelectWidget extends LightningElement {
 
     get hideInGiftEntryBatch() {
         if (this.parentId === TOKENIZE_ID) {
-            if (GeGatewaySettings.getIsGiftEntryBatch() && this.isGatewayAssignmentEnabled) {
-                return false;
-            }
-            return true;
+            return !(GeGatewaySettings.getIsGiftEntryBatch() && this.isGatewayAssignmentEnabled);
+
         }
         return false;
     }
 
     get cssClassPrefix() {
         return this.parentId === TOKENIZE_ID ? GIFT_ENTRY_CSS_CLASS : TEMPLATE_CSS_CLASS;
+    }
+
+    get shouldShowGateways() {
+        return this.isGatewayAssignmentEnabled || this.parentId === MANAGEMENT_ID;
+    }
+
+    get shouldShowPaymentMethods() {
+        return this.parentId !== MANAGEMENT_ID;
+    }
+
+    get shouldShowExpandControls() {
+        return this.parentId !== MANAGEMENT_ID;
     }
 }

--- a/force-app/main/default/lwc/geGatewaySettings/geGatewaySettings.js
+++ b/force-app/main/default/lwc/geGatewaySettings/geGatewaySettings.js
@@ -47,10 +47,6 @@ class GeGatewaySettings {
         return this.decryptedGatewayId;
     }
 
-    getIsGiftEntryBatch() {
-        return this.isGiftEntryBatch;
-    }
-
     getTemplateRecordId() {
         return this.templateRecordId;
     }

--- a/force-app/main/default/lwc/geGatewaySettings/geGatewaySettings.js
+++ b/force-app/main/default/lwc/geGatewaySettings/geGatewaySettings.js
@@ -9,10 +9,8 @@ class GeGatewaySettings {
     templateRecordId = null;
     decryptedGatewayId = null;
     isGiftEntryBatch = false;
-    isGiftEntry = false;
 
     setElevateSettings(initialSettings, templateRecordId) {
-        this.isGiftEntry = false;
         this.isGiftEntryBatch = false;
         this.elevateSettings = initialSettings;
         this.templateRecordId = templateRecordId;
@@ -20,7 +18,6 @@ class GeGatewaySettings {
     }
 
     initDecryptedElevateSettings(elevateSettings) {
-        this.isGiftEntry = true;
         this.isGiftEntryBatch = true;
         this.elevateSettings = elevateSettings;
         if (this.elevateSettings?.uniqueKey) {
@@ -33,7 +30,6 @@ class GeGatewaySettings {
     }
 
     clearDecryptedElevateSettings() {
-        this.isGiftEntry = true;
         this.isGiftEntryBatch = false;
         this.elevateSettings = {};
         this.decryptedGatewayId = null;
@@ -49,10 +45,6 @@ class GeGatewaySettings {
 
     getDecryptedGatewayId() {
         return this.decryptedGatewayId;
-    }
-
-    getIsGiftEntry() {
-        return this.isGiftEntry;
     }
 
     getIsGiftEntryBatch() {

--- a/force-app/main/default/lwc/geGatewaySettings/geGatewaySettings.js
+++ b/force-app/main/default/lwc/geGatewaySettings/geGatewaySettings.js
@@ -21,12 +21,14 @@ class GeGatewaySettings {
         this.isGiftEntryBatch = true;
         this.elevateSettings = elevateSettings;
         if (this.elevateSettings?.uniqueKey) {
-            this.decryptElevateGateway().then(error => {
-                if (this.elevateSettings?.uniqueKey && !this.decryptedGatewayId) {
-                    showToast(psGatewayNotValid, details, 'error', 'sticky');
-                }
+            this.decryptElevateGateway().catch((error) => {
+                this.handleError(psGatewayNotValid, error);
             });
         }
+    }
+
+    handleError(message, error) {
+        showToast(message, error, 'error', 'sticky');
     }
 
     clearDecryptedElevateSettings() {
@@ -37,6 +39,10 @@ class GeGatewaySettings {
 
     async decryptElevateGateway() {
         this.decryptedGatewayId = await decryptGatewayId({encryptedGatewayId: this.elevateSettings.uniqueKey});
+
+        if (this.elevateSettings?.uniqueKey && !this.decryptedGatewayId) {
+            this.handleError(psGatewayNotValid);
+        }
     }
 
     getElevateSettings() {

--- a/force-app/main/default/lwc/gePaymentGatewayManagement/gePaymentGatewayManagement.html
+++ b/force-app/main/default/lwc/gePaymentGatewayManagement/gePaymentGatewayManagement.html
@@ -80,7 +80,7 @@
 
             <lightning-layout-item size='12' class='slds-p-left_small slds-p-top_none slds-p-bottom_large'>
                 <c-ge-gateway-select-widget data-id='gatewaySelectWidget'
-                                            parent-id={parentId}>
+                                            parent-context={parentContext}>
                 </c-ge-gateway-select-widget>
             </lightning-layout-item>
 

--- a/force-app/main/default/lwc/gePaymentGatewayManagement/gePaymentGatewayManagement.html
+++ b/force-app/main/default/lwc/gePaymentGatewayManagement/gePaymentGatewayManagement.html
@@ -77,8 +77,15 @@
                     Elevate Admin Console | Gateway Management.
                 </p>
             </lightning-layout-item>
+
+            <lightning-layout-item size='12' class='slds-p-left_small slds-p-top_none slds-p-bottom_large'>
+                <c-ge-gateway-select-widget data-id='gatewaySelectWidget'
+                                            parent-id={parentId}>
+                </c-ge-gateway-select-widget>
+            </lightning-layout-item>
+
             <template if:true={isReadOnly}>
-                <lightning-layout-item size="12" class="slds-text-align_center">
+                <lightning-layout-item size="12" class="slds-p-left_small slds-text-align_left">
                     <lightning-button
                             label="Edit"
                             data-id="editGatewayButton"
@@ -87,16 +94,7 @@
                     </lightning-button>
                 </lightning-layout-item>
             </template>
-            <lightning-layout-item size="4">
-                <!-- Temporary Hardcoded Text until this functionality is moved out of NPSP entirely -->
-                <lightning-input variant="label-inline"
-                                 read-only={isReadOnly}
-                                 label="Gateway ID"
-                                 value={gatewayId}
-                                 type="text"
-                                 data-id="gatewayIdField"
-                                 data-qa-locator="input gateway id field">
-                </lightning-input>
+            <lightning-layout-item size="12" class="slds-p-left_small slds-text-align_left">
                 <template if:false={isReadOnly}>
                     <lightning-button-group>
                         <!-- Temporary Hardcoded Text until this functionality is moved out of NPSP entirely -->

--- a/force-app/main/default/lwc/gePaymentGatewayManagement/gePaymentGatewayManagement.js
+++ b/force-app/main/default/lwc/gePaymentGatewayManagement/gePaymentGatewayManagement.js
@@ -40,7 +40,7 @@ import checkForElevateCustomer from '@salesforce/apex/PS_GatewayManagement.isEle
 import checkForSystemAdmin from '@salesforce/apex/PS_GatewayManagement.isSystemAdmin';
 import { fireEvent, registerListener } from 'c/pubsubNoPageRef';
 
-const PARENT_ID = 'MANAGEMENT';
+const GATEWAY_MANAGEMENT_MODE = 'MANAGEMENT';
 
 export default class GePaymentGatewayManagement extends LightningElement {
 
@@ -54,7 +54,7 @@ export default class GePaymentGatewayManagement extends LightningElement {
     isSystemAdmin;
     hasAccess;
 
-    parentId = PARENT_ID;
+    parentContext = GATEWAY_MANAGEMENT_MODE;
 
     CUSTOM_LABELS = { messageLoading, insufficientPermissions, commonAdminPermissionErrorMessage };
 


### PR DESCRIPTION
Use configured Elevate payment gateway to override default.
# Critical Changes

# Changes
- We've added the ability to choose an Elevate payment gateway on a Gift Entry template to override the default gateway.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
