### PR TITLE
The Elevate field bundle cannot be used in Sandboxes that have Enhanced Domains enabled

### DIFF
--- a/force-app/main/default/classes/GE_PaymentServices.cls
+++ b/force-app/main/default/classes/GE_PaymentServices.cls
@@ -140,6 +140,22 @@ public with sharing class GE_PaymentServices {
     }
 
     /**
+     * @description Returns salesforce org url
+     * @return String JSON of org URL
+     */
+    public String getOrgUrl() {
+        return System.Url.getOrgDomainURL().toExternalForm();
+    }
+
+    /**
+     * @description Returns salesforce base url
+     * @return String JSON of salesforce base URL
+     */
+    public String getSFBaseUrl() {
+        return System.Url.getSalesforceBaseURL().toExternalForm();
+    }
+
+    /**
      * @description Returns purchase request body
      * @param jsonRequestBody: JSON containing parameters for the purchase call request body
      * @return PurchaseCallBody

--- a/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
@@ -108,17 +108,17 @@ describe('c-ps-Elevate-Token-Handler', () => {
 
    });
 
-   it('should create five non-namespaced visualforce origin urls', () => {
+   it('should create eight non-namespaced visualforce origin urls', () => {
       const vfURLS = buildVFUrls(mockDomainInfo(), 'c');
-      expect(vfURLS.length).toEqual(5);
+      expect(vfURLS.length).toEqual(8);
       vfURLS.forEach(url => {
          expect(url.value.includes('c')).toBe(true);
       })
    });
 
-   it('should create five namespaced visualforce origin urls', () => {
+   it('should create eight namespaced visualforce origin urls', () => {
       const vfURLS = buildVFUrls(mockDomainInfo(), 'npsp');
-      expect(vfURLS.length).toEqual(5);
+      expect(vfURLS.length).toEqual(8);
       vfURLS.forEach(url => {
          expect(url.value.includes('npsp')).toBe(true);
       })
@@ -168,9 +168,9 @@ describe('c-ps-Elevate-Token-Handler', () => {
 
    });
 
-   it('should create six non-namespaced visualforce origin urls on Experience Sites', () => {
+   it('should create nine non-namespaced visualforce origin urls on Experience Sites', () => {
       const vfURLS = buildVFUrls(mockDomainInfoExperienceSite(), 'c');
-      expect(vfURLS.length).toEqual(6);
+      expect(vfURLS.length).toEqual(9);
       vfURLS.forEach(url => {
          expect(url.value.includes('c')).toBe(true);
       })

--- a/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
@@ -108,17 +108,17 @@ describe('c-ps-Elevate-Token-Handler', () => {
 
    });
 
-   it('should create seven non-namespaced visualforce origin urls', () => {
+   it('should create five non-namespaced visualforce origin urls', () => {
       const vfURLS = buildVFUrls(mockDomainInfo(), 'c');
-      expect(vfURLS.length).toEqual(7);
+      expect(vfURLS.length).toEqual(5);
       vfURLS.forEach(url => {
          expect(url.value.includes('c')).toBe(true);
       })
    });
 
-   it('should create seven namespaced visualforce origin urls', () => {
+   it('should create five namespaced visualforce origin urls', () => {
       const vfURLS = buildVFUrls(mockDomainInfo(), 'npsp');
-      expect(vfURLS.length).toEqual(7);
+      expect(vfURLS.length).toEqual(5);
       vfURLS.forEach(url => {
          expect(url.value.includes('npsp')).toBe(true);
       })
@@ -168,9 +168,9 @@ describe('c-ps-Elevate-Token-Handler', () => {
 
    });
 
-   it('should create eight non-namespaced visualforce origin urls on Experience Sites', () => {
+   it('should create six non-namespaced visualforce origin urls on Experience Sites', () => {
       const vfURLS = buildVFUrls(mockDomainInfoExperienceSite(), 'c');
-      expect(vfURLS.length).toEqual(8);
+      expect(vfURLS.length).toEqual(6);
       vfURLS.forEach(url => {
          expect(url.value.includes('c')).toBe(true);
       })

--- a/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
@@ -7,8 +7,8 @@ import { isBlank } from 'c/util';
 
 
 /***
-* @description Visualforce page used to handle the payment services credit card tokenization request
-*/
+ * @description Visualforce page used to handle the payment services credit card tokenization request
+ */
 const TOKENIZE_CARD_PAGE_NAME = 'GE_TokenizeCard';
 
 const MOUNT_IFRAME_EVENT_ACTION = 'mount';
@@ -16,20 +16,20 @@ const MOUNT_IFRAME_EVENT_ACTION = 'mount';
 const SET_PAYMENT_METHOD_EVENT_ACTION = 'setPaymentMethod';
 
 /***
-* @description Max number of ms to wait for the response containing a token or an error
-*/
+ * @description Max number of ms to wait for the response containing a token or an error
+ */
 const TOKENIZE_TIMEOUT_MS = 10000;
 
 const NON_NAMESPACED_CHARACTER = 'c';
 
 
 /***
-* @description Payment services Elevate credit card tokenization service
-*/
+ * @description Payment services Elevate credit card tokenization service
+ */
 class psElevateTokenHandler {
     /***
-    * @description Custom labels
-    */
+     * @description Custom labels
+     */
     labels = Object.freeze({
         tokenRequestTimedOut
     });
@@ -39,8 +39,8 @@ class psElevateTokenHandler {
 
 
     /***
-    * @description Returns credit card tokenization Visualforce page URL
-    */
+     * @description Returns credit card tokenization Visualforce page URL
+     */
     getTokenizeCardPageURL() {
         return this.currentNamespace
             ? `/apex/${this.currentNamespace}__${TOKENIZE_CARD_PAGE_NAME}`
@@ -50,28 +50,34 @@ class psElevateTokenHandler {
     getVisualForceOriginURLs(domainInfo, namespace) {
         const url = `https://${domainInfo.orgDomain}--${namespace}.visualforce.com`;
         const alternateUrl = `https://${domainInfo.orgDomain}--${namespace}.${domainInfo.podName}.visual.force.com`;
+        const lightningUrl =  `https://${domainInfo.orgDomain}--${namespace}.lightning.force.com`;
         const productionEnhancedUrl = `https://${domainInfo.orgDomain}--${namespace}.vf.force.com`;
         const productionEnhancedUrlLogin = `https://${domainInfo.orgDomain}--${namespace}.my.salesforce.com`;
         const sandboxEnhancedUrl =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.vf.force.com`;
-        
+        const sandboxEnhancedLightning =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.lightning.force.com`;
+        const sandboxEnhancedCanon =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.my.salesforce.com`;
+
         const originURLs = [
             {value: url},
             {value: alternateUrl},
+            {value: lightningUrl},
             {value: productionEnhancedUrl},
             {value: sandboxEnhancedUrl},
             {value: productionEnhancedUrlLogin},
+            {value: sandboxEnhancedLightning},
+            {value: sandboxEnhancedCanon},
         ];
         if (!isBlank(domainInfo.communityBaseURL)) {
             return [...originURLs, { value: domainInfo.communityBaseURL }];
         }
-        
+
         return originURLs;
     }
 
     /***
-    * @description Builds the Visualforce origin url that we need in order to
-    * make sure we're only listening for messages from the correct source.
-    */
+     * @description Builds the Visualforce origin url that we need in order to
+     * make sure we're only listening for messages from the correct source.
+     */
     setVisualforceOriginURLs(domainInfo) {
         if (isNull(domainInfo)) {
             return;
@@ -85,24 +91,24 @@ class psElevateTokenHandler {
     }
 
     /***
-    * @description Returns the NPSP namespace (if any)
-    */
+     * @description Returns the NPSP namespace (if any)
+     */
     get currentNamespace() {
         return getNamespace(PAYMENT_AUTHORIZATION_TOKEN_FIELD.fieldApiName);
     }
 
     /***
-    * @description Dispatches the application event when the Elevate credit card iframe
-    * is displayed or hidden
-    */
+     * @description Dispatches the application event when the Elevate credit card iframe
+     * is displayed or hidden
+     */
     dispatchApplicationEvent(eventName, payload) {
         fireEvent(null, eventName, payload);
     }
 
     /***
-    * @description Listens for a message from the Visualforce iframe.
-    * Rejects any messages from an unknown origin.
-    */
+     * @description Listens for a message from the Visualforce iframe.
+     * Rejects any messages from an unknown origin.
+     */
     registerPostMessageListener(component) {
         const self = this;
 
@@ -141,9 +147,9 @@ class psElevateTokenHandler {
     }
 
     /***
-    * @description Handles messages received from Visualforce page.
-    * @param message Message received from the iframe
-    */
+     * @description Handles messages received from Visualforce page.
+     * @param message Message received from the iframe
+     */
     handleMessage(message) {
         const isValidMessageType = message.type === 'post__npsp';
         if (isValidMessageType) {
@@ -160,12 +166,12 @@ class psElevateTokenHandler {
      * @return Promise A token promise
      */
     requestToken({
-        iframe,
-        handleError,
-        resolveToken,
-        eventAction,
-        tokenizeParameters,
-    } = {}) {
+                     iframe,
+                     handleError,
+                     resolveToken,
+                     eventAction,
+                     tokenizeParameters,
+                 } = {}) {
         if (isNull(iframe)) {
             return;
         }

--- a/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
@@ -53,17 +53,13 @@ class psElevateTokenHandler {
         const productionEnhancedUrl = `https://${domainInfo.orgDomain}--${namespace}.vf.force.com`;
         const productionEnhancedUrlLogin = `https://${domainInfo.orgDomain}--${namespace}.my.salesforce.com`;
         const sandboxEnhancedUrl =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.vf.force.com`;
-        const sandboxEnhancedUrlLogin =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.my.salesforce.com`;
-        const sandboxEnhancedUrlExperience =  `https://${domainInfo.orgDomain}--${namespace}.sandbox.my.site.com`;
-
+        
         const originURLs = [
             {value: url},
             {value: alternateUrl},
             {value: productionEnhancedUrl},
             {value: sandboxEnhancedUrl},
             {value: productionEnhancedUrlLogin},
-            {value: sandboxEnhancedUrlLogin},
-            {value: sandboxEnhancedUrlExperience},
         ];
         if (!isBlank(domainInfo.communityBaseURL)) {
             return [...originURLs, { value: domainInfo.communityBaseURL }];

--- a/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
@@ -7,8 +7,8 @@ import { isBlank } from 'c/util';
 
 
 /***
- * @description Visualforce page used to handle the payment services credit card tokenization request
- */
+* @description Visualforce page used to handle the payment services credit card tokenization request
+*/
 const TOKENIZE_CARD_PAGE_NAME = 'GE_TokenizeCard';
 
 const MOUNT_IFRAME_EVENT_ACTION = 'mount';
@@ -16,20 +16,20 @@ const MOUNT_IFRAME_EVENT_ACTION = 'mount';
 const SET_PAYMENT_METHOD_EVENT_ACTION = 'setPaymentMethod';
 
 /***
- * @description Max number of ms to wait for the response containing a token or an error
- */
+* @description Max number of ms to wait for the response containing a token or an error
+*/
 const TOKENIZE_TIMEOUT_MS = 10000;
 
 const NON_NAMESPACED_CHARACTER = 'c';
 
 
 /***
- * @description Payment services Elevate credit card tokenization service
- */
+* @description Payment services Elevate credit card tokenization service
+*/
 class psElevateTokenHandler {
     /***
-     * @description Custom labels
-     */
+    * @description Custom labels
+    */
     labels = Object.freeze({
         tokenRequestTimedOut
     });
@@ -39,8 +39,8 @@ class psElevateTokenHandler {
 
 
     /***
-     * @description Returns credit card tokenization Visualforce page URL
-     */
+    * @description Returns credit card tokenization Visualforce page URL
+    */
     getTokenizeCardPageURL() {
         return this.currentNamespace
             ? `/apex/${this.currentNamespace}__${TOKENIZE_CARD_PAGE_NAME}`
@@ -75,9 +75,9 @@ class psElevateTokenHandler {
     }
 
     /***
-     * @description Builds the Visualforce origin url that we need in order to
-     * make sure we're only listening for messages from the correct source.
-     */
+    * @description Builds the Visualforce origin url that we need in order to
+    * make sure we're only listening for messages from the correct source.
+    */
     setVisualforceOriginURLs(domainInfo) {
         if (isNull(domainInfo)) {
             return;
@@ -91,24 +91,24 @@ class psElevateTokenHandler {
     }
 
     /***
-     * @description Returns the NPSP namespace (if any)
-     */
+    * @description Returns the NPSP namespace (if any)
+    */
     get currentNamespace() {
         return getNamespace(PAYMENT_AUTHORIZATION_TOKEN_FIELD.fieldApiName);
     }
 
     /***
-     * @description Dispatches the application event when the Elevate credit card iframe
-     * is displayed or hidden
-     */
+    * @description Dispatches the application event when the Elevate credit card iframe
+    * is displayed or hidden
+    */
     dispatchApplicationEvent(eventName, payload) {
         fireEvent(null, eventName, payload);
     }
 
     /***
-     * @description Listens for a message from the Visualforce iframe.
-     * Rejects any messages from an unknown origin.
-     */
+    * @description Listens for a message from the Visualforce iframe.
+    * Rejects any messages from an unknown origin.
+    */
     registerPostMessageListener(component) {
         const self = this;
 
@@ -147,9 +147,9 @@ class psElevateTokenHandler {
     }
 
     /***
-     * @description Handles messages received from Visualforce page.
-     * @param message Message received from the iframe
-     */
+    * @description Handles messages received from Visualforce page.
+    * @param message Message received from the iframe
+    */
     handleMessage(message) {
         const isValidMessageType = message.type === 'post__npsp';
         if (isValidMessageType) {
@@ -166,12 +166,12 @@ class psElevateTokenHandler {
      * @return Promise A token promise
      */
     requestToken({
-                     iframe,
-                     handleError,
-                     resolveToken,
-                     eventAction,
-                     tokenizeParameters,
-                 } = {}) {
+        iframe,
+        handleError,
+        resolveToken,
+        eventAction,
+        tokenizeParameters,
+    } = {}) {
         if (isNull(iframe)) {
             return;
         }

--- a/force-app/main/default/pages/GE_TokenizeCard.page
+++ b/force-app/main/default/pages/GE_TokenizeCard.page
@@ -207,12 +207,14 @@
             return paymentMethod === CREDIT_CARD || paymentMethod === ACH;
         }
 
+        // This function is based on some limitations in extracting the actual window URL.
         function buildLightningOrigin() {
             const siteBaseURL = '{!$Site.BaseUrl}';
-            let orgUrl = '{!OrgUrl}';
-            const sforceBaseUrl = '{!SFBaseUrl}';
+            let orgUrl = '{!OrgUrl}'; // This value is returned in the canonical format "MyInstance.my.salesforce.com" even if it is a lightning.force.com based URL
+            const sforceBaseUrl = '{!SFBaseUrl}'; // This value is either my.salesforce.com or lightning.force.com or vf.force.com
 
-            if(sforceBaseUrl.includes("vf.force.com")){
+            //If the Salesforce Base URL is returned with the vf.force.com format, we assume the window URL is lightning.force.com
+            if(sforceBaseUrl.includes("vf.force.com")){ // This is not a guaranteed pattern but the best way we have now to tell if it's lightning.force.com form
                 orgUrl = orgUrl.replace(".my.", ".lightning.").replace(".salesforce.", ".force.");
             }
             if (siteBaseURL.length > 0) {

--- a/force-app/main/default/pages/GE_TokenizeCard.page
+++ b/force-app/main/default/pages/GE_TokenizeCard.page
@@ -211,14 +211,10 @@
             const siteBaseURL = '{!$Site.BaseUrl}';
             let orgUrl = '{!OrgUrl}';
             const sforceBaseUrl = '{!SFBaseUrl}';
-            console.log("orgURL", orgUrl);
-            console.log("sforceURL", sforceBaseUrl);
 
             if(sforceBaseUrl.includes("vf.force.com")){
-                orgUrl = orgUrl.replace(".my.", ".lightning.");
-                orgUrl = orgUrl.replace(".salesforce.", ".force.");
+                orgUrl = orgUrl.replace(".my.", ".lightning.").replace(".salesforce.", ".force.");
             }
-            console.log("post change", orgUrl)
             if (siteBaseURL.length > 0) {
                 return siteBaseURL;
             } else {

--- a/force-app/main/default/pages/GE_TokenizeCard.page
+++ b/force-app/main/default/pages/GE_TokenizeCard.page
@@ -13,7 +13,7 @@
     <script src="{!elevateSDKURL}"></script>
     <script>
         const sfdo = new sfdoPaymentsJsSdk();
-        let lightningOrigin = buildLightningOrigin();
+        const lightningOrigin = buildLightningOrigin();
         const DEFAULT_NAME_ON_CARD = '[Not Provided]';
         const postMessageType = 'post__npsp';
         const CREDIT_CARD = 'Credit Card';

--- a/force-app/main/default/pages/GE_TokenizeCard.page
+++ b/force-app/main/default/pages/GE_TokenizeCard.page
@@ -13,7 +13,7 @@
     <script src="{!elevateSDKURL}"></script>
     <script>
         const sfdo = new sfdoPaymentsJsSdk();
-        const lightningOrigin = buildLightningOrigin();
+        let lightningOrigin = buildLightningOrigin();
         const DEFAULT_NAME_ON_CARD = '[Not Provided]';
         const postMessageType = 'post__npsp';
         const CREDIT_CARD = 'Credit Card';
@@ -208,15 +208,18 @@
         }
 
         function buildLightningOrigin() {
-            const hostname = window.location.hostname;
-            const arr = hostname.split(".");
-            let domain = arr[0].replace('--npsp', '');
-            domain = domain.replace('--c', '');
             const siteBaseURL = '{!$Site.BaseUrl}';
+            let orgUrl = '{!OrgUrl}';
+            const sforceBaseUrl = '{!SFBaseUrl}';
+
+            if(sforceBaseUrl.includes("vf.force.com")){
+                orgUrl = orgUrl.replace(".my.", ".lightning.");
+                orgUrl = orgUrl.replace(".salesforce.", ".force.");
+            }
             if (siteBaseURL.length > 0) {
                 return siteBaseURL;
             } else {
-                return `https://${domain}.lightning.force.com`;
+                return orgUrl;
             }
         }
 

--- a/force-app/main/default/pages/GE_TokenizeCard.page
+++ b/force-app/main/default/pages/GE_TokenizeCard.page
@@ -211,11 +211,14 @@
             const siteBaseURL = '{!$Site.BaseUrl}';
             let orgUrl = '{!OrgUrl}';
             const sforceBaseUrl = '{!SFBaseUrl}';
+            console.log("orgURL", orgUrl);
+            console.log("sforceURL", sforceBaseUrl);
 
             if(sforceBaseUrl.includes("vf.force.com")){
                 orgUrl = orgUrl.replace(".my.", ".lightning.");
                 orgUrl = orgUrl.replace(".salesforce.", ".force.");
             }
+            console.log("post change", orgUrl)
             if (siteBaseURL.length > 0) {
                 return siteBaseURL;
             } else {


### PR DESCRIPTION
[W-11652305
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001515XIYAY/view)
Updated the lightning origin URL format to include sandbox/canonical URLs.
# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
