### PR TITLE
Pause API E2E fixes

### DIFF
--- a/force-app/main/default/classes/GE_PaymentServices.cls
+++ b/force-app/main/default/classes/GE_PaymentServices.cls
@@ -153,8 +153,21 @@ public with sharing class GE_PaymentServices {
      * @return String JSON of visualforce URL
      */
     @AuraEnabled(cacheable=true)
-    public static String getVfURL(String namespace) {
-        return DomainCreator.getVisualforceHostname(namespace);
+    public static OriginUrls getOriginUrls(String namespace) {
+        return new OriginUrls(
+            DomainCreator.getVisualforceHostname(namespace),
+                DomainCreator.getLightningHostname()
+        );
+    }
+
+    public class OriginUrls {
+        @AuraEnabled public String visualForceOriginUrl;
+        @AuraEnabled public String lightningOriginUrl;
+
+        public OriginUrls(String visualForceOriginUrl, String lightningOriginUrl) {
+            this.visualForceOriginUrl = 'https://'+visualForceOriginUrl;
+            this.lightningOriginUrl = 'https://'+lightningOriginUrl;
+        }
     }
 
     /**

--- a/force-app/main/default/classes/PS_CommitmentRequest.cls
+++ b/force-app/main/default/classes/PS_CommitmentRequest.cls
@@ -703,12 +703,12 @@ public inherited sharing class PS_CommitmentRequest {
         }
 
         public RequestBody withStartTimestamp(Date startTimestamp) {
-            this.startTimestamp = getISOFormatDateTimeFor(startTimestamp);
+            this.startTimestamp = getISOFormatDateTimeFor(startTimestamp, false);
             return this;
         }
 
         public RequestBody withEndTimestamp(Date endTimestamp) {
-            this.endTimestamp = getISOFormatDateTimeFor(endTimestamp);
+            this.endTimestamp = getISOFormatDateTimeFor(endTimestamp, true);
             return this;
         }
 
@@ -722,10 +722,12 @@ public inherited sharing class PS_CommitmentRequest {
             return this;
         }
 
-        private String getISOFormatDateTimeFor(Date specifiedDate) {
-            Datetime specifiedDateTime = Datetime.newInstance(
-                specifiedDate.year(), specifiedDate.month(), specifiedDate.day());
-            return JSON.serialize(specifiedDateTime);
+        public String getISOFormatDateTimeFor(Date specifiedDate, Boolean isPauseEndDate) {
+            Datetime donationDatetime = specifiedDate == Datetime.now().date()
+                    ? Datetime.now()
+                    : Datetime.newInstance(specifiedDate.year(), specifiedDate.month(), specifiedDate.day());
+            donationDatetime = isPauseEndDate ? donationDatetime.addHours(1): donationDatetime;
+            return donationDatetime.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
         }
     }
 
@@ -787,7 +789,7 @@ public inherited sharing class PS_CommitmentRequest {
             Datetime donationDatetime = donationDate == Datetime.now().date()
                 ? Datetime.now()
                 : Datetime.newInstance(donationDate.year(), donationDate.month(), donationDate.day());
-            
+
             return donationDatetime.formatGMT('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
         }
     }

--- a/force-app/main/default/classes/PS_CommitmentRequest.cls
+++ b/force-app/main/default/classes/PS_CommitmentRequest.cls
@@ -236,12 +236,14 @@ public inherited sharing class PS_CommitmentRequest {
             : getUpdateRequestBody(rd, oldRd, token);
     }
 
-    public PauseRequestBody getPauseRequestBody(RecurringDonationSchedule__c schedule) {
+    public PauseRequestBody getPauseRequestBody(RD2_ScheduleService.ElevatePauseSchedule schedule) {
+
+
        return new PauseRequestBody()
-           .withStartTimestamp(schedule.StartDate__c)
-           .withEndTimestamp(schedule.EndDate__c)
-           .withReasonComment(ELEVATE_PAUSE_REASONS.get(schedule.StatusReason__c))
-           .withReason(ELEVATE_PAUSE_REASONS.get(schedule.StatusReason__c));
+           .withStartTimestamp(schedule.startDate)
+           .withEndTimestamp(schedule.endDate)
+           .withReasonComment(ELEVATE_PAUSE_REASONS.get(schedule.statusReason))
+           .withReason(ELEVATE_PAUSE_REASONS.get(schedule.statusReason));
     }
 
     /***
@@ -494,13 +496,13 @@ public inherited sharing class PS_CommitmentRequest {
         public String reasonComment;
 
 
-        public PauseRequestBody withStartTimestamp(Date startTimestamp) {
-            this.startTimestamp = getISOFormatDateTimeFor(startTimestamp, false);
+        public PauseRequestBody withStartTimestamp(Datetime startTimestamp) {
+            this.startTimestamp = getISOFormatDateTimeFor(startTimestamp);
             return this;
         }
 
-        public PauseRequestBody withEndTimestamp(Date endTimestamp) {
-            this.endTimestamp = getISOFormatDateTimeFor(endTimestamp, true);
+        public PauseRequestBody withEndTimestamp(Datetime endTimestamp) {
+            this.endTimestamp = getISOFormatDateTimeFor(endTimestamp);
             return this;
         }
 
@@ -514,12 +516,8 @@ public inherited sharing class PS_CommitmentRequest {
             return this;
         }
 
-        public String getISOFormatDateTimeFor(Date specifiedDate, Boolean isPauseEndDate) {
-            Datetime donationDatetime = specifiedDate == Datetime.now().date()
-                    ? Datetime.now()
-                    : Datetime.newInstance(specifiedDate.year(), specifiedDate.month(), specifiedDate.day());
-            donationDatetime = isPauseEndDate ? donationDatetime.addHours(1): donationDatetime;
-            return donationDatetime.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
+        public String getISOFormatDateTimeFor(Datetime specifiedDate) {
+            return specifiedDate.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
         }
 
     }

--- a/force-app/main/default/classes/PS_CommitmentRequest.cls
+++ b/force-app/main/default/classes/PS_CommitmentRequest.cls
@@ -236,10 +236,11 @@ public inherited sharing class PS_CommitmentRequest {
             : getUpdateRequestBody(rd, oldRd, token);
     }
 
-    public RequestBody getPauseRequestBody(RecurringDonationSchedule__c schedule) {
-       return new RequestBody()
+    public PauseRequestBody getPauseRequestBody(RecurringDonationSchedule__c schedule) {
+       return new PauseRequestBody()
            .withStartTimestamp(schedule.StartDate__c)
            .withEndTimestamp(schedule.EndDate__c)
+           .withReasonComment(ELEVATE_PAUSE_REASONS.get(schedule.StatusReason__c))
            .withReason(ELEVATE_PAUSE_REASONS.get(schedule.StatusReason__c));
     }
 
@@ -484,6 +485,45 @@ public inherited sharing class PS_CommitmentRequest {
         public String consentType;
     }
 
+    public class PauseRequestBody {
+        public PauseRequestBody() {}
+
+        public String startTimestamp;
+        public String endTimestamp;
+        public String reason;
+        public String reasonComment;
+
+
+        public PauseRequestBody withStartTimestamp(Date startTimestamp) {
+            this.startTimestamp = getISOFormatDateTimeFor(startTimestamp, false);
+            return this;
+        }
+
+        public PauseRequestBody withEndTimestamp(Date endTimestamp) {
+            this.endTimestamp = getISOFormatDateTimeFor(endTimestamp, true);
+            return this;
+        }
+
+        public PauseRequestBody withReason(String reason) {
+            this.reason = reason;
+            return this;
+        }
+
+        public PauseRequestBody withReasonComment(String reasonComment) {
+            this.reasonComment = reasonComment;
+            return this;
+        }
+
+        public String getISOFormatDateTimeFor(Date specifiedDate, Boolean isPauseEndDate) {
+            Datetime donationDatetime = specifiedDate == Datetime.now().date()
+                    ? Datetime.now()
+                    : Datetime.newInstance(specifiedDate.year(), specifiedDate.month(), specifiedDate.day());
+            donationDatetime = isPauseEndDate ? donationDatetime.addHours(1): donationDatetime;
+            return donationDatetime.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
+        }
+
+    }
+
     /***
     * @description Assists in constructing the Commitment HttpRequest body.
     */
@@ -510,10 +550,7 @@ public inherited sharing class PS_CommitmentRequest {
          */
         public Map<String, Object> productMetadata;
 
-        public String startTimestamp;
-        public String endTimestamp;
-        public String reason;
-        public String reasonComment;
+
 
         /***
          * @description Constructor
@@ -700,34 +737,6 @@ public inherited sharing class PS_CommitmentRequest {
          */
         public Boolean isCommitmentUpdate() {
             return this.id != null;
-        }
-
-        public RequestBody withStartTimestamp(Date startTimestamp) {
-            this.startTimestamp = getISOFormatDateTimeFor(startTimestamp, false);
-            return this;
-        }
-
-        public RequestBody withEndTimestamp(Date endTimestamp) {
-            this.endTimestamp = getISOFormatDateTimeFor(endTimestamp, true);
-            return this;
-        }
-
-        public RequestBody withReason(String reason) {
-            this.reason = reason;
-            return this;
-        }
-
-        public RequestBody withReasonComment(String reasonComment) {
-            this.reasonComment = reasonComment;
-            return this;
-        }
-
-        public String getISOFormatDateTimeFor(Date specifiedDate, Boolean isPauseEndDate) {
-            Datetime donationDatetime = specifiedDate == Datetime.now().date()
-                    ? Datetime.now()
-                    : Datetime.newInstance(specifiedDate.year(), specifiedDate.month(), specifiedDate.day());
-            donationDatetime = isPauseEndDate ? donationDatetime.addHours(1): donationDatetime;
-            return donationDatetime.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
         }
     }
 

--- a/force-app/main/default/classes/PS_CommitmentRequest.cls
+++ b/force-app/main/default/classes/PS_CommitmentRequest.cls
@@ -194,6 +194,17 @@ public inherited sharing class PS_CommitmentRequest {
             .withBody(jsonRequestBody)
             .build();
     }
+    public static HttpRequest buildRequest(String commitmentId, String jsonRequestBody,
+            PS_Request.ElevateEndpoint endpoint, UTIL_Http.Method method) {
+
+        return new PS_Request.Builder()
+                .withMethod(method)
+                .withEndpoint(endpoint)
+                .withCommitmentId(commitmentId)
+                .withRecommendedTimeout()
+                .withBody(jsonRequestBody)
+                .build();
+    }
 
     /**
     * @description Builds a HTTP request for the provided commitment Id, Http method and endpoint
@@ -205,6 +216,7 @@ public inherited sharing class PS_CommitmentRequest {
         return new PS_Request.Builder()
                 .withCommitmentId(commitmentId)
                 .withEndpoint(endpoint)
+                .withRecommendedTimeout()
                 .withMethod(method)
                 .build();
     }

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -151,6 +151,8 @@ public without sharing class RD2_CommitmentService {
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId, jsonRequestBody,
                 endpoint, UTIL_Http.Method.POST);
 
+            System.debug('Request: '+JSON.serializePretty(request));
+
             response = requestService.sendRequest(request);
 
         } catch (Exception ex) {
@@ -166,6 +168,8 @@ public without sharing class RD2_CommitmentService {
         try {
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId,
                 UTIL_Http.Method.DEL, endpoint);
+
+            System.debug('Delete Request: '+JSON.serializePretty(request));
 
             response = requestService.sendRequest(request);
 

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -155,6 +155,8 @@ public without sharing class RD2_CommitmentService {
 
             response = requestService.sendRequest(request);
 
+            System.debug('Response: '+JSON.serializePretty(response));
+
         } catch (Exception ex) {
             response = requestService.buildErrorResponse(ex);
         }
@@ -172,6 +174,8 @@ public without sharing class RD2_CommitmentService {
             System.debug('Delete Request: '+JSON.serializePretty(request));
 
             response = requestService.sendRequest(request);
+
+            System.debug('Delete response: '+JSON.serializePretty(response));
 
         } catch (Exception ex) {
             response = requestService.buildErrorResponse(ex);

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -46,8 +46,12 @@ public without sharing class RD2_CommitmentService {
         if (shouldSendToElevate(rd, oldRd, paymentMethodToken)) {
             PS_CommitmentRequest.RequestBody requestBody = new PS_CommitmentRequest().getRequestBody(rd, oldRd, paymentMethodToken);
 
+            UTIL_Http.Method method = String.isBlank(rd.CommitmentId__c)
+                    ? UTIL_Http.Method.POST
+                    : UTIL_Http.Method.PATCH;
+
             response = sendRequest(rd.CommitmentId__c, JSON.serialize(requestBody),
-                PS_Request.ElevateEndpoint.COMMITMENT, UTIL_Http.Method.POST);
+                PS_Request.ElevateEndpoint.COMMITMENT, method);
 
             processResponse(rd, response);
         }

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -47,7 +47,7 @@ public without sharing class RD2_CommitmentService {
             PS_CommitmentRequest.RequestBody requestBody = new PS_CommitmentRequest().getRequestBody(rd, oldRd, paymentMethodToken);
 
             response = sendRequest(rd.CommitmentId__c, JSON.serialize(requestBody),
-                PS_Request.ElevateEndpoint.COMMITMENT);
+                PS_Request.ElevateEndpoint.COMMITMENT, UTIL_Http.Method.POST);
 
             processResponse(rd, response);
         }
@@ -60,8 +60,10 @@ public without sharing class RD2_CommitmentService {
 
         PS_CommitmentRequest.PauseRequestBody requestBody = new PS_CommitmentRequest().getPauseRequestBody(schedule);
 
+        UTIL_Http.Method method = schedule.shouldEditPause ? UTIL_Http.Method.PATCH : UTIL_Http.Method.POST;
+
         response = sendRequest(rd.getSObject()?.CommitmentId__c, JSON.serialize(requestBody),
-            PS_Request.ElevateEndpoint.COMMITMENT_PAUSE);
+            PS_Request.ElevateEndpoint.COMMITMENT_PAUSE, method);
 
         processResponse(rd, response);
 
@@ -144,21 +146,13 @@ public without sharing class RD2_CommitmentService {
     * @return response Payments API response
     */
     private UTIL_Http.Response sendRequest(String commitmentId, String jsonRequestBody,
-        PS_Request.ElevateEndpoint endpoint) {
+        PS_Request.ElevateEndpoint endpoint, UTIL_Http.Method method) {
         UTIL_Http.Response response;
 
         try {
-            System.debug('jsonRequestBody: '+jsonRequestBody);
-
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId, jsonRequestBody,
-                endpoint, UTIL_Http.Method.POST);
-
-            System.debug('Request: '+request.getBody());
-
-
+                endpoint, method);
             response = requestService.sendRequest(request);
-
-            System.debug('Response: '+response);
 
         } catch (Exception ex) {
             response = requestService.buildErrorResponse(ex);
@@ -173,13 +167,7 @@ public without sharing class RD2_CommitmentService {
         try {
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId,
                 UTIL_Http.Method.DEL, endpoint);
-
-            System.debug('Delete Request: '+request);
-
             response = requestService.sendRequest(request);
-
-            System.debug('Delete response: '+response);
-
         } catch (Exception ex) {
             response = requestService.buildErrorResponse(ex);
         }

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -55,7 +55,7 @@ public without sharing class RD2_CommitmentService {
         return response;
     }
 
-    public UTIL_Http.Response handleCommitmentPause(RecurringDonationSchedule__c schedule, RD2_RecurringDonation rd) {
+    public UTIL_Http.Response handleCommitmentPause(RD2_ScheduleService.ElevatePauseSchedule schedule, RD2_RecurringDonation rd) {
         UTIL_Http.Response response;
 
         PS_CommitmentRequest.PauseRequestBody requestBody = new PS_CommitmentRequest().getPauseRequestBody(schedule);

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -151,11 +151,11 @@ public without sharing class RD2_CommitmentService {
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId, jsonRequestBody,
                 endpoint, UTIL_Http.Method.POST);
 
-            System.debug('Request: '+JSON.serializePretty(request));
+            System.debug('Request: '+request);
 
             response = requestService.sendRequest(request);
 
-            System.debug('Response: '+JSON.serializePretty(response));
+            System.debug('Response: '+response);
 
         } catch (Exception ex) {
             response = requestService.buildErrorResponse(ex);
@@ -171,11 +171,11 @@ public without sharing class RD2_CommitmentService {
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId,
                 UTIL_Http.Method.DEL, endpoint);
 
-            System.debug('Delete Request: '+JSON.serializePretty(request));
+            System.debug('Delete Request: '+request);
 
             response = requestService.sendRequest(request);
 
-            System.debug('Delete response: '+JSON.serializePretty(response));
+            System.debug('Delete response: '+response);
 
         } catch (Exception ex) {
             response = requestService.buildErrorResponse(ex);

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -47,7 +47,7 @@ public without sharing class RD2_CommitmentService {
             PS_CommitmentRequest.RequestBody requestBody = new PS_CommitmentRequest().getRequestBody(rd, oldRd, paymentMethodToken);
 
             response = sendRequest(rd.CommitmentId__c, JSON.serialize(requestBody),
-                PS_Request.ElevateEndpoint.COMMITMENT);
+                PS_Request.ElevateEndpoint.COMMITMENT, UTIL_Http.Method.POST);
 
             processResponse(rd, response);
         }
@@ -60,8 +60,10 @@ public without sharing class RD2_CommitmentService {
 
         PS_CommitmentRequest.PauseRequestBody requestBody = new PS_CommitmentRequest().getPauseRequestBody(schedule);
 
+        UTIL_Http.Method method = schedule.scheduleId != null ? UTIL_Http.Method.PATCH : UTIL_Http.Method.POST;
+
         response = sendRequest(rd.getSObject()?.CommitmentId__c, JSON.serialize(requestBody),
-            PS_Request.ElevateEndpoint.COMMITMENT_PAUSE);
+            PS_Request.ElevateEndpoint.COMMITMENT_PAUSE, method);
 
         processResponse(rd, response);
 
@@ -144,14 +146,14 @@ public without sharing class RD2_CommitmentService {
     * @return response Payments API response
     */
     private UTIL_Http.Response sendRequest(String commitmentId, String jsonRequestBody,
-        PS_Request.ElevateEndpoint endpoint) {
+        PS_Request.ElevateEndpoint endpoint, UTIL_Http.Method method) {
         UTIL_Http.Response response;
 
         try {
             System.debug('jsonRequestBody: '+jsonRequestBody);
 
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId, jsonRequestBody,
-                endpoint, UTIL_Http.Method.POST);
+                endpoint, method);
 
             System.debug('Request: '+request.getBody());
 

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -58,7 +58,7 @@ public without sharing class RD2_CommitmentService {
     public UTIL_Http.Response handleCommitmentPause(RecurringDonationSchedule__c schedule, RD2_RecurringDonation rd) {
         UTIL_Http.Response response;
 
-        PS_CommitmentRequest.RequestBody requestBody = new PS_CommitmentRequest().getPauseRequestBody(schedule);
+        PS_CommitmentRequest.PauseRequestBody requestBody = new PS_CommitmentRequest().getPauseRequestBody(schedule);
 
         response = sendRequest(rd.getSObject()?.CommitmentId__c, JSON.serialize(requestBody),
             PS_Request.ElevateEndpoint.COMMITMENT_PAUSE);
@@ -148,10 +148,13 @@ public without sharing class RD2_CommitmentService {
         UTIL_Http.Response response;
 
         try {
+            System.debug('jsonRequestBody: '+jsonRequestBody);
+
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId, jsonRequestBody,
                 endpoint, UTIL_Http.Method.POST);
 
-            System.debug('Request: '+request);
+            System.debug('Request: '+request.getBody());
+
 
             response = requestService.sendRequest(request);
 

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -47,7 +47,7 @@ public without sharing class RD2_CommitmentService {
             PS_CommitmentRequest.RequestBody requestBody = new PS_CommitmentRequest().getRequestBody(rd, oldRd, paymentMethodToken);
 
             response = sendRequest(rd.CommitmentId__c, JSON.serialize(requestBody),
-                PS_Request.ElevateEndpoint.COMMITMENT, UTIL_Http.Method.POST);
+                PS_Request.ElevateEndpoint.COMMITMENT);
 
             processResponse(rd, response);
         }
@@ -60,10 +60,8 @@ public without sharing class RD2_CommitmentService {
 
         PS_CommitmentRequest.PauseRequestBody requestBody = new PS_CommitmentRequest().getPauseRequestBody(schedule);
 
-        UTIL_Http.Method method = schedule.scheduleId != null ? UTIL_Http.Method.PATCH : UTIL_Http.Method.POST;
-
         response = sendRequest(rd.getSObject()?.CommitmentId__c, JSON.serialize(requestBody),
-            PS_Request.ElevateEndpoint.COMMITMENT_PAUSE, method);
+            PS_Request.ElevateEndpoint.COMMITMENT_PAUSE);
 
         processResponse(rd, response);
 
@@ -146,14 +144,14 @@ public without sharing class RD2_CommitmentService {
     * @return response Payments API response
     */
     private UTIL_Http.Response sendRequest(String commitmentId, String jsonRequestBody,
-        PS_Request.ElevateEndpoint endpoint, UTIL_Http.Method method) {
+        PS_Request.ElevateEndpoint endpoint) {
         UTIL_Http.Response response;
 
         try {
             System.debug('jsonRequestBody: '+jsonRequestBody);
 
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId, jsonRequestBody,
-                endpoint, method);
+                endpoint, UTIL_Http.Method.POST);
 
             System.debug('Request: '+request.getBody());
 

--- a/force-app/main/default/classes/RD2_CommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CommitmentService.cls
@@ -149,7 +149,7 @@ public without sharing class RD2_CommitmentService {
 
         try {
             HttpRequest request = PS_CommitmentRequest.buildRequest(commitmentId, jsonRequestBody,
-                endpoint);
+                endpoint, UTIL_Http.Method.POST);
 
             response = requestService.sendRequest(request);
 

--- a/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
+++ b/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
@@ -259,6 +259,8 @@ public with sharing class RD2_PauseForm_CTRL {
             PauseData pause = (PauseData) JSON.deserialize(jsonPauseData, PauseData.class);
             RD2_RecurringDonation rd = getRecurringDonation(pause.rdId);
 
+            System.debug('Pause '+ pause);
+
             if (isOnlineRecurringDonationRecord(rd)) {
                 validatePause(pause);
                 UTIL_Http.Response response = pauseElevateRDsFor(pause);

--- a/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
+++ b/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
@@ -304,7 +304,8 @@ public with sharing class RD2_PauseForm_CTRL {
             if (isPauseRemoved(pause)) {
                 response = commitmentService.handleRemoveCommitmentPause(rd);
             } else {
-                response = commitmentService.handleCommitmentPause(buildPauseSchedule(pause, rd), rd);
+                response = commitmentService.handleCommitmentPause(
+                        pauseHandler.createElevatePauseSchedule(pause, rd), rd);
             }
 
             return response;
@@ -334,14 +335,6 @@ public with sharing class RD2_PauseForm_CTRL {
             pause.startDate,
             pause.resumeAfterDate,
             pause.rdId
-        );
-    }
-    private static RD2_ScheduleService.ElevatePauseSchedule buildPauseSchedule (PauseData pause, RD2_RecurringDonation rd) {
-        return pauseHandler.createElevatePauseSchedule(
-                pause.pausedReason?.value,
-                pause.startDate,
-                pause.resumeAfterDate,
-                rd
         );
     }
 

--- a/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
+++ b/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
@@ -257,10 +257,8 @@ public with sharing class RD2_PauseForm_CTRL {
         Boolean hasScheduleChanged = false;
         try {
             PauseData pause = (PauseData) JSON.deserialize(jsonPauseData, PauseData.class);
-            System.debug('Pause '+ pause);
-            RD2_RecurringDonation rd = getRecurringDonation(pause.rdId);
 
-            System.debug('Pause '+ pause);
+            RD2_RecurringDonation rd = getRecurringDonation(pause.rdId);
 
             if (isOnlineRecurringDonationRecord(rd)) {
                 validatePause(pause);
@@ -302,8 +300,9 @@ public with sharing class RD2_PauseForm_CTRL {
 
         try {
             UTIL_Http.Response response;
-            response = commitmentService.handleRemoveCommitmentPause(rd);
-            if (commitmentService.isCommitmentSuccess(response) && !isPauseRemoved(pause)) {
+            if (isPauseRemoved(pause)) {
+                response = commitmentService.handleRemoveCommitmentPause(rd);
+            } else {
                 response = commitmentService.handleCommitmentPause(
                         pauseHandler.createElevatePauseSchedule(pause, rd), rd);
             }

--- a/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
+++ b/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
@@ -257,6 +257,7 @@ public with sharing class RD2_PauseForm_CTRL {
         Boolean hasScheduleChanged = false;
         try {
             PauseData pause = (PauseData) JSON.deserialize(jsonPauseData, PauseData.class);
+            System.debug('Pause '+ pause);
             RD2_RecurringDonation rd = getRecurringDonation(pause.rdId);
 
             System.debug('Pause '+ pause);
@@ -301,9 +302,8 @@ public with sharing class RD2_PauseForm_CTRL {
 
         try {
             UTIL_Http.Response response;
-            if (isPauseRemoved(pause)) {
-                response = commitmentService.handleRemoveCommitmentPause(rd);
-            } else {
+            response = commitmentService.handleRemoveCommitmentPause(rd);
+            if (commitmentService.isCommitmentSuccess(response) && !isPauseRemoved(pause)) {
                 response = commitmentService.handleCommitmentPause(
                         pauseHandler.createElevatePauseSchedule(pause, rd), rd);
             }

--- a/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
+++ b/force-app/main/default/classes/RD2_PauseForm_CTRL.cls
@@ -304,7 +304,7 @@ public with sharing class RD2_PauseForm_CTRL {
             if (isPauseRemoved(pause)) {
                 response = commitmentService.handleRemoveCommitmentPause(rd);
             } else {
-                response = commitmentService.handleCommitmentPause(buildPauseSchedule(pause), rd);
+                response = commitmentService.handleCommitmentPause(buildPauseSchedule(pause, rd), rd);
             }
 
             return response;
@@ -334,6 +334,14 @@ public with sharing class RD2_PauseForm_CTRL {
             pause.startDate,
             pause.resumeAfterDate,
             pause.rdId
+        );
+    }
+    private static RD2_ScheduleService.ElevatePauseSchedule buildPauseSchedule (PauseData pause, RD2_RecurringDonation rd) {
+        return pauseHandler.createElevatePauseSchedule(
+                pause.pausedReason?.value,
+                pause.startDate,
+                pause.resumeAfterDate,
+                rd
         );
     }
 

--- a/force-app/main/default/classes/RD2_ScheduleService.cls
+++ b/force-app/main/default/classes/RD2_ScheduleService.cls
@@ -1027,6 +1027,23 @@ public without sharing class RD2_ScheduleService {
         }
     }
 
+    public class ElevatePauseSchedule {
+        public RD2_RecurringDonation donation;
+        public Datetime startDate;
+        public Datetime endDate;
+        public String statusReason;
+
+        public ElevatePauseSchedule(RD2_RecurringDonation donation,
+                Datetime startDate, Datetime endDate, String statusReason) {
+            this.donation = donation;
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.statusReason = statusReason;
+        }
+    }
+
+
+
     /***
     * @description Handles Pause Recurring Donation functionality
     */
@@ -1040,8 +1057,30 @@ public without sharing class RD2_ScheduleService {
                 StartDate__c = startDate,
                 EndDate__c = endDate
             );
-    
         }
+
+        public ElevatePauseSchedule createElevatePauseSchedule (String statusReason,
+                Date startDate, Date endDate, RD2_RecurringDonation rd) {
+            return new ElevatePauseSchedule(
+                    rd,
+                    Datetime.newInstance(startDate.year(), startDate.month(), startDate.day()),
+                    calculatePauseEndDate(endDate, rd),
+                    statusReason);
+        }
+
+
+        private Datetime calculatePauseEndDate (Date endDate, RD2_RecurringDonation rd) {
+            RD2_ScheduleService rd2ScheduleService = new RD2_ScheduleService();
+            List<Installment> installments = rd2ScheduleService.getAllVisualizedInstallments(endDate,
+                    1, rd.getSObject().RecurringDonationSchedules__r);
+            Date nextDonationDate =  installments[0].nextDonationDate;
+
+            return Datetime.newInstance(
+                    nextDonationDate.year(), nextDonationDate.month(), nextDonationDate.day()).addSeconds(-1);
+
+        }
+
+
         /***
         * @description Indicates if the Recurring Donation has an active pause schedule
         * at some point in the future (not necessarily in a current pause state).

--- a/force-app/main/default/classes/RD2_ScheduleService.cls
+++ b/force-app/main/default/classes/RD2_ScheduleService.cls
@@ -1035,20 +1035,31 @@ public without sharing class RD2_ScheduleService {
         public Datetime startDate;
         public Datetime endDate;
         public String statusReason;
-        public ElevatePauseSchedule(RD2_RecurringDonation rd, RD2_PauseForm_CTRL.PauseData pause) {
+        public Boolean shouldEditPause;
+        public ElevatePauseSchedule(List<RecurringDonationSchedule__c> donationSchedules,
+                RD2_PauseForm_CTRL.PauseData pause) {
             this.startDate = pause.startDate;
-            this.endDate = calculateElevatePauseEndDate(pause.resumeAfterDate, rd);
+            this.endDate = calculateElevatePauseEndDate(pause.resumeAfterDate, donationSchedules);
             this.statusReason = pause.pausedReason?.value;
+            this.shouldEditPause = shouldEditPause(donationSchedules);
         }
-        private Datetime calculateElevatePauseEndDate (Date endDate, RD2_RecurringDonation rd) {
+        private Datetime calculateElevatePauseEndDate (Date endDate,
+                List<RecurringDonationSchedule__c> donationSchedules) {
             RD2_ScheduleService rd2ScheduleService = new RD2_ScheduleService();
             Date nextDonationDate = rd2ScheduleService.getNextInstallment(
-                    endDate, rd.getSObject().RecurringDonationSchedules__r
+                    endDate, donationSchedules
             ).nextDonationDate;
 
             return Datetime.newInstance(
                     nextDonationDate.year(), nextDonationDate.month(), nextDonationDate.day()).addSeconds(-1);
 
+        }
+
+        private Boolean shouldEditPause (List<RecurringDonationSchedule__c> donationSchedules) {
+            for (RecurringDonationSchedule__c schedule : donationSchedules) {
+                return schedule.IsPause__c;
+            }
+            return false;
         }
     }
 
@@ -1068,7 +1079,7 @@ public without sharing class RD2_ScheduleService {
         }
 
         public ElevatePauseSchedule createElevatePauseSchedule (RD2_PauseForm_CTRL.PauseData pause, RD2_RecurringDonation rd) {
-            return new ElevatePauseSchedule(rd, pause);
+            return new ElevatePauseSchedule(rd.getSObject().RecurringDonationSchedules__r, pause);
         }
 
 

--- a/force-app/main/default/classes/RD2_ScheduleService.cls
+++ b/force-app/main/default/classes/RD2_ScheduleService.cls
@@ -1027,22 +1027,32 @@ public without sharing class RD2_ScheduleService {
         }
     }
 
+    /**
+     * Inner class to build Elevate specific pause schedules
+     *
+     */
     public class ElevatePauseSchedule {
-        public RD2_RecurringDonation donation;
         public Datetime startDate;
         public Datetime endDate;
         public String statusReason;
+        public Id scheduleId;
+        public ElevatePauseSchedule(RD2_RecurringDonation rd, RD2_PauseForm_CTRL.PauseData pause) {
+            this.startDate = pause.startDate;
+            this.endDate = calculateElevatePauseEndDate(pause.resumeAfterDate, rd);
+            this.statusReason = pause.pausedReason?.value;
+            this.scheduleId = pause.scheduleId;
+        }
+        private Datetime calculateElevatePauseEndDate (Date endDate, RD2_RecurringDonation rd) {
+            RD2_ScheduleService rd2ScheduleService = new RD2_ScheduleService();
+            Date nextDonationDate = rd2ScheduleService.getNextInstallment(
+                    endDate, rd.getSObject().RecurringDonationSchedules__r
+            ).nextDonationDate;
 
-        public ElevatePauseSchedule(RD2_RecurringDonation donation,
-                Datetime startDate, Datetime endDate, String statusReason) {
-            this.donation = donation;
-            this.startDate = startDate;
-            this.endDate = endDate;
-            this.statusReason = statusReason;
+            return Datetime.newInstance(
+                    nextDonationDate.year(), nextDonationDate.month(), nextDonationDate.day()).addSeconds(-1);
+
         }
     }
-
-
 
     /***
     * @description Handles Pause Recurring Donation functionality
@@ -1059,25 +1069,8 @@ public without sharing class RD2_ScheduleService {
             );
         }
 
-        public ElevatePauseSchedule createElevatePauseSchedule (String statusReason,
-                Date startDate, Date endDate, RD2_RecurringDonation rd) {
-            return new ElevatePauseSchedule(
-                    rd,
-                    Datetime.newInstance(startDate.year(), startDate.month(), startDate.day()),
-                    calculatePauseEndDate(endDate, rd),
-                    statusReason);
-        }
-
-
-        private Datetime calculatePauseEndDate (Date endDate, RD2_RecurringDonation rd) {
-            RD2_ScheduleService rd2ScheduleService = new RD2_ScheduleService();
-            List<Installment> installments = rd2ScheduleService.getAllVisualizedInstallments(endDate,
-                    1, rd.getSObject().RecurringDonationSchedules__r);
-            Date nextDonationDate =  installments[0].nextDonationDate;
-
-            return Datetime.newInstance(
-                    nextDonationDate.year(), nextDonationDate.month(), nextDonationDate.day()).addSeconds(-1);
-
+        public ElevatePauseSchedule createElevatePauseSchedule (RD2_PauseForm_CTRL.PauseData pause, RD2_RecurringDonation rd) {
+            return new ElevatePauseSchedule(rd, pause);
         }
 
 

--- a/force-app/main/default/classes/RD2_ScheduleService.cls
+++ b/force-app/main/default/classes/RD2_ScheduleService.cls
@@ -1035,12 +1035,10 @@ public without sharing class RD2_ScheduleService {
         public Datetime startDate;
         public Datetime endDate;
         public String statusReason;
-        public Id scheduleId;
         public ElevatePauseSchedule(RD2_RecurringDonation rd, RD2_PauseForm_CTRL.PauseData pause) {
             this.startDate = pause.startDate;
             this.endDate = calculateElevatePauseEndDate(pause.resumeAfterDate, rd);
             this.statusReason = pause.pausedReason?.value;
-            this.scheduleId = pause.scheduleId;
         }
         private Datetime calculateElevatePauseEndDate (Date endDate, RD2_RecurringDonation rd) {
             RD2_ScheduleService rd2ScheduleService = new RD2_ScheduleService();

--- a/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
@@ -100,14 +100,14 @@ describe('c-ps-Elevate-Token-Handler', () => {
    it('should create one non-namespaced visualforce origin urls', async () => {
       const vfURLS = buildVFUrls(mockDomainInfo(), 'c');
       return vfURLS.then(data => {
-         expect(data.length).toEqual(1);
+         expect(data.length).toEqual(2);
       });
    });
 
    it('should create one namespaced visualforce origin urls', () => {
       const vfURLS = buildVFUrls(mockDomainInfo(), 'npsp');
       return vfURLS.then(data => {
-         expect(data.length).toEqual(1);
+         expect(data.length).toEqual(2);
       });
    });
 

--- a/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/__tests__/psElevateTokenHandler.test.js
@@ -1,4 +1,5 @@
 import psElevateTokenHandler from '../psElevateTokenHandler';
+import getOriginUrls from '@salesforce/apex/GE_PaymentServices.getOriginUrls';
 
 const createPostMessageEvent = (type) => {
    switch (type) {
@@ -43,6 +44,16 @@ const createPostMessageEvent = (type) => {
       default:
    }
 }
+jest.mock(
+    '@salesforce/apex/GE_PaymentServices.getOriginUrls',
+    () => {
+       return {
+          default: jest.fn()
+       };
+    },
+    { virtual: true }
+);
+
 
 const buildVFUrls = async(domainInfo, namespace) => {
    return await psElevateTokenHandler.getVisualForceOriginURLs(domainInfo, namespace);
@@ -71,6 +82,10 @@ describe('c-ps-Elevate-Token-Handler', () => {
    });
 
    it('should discard an invalid message', async() => {
+      getOriginUrls.mockResolvedValue({
+         visualForceOriginUrl: 'https://flow-connect-2738-dev-ed--c.vf.force.com',
+         lightningOriginUrl: 'https://flow-connect-2738-dev-ed--c.lightning.force.com'
+      });
       psElevateTokenHandler.setVisualforceOriginURLs(mockDomainInfo());
       await flushPromises();
       const isMessageHandled =
@@ -132,7 +147,7 @@ describe('c-ps-Elevate-Token-Handler', () => {
    it('should create two non-namespaced visualforce origin urls on Experience Sites', () => {
       const vfURLS = buildVFUrls(mockDomainInfoExperienceSite(), 'c');
       return vfURLS.then(data => {
-         expect(data.length).toEqual(2);
+         expect(data.length).toEqual(3);
          expect(data[1].value.includes('c')).toBe(true);
       });
    });

--- a/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
@@ -8,8 +8,8 @@ import { isBlank } from 'c/util';
 
 
 /***
-* @description Visualforce page used to handle the payment services credit card tokenization request
-*/
+ * @description Visualforce page used to handle the payment services credit card tokenization request
+ */
 const TOKENIZE_CARD_PAGE_NAME = 'GE_TokenizeCard';
 
 const MOUNT_IFRAME_EVENT_ACTION = 'mount';
@@ -17,20 +17,20 @@ const MOUNT_IFRAME_EVENT_ACTION = 'mount';
 const SET_PAYMENT_METHOD_EVENT_ACTION = 'setPaymentMethod';
 
 /***
-* @description Max number of ms to wait for the response containing a token or an error
-*/
+ * @description Max number of ms to wait for the response containing a token or an error
+ */
 const TOKENIZE_TIMEOUT_MS = 10000;
 
 const NON_NAMESPACED_CHARACTER = 'c';
 
 
 /***
-* @description Payment services Elevate credit card tokenization service
-*/
+ * @description Payment services Elevate credit card tokenization service
+ */
 class psElevateTokenHandler {
     /***
-    * @description Custom labels
-    */
+     * @description Custom labels
+     */
     labels = Object.freeze({
         tokenRequestTimedOut
     });
@@ -40,8 +40,8 @@ class psElevateTokenHandler {
 
 
     /***
-    * @description Returns credit card tokenization Visualforce page URL
-    */
+     * @description Returns credit card tokenization Visualforce page URL
+     */
     getTokenizeCardPageURL() {
         return this.currentNamespace
             ? `/apex/${this.currentNamespace}__${TOKENIZE_CARD_PAGE_NAME}`
@@ -63,9 +63,9 @@ class psElevateTokenHandler {
     }
 
     /***
-    * @description Builds the Visualforce origin url that we need in order to
-    * make sure we're only listening for messages from the correct source.
-    */
+     * @description Builds the Visualforce origin url that we need in order to
+     * make sure we're only listening for messages from the correct source.
+     */
     async setVisualforceOriginURLs(domainInfo) {
         if (isNull(domainInfo)) {
             return;
@@ -79,24 +79,24 @@ class psElevateTokenHandler {
     }
 
     /***
-    * @description Returns the NPSP namespace (if any)
-    */
+     * @description Returns the NPSP namespace (if any)
+     */
     get currentNamespace() {
         return getNamespace(PAYMENT_AUTHORIZATION_TOKEN_FIELD.fieldApiName);
     }
 
     /***
-    * @description Dispatches the application event when the Elevate credit card iframe
-    * is displayed or hidden
-    */
+     * @description Dispatches the application event when the Elevate credit card iframe
+     * is displayed or hidden
+     */
     dispatchApplicationEvent(eventName, payload) {
         fireEvent(null, eventName, payload);
     }
 
     /***
-    * @description Listens for a message from the Visualforce iframe.
-    * Rejects any messages from an unknown origin.
-    */
+     * @description Listens for a message from the Visualforce iframe.
+     * Rejects any messages from an unknown origin.
+     */
     registerPostMessageListener(component) {
         const self = this;
 
@@ -135,9 +135,9 @@ class psElevateTokenHandler {
     }
 
     /***
-    * @description Handles messages received from Visualforce page.
-    * @param message Message received from the iframe
-    */
+     * @description Handles messages received from Visualforce page.
+     * @param message Message received from the iframe
+     */
     handleMessage(message) {
         const isValidMessageType = message.type === 'post__npsp';
         if (isValidMessageType) {
@@ -154,12 +154,12 @@ class psElevateTokenHandler {
      * @return Promise A token promise
      */
     requestToken({
-        iframe,
-        handleError,
-        resolveToken,
-        eventAction,
-        tokenizeParameters,
-    } = {}) {
+                     iframe,
+                     handleError,
+                     resolveToken,
+                     eventAction,
+                     tokenizeParameters,
+                 } = {}) {
         if (isNull(iframe)) {
             return;
         }

--- a/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
+++ b/force-app/main/default/lwc/psElevateTokenHandler/psElevateTokenHandler.js
@@ -3,7 +3,7 @@ import { getNamespace, isFunction, isNull, validateJSONString } from 'c/utilComm
 import PAYMENT_AUTHORIZATION_TOKEN_FIELD from
         '@salesforce/schema/DataImport__c.Payment_Authorization_Token__c';
 import tokenRequestTimedOut from '@salesforce/label/c.gePaymentRequestTimedOut';
-import getVfURL from '@salesforce/apex/GE_PaymentServices.getVfURL';
+import getOriginUrls from '@salesforce/apex/GE_PaymentServices.getOriginUrls';
 import { isBlank } from 'c/util';
 
 
@@ -49,11 +49,11 @@ class psElevateTokenHandler {
     }
 
     async getVisualForceOriginURLs(domainInfo, namespace) {
-        const vfHostName = await getVfURL({namespace});
-        const vfURL = `https://${vfHostName}`;
+        const originUrls = await getOriginUrls({namespace});
 
         const originURLs = [
-            {value: vfURL},
+            {value: originUrls.visualForceOriginUrl},
+            {value: originUrls.lightningOriginUrl}
         ];
         if (!isBlank(domainInfo.communityBaseURL)) {
             return [...originURLs, { value: domainInfo.communityBaseURL }];

--- a/force-app/main/default/lwc/rd2ElevateCreditCardForm/rd2ElevateCreditCardForm.js
+++ b/force-app/main/default/lwc/rd2ElevateCreditCardForm/rd2ElevateCreditCardForm.js
@@ -196,7 +196,7 @@ export default class rd2ElevateCreditCardForm extends LightningElement {
             this.handleError(error);
         });
 
-        tokenHandler.setVisualforceOriginURLs(domainInfo);
+        await tokenHandler.setVisualforceOriginURLs(domainInfo);
         
         if(this.isDigitalExperience) {
             this.handleUserEnabledWidget();


### PR DESCRIPTION
WI: [W-11575839](https://gus.lightning.force.com/a07EE000013lI2fYAE)
# Critical Changes

# Changes

- To pause elevate connected installments, we now have to supply intervals instead of installment start and end dates regardless of the number of selected installments
- The PATCH HTTP verb is now used for updating existing pauses
- Origin URLs fix for the elevate widget
# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
