### PR TITLE
Fix for colliding queueables in Gift Entry

### DIFF
--- a/force-app/main/default/classes/GiftBatchForQueueable.cls
+++ b/force-app/main/default/classes/GiftBatchForQueueable.cls
@@ -99,9 +99,16 @@ public inherited sharing class GiftBatchForQueueable {
         set;
     }
 
-    private void disableRD2AsynchronousProcesses() {
-        RD2_Settings rd2Settings = RD2_Settings.getInstance();
-        rd2Settings.isGiftEntryMode = true;
+
+    @TestVisible
+    private GiftBatchService giftBatchService {
+        get {
+            if (giftBatchService == null) {
+                return new GiftBatchService();
+            }
+            return giftBatchService;
+        }
+        set;
     }
 
     public GiftBatchForQueueable(GiftBatchId giftBatchId, GiftBatchSelector giftBatchSelector) {
@@ -122,9 +129,7 @@ public inherited sharing class GiftBatchForQueueable {
         List<Id> giftIdsToSelect = chunkedIds.get(0);
         gifts = new Gifts(giftsSelector.getGiftsReadyToMoveToProcessing(giftIdsToSelect, CHUNK_LIMIT));
         gifts.moveProcessableToProcessingStatus();
-        if (gifts.hasRecurringGifts()) {
-            disableRD2AsynchronousProcesses();
-        }
+        giftBatchService.disableRD2AsynchronousProcesses();
     }
 
     public void preprocessRecurringGifts() {

--- a/force-app/main/default/classes/GiftBatchService.cls
+++ b/force-app/main/default/classes/GiftBatchService.cls
@@ -83,6 +83,18 @@ public with sharing class GiftBatchService {
         updateGiftBatchWith(giftBatchId, asyncApexJobId);
     }
 
+    public void disableRD2AsynchronousProcesses() {
+        RD2_Settings rd2Settings = RD2_Settings.getInstance();
+        rd2Settings.isGiftEntryMode = true;
+    }
+
+
+    public void enableRD2AsynchronousProcesses() {
+        RD2_Settings rd2Settings = RD2_Settings.getInstance();
+        rd2Settings.isGiftEntryMode = false;
+    }
+
+
     public void chainNextQueueable(GiftBatchForQueueable queueableGiftBatch) {
         if (Test.isRunningTest()) {
             AsyncApexJobId queueableId = new AsyncApexJobId(UTIL_UnitTestData_TEST.mockId(AsyncApexJob.SObjectType));

--- a/force-app/main/default/classes/GiftEntryProcessorQueueFinalizer.cls
+++ b/force-app/main/default/classes/GiftEntryProcessorQueueFinalizer.cls
@@ -55,6 +55,9 @@ public inherited sharing class GiftEntryProcessorQueueFinalizer implements Final
             when UNHANDLED_EXCEPTION {
                 unhandledException(context);
             }
+            when SUCCESS {
+                giftBatchService.enableRD2AsynchronousProcesses();
+            }
         }
     }
 

--- a/force-app/main/default/classes/RD2_QueueableService.cls
+++ b/force-app/main/default/classes/RD2_QueueableService.cls
@@ -95,7 +95,7 @@ public class RD2_QueueableService {
 
         EvaluateInstallmentOpportunities service = new EvaluateInstallmentOpportunities(toProcess, rdIdsWhereScheduleChanged, oldRds);
 
-        if (Limits.getQueueableJobs() < Limits.getLimitQueueableJobs()) {
+        if (Limits.getQueueableJobs() < Limits.getLimitQueueableJobs() && canQueueNamingService()) {
             System.enqueueJob(service);
 
         } else {

--- a/force-app/main/default/classes/RD2_QueueableService.cls
+++ b/force-app/main/default/classes/RD2_QueueableService.cls
@@ -94,8 +94,9 @@ public class RD2_QueueableService {
         }
 
         EvaluateInstallmentOpportunities service = new EvaluateInstallmentOpportunities(toProcess, rdIdsWhereScheduleChanged, oldRds);
+        RD2_Settings settings = RD2_Settings.getInstance();
 
-        if (Limits.getQueueableJobs() < Limits.getLimitQueueableJobs() && canQueueNamingService()) {
+        if (Limits.getQueueableJobs() < Limits.getLimitQueueableJobs() && !settings.isGiftEntryMode) {
             System.enqueueJob(service);
 
         } else {


### PR DESCRIPTION
WI: [W-12013424](https://gus.lightning.force.com/a07EE00001BaWizYAF)
# Critical Changes

# Changes
This PR addresses the issue of the RD2OpportunityEval Queueable breaking the chaining mechanism of the GiftEntryProcessorQueue when recurring gifts are being processed via Gift Entry.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
