### PR TITLE
Add a Validation to Prevent a Gift Entry User from Choosing the "Fixed" schedule recurring type for Elevate Recurring Gifts in Batch Gift Entry

### DIFF
--- a/force-app/main/default/classes/ElevateBatchItem.cls
+++ b/force-app/main/default/classes/ElevateBatchItem.cls
@@ -37,6 +37,7 @@ public with sharing class ElevateBatchItem {
     @AuraEnabled public String elevateBatchId {get; set;}
     @AuraEnabled public String declineReason {get; set;}
     @AuraEnabled public String cardLast4 {get; set;}
+    @AuraEnabled public String achLast4 {get; set;}
     @AuraEnabled public String cardNetwork {get; set;}
     @AuraEnabled public String cardExpirationMonth {get; set;}
     @AuraEnabled public String cardExpirationYear {get; set;}
@@ -59,7 +60,8 @@ public with sharing class ElevateBatchItem {
         this.elevateBatchId  = createBatchItemResponse.elevateBatchId();
         this.originalTransactionId = createBatchItemResponse.originalTransactionId();
         this.declineReason = createBatchItemResponse.declineReason();
-        this.cardLast4 = createBatchItemResponse.last4();
+        this.cardLast4 = createBatchItemResponse.cardLast4();
+        this.achLast4 = createBatchItemResponse.achLast4();
         this.status = createBatchItemResponse.status();
         this.statusReason = createBatchItemResponse.statusReason();
         this.cardNetwork = createBatchItemResponse.brand();

--- a/force-app/main/default/classes/ElevateBatchItemCreateResponse.cls
+++ b/force-app/main/default/classes/ElevateBatchItemCreateResponse.cls
@@ -215,8 +215,12 @@ public class ElevateBatchItemCreateResponse {
         return purchaseResponse?.authExpiresAt;
     }
 
-    public String last4() {
+    public String cardLast4() {
         return commitmentResponse != null ? commitmentResponse.cardData?.last4 : purchaseResponse.cardData?.last4;
+    }
+
+    public String achLast4() {
+        return commitmentResponse != null ? commitmentResponse.achData?.last4 : purchaseResponse.achData?.last4;
     }
 
     public String brand() {

--- a/force-app/main/default/lwc/geConstants/geConstants.js
+++ b/force-app/main/default/lwc/geConstants/geConstants.js
@@ -52,7 +52,9 @@ const CLICKED_DOWN = 'clicked-down';
 const DOWN = 'down';
 const UP = 'up';
 
-const DEFAULT_NAME_ON_CARD = '[Not Provided]'
+const DEFAULT_NAME_ON_CARD = '[Not Provided]';
+
+const RECURRING_TYPE_FIXED = 'Fixed';
 
 export {
     COMMITMENT_INACTIVE_STATUS,
@@ -77,5 +79,6 @@ export {
     CLICKED_DOWN,
     DOWN,
     UP,
-    DEFAULT_NAME_ON_CARD
+    DEFAULT_NAME_ON_CARD,
+    RECURRING_TYPE_FIXED
 };

--- a/force-app/main/default/lwc/geFormRenderer/__tests__/geFormRenderer.test.js
+++ b/force-app/main/default/lwc/geFormRenderer/__tests__/geFormRenderer.test.js
@@ -31,6 +31,27 @@ describe('c-ge-form-renderer', () => {
     });
 
     describe('render behavior', () => {
+        it('save button is disabled when schedule recurring type is Fixed for Elevate RD', async() => {
+            retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);
+            getAllocationsSettings.mockResolvedValue(allocationsSettingsNoDefaultGAU);
+
+            const element = createElement('c-ge-form-renderer', {is: GeFormRenderer });
+            element.batchId = 'DUMMY_BATCH_ID';
+            element.isElevateCustomer = true;
+            document.body.appendChild(element);
+            await flushPromises();
+
+            element.giftInView = {
+                fields: {
+                    'Recurring_Donation_Recurring_Type__c': 'Fixed'
+                }
+            };
+            await flushPromises();
+
+            const saveButton = element.shadowRoot.querySelector('[data-id="bgeSaveButton"]');
+            expect(saveButton.disabled).toBeTruthy();
+        });
+
         it('renders make recurring button, when in batch mode and feature is enabled', async () => {
             retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);
             getAllocationsSettings.mockResolvedValue(allocationsSettingsNoDefaultGAU);
@@ -308,7 +329,6 @@ describe('c-ge-form-renderer', () => {
         const sections = element.shadowRoot.querySelectorAll('c-ge-form-section');
         expect(sections).toHaveLength(4);
     });
-
 
     it('form when saving without filling anything in should result in a page level error for missing fields', async () => {
         retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);

--- a/force-app/main/default/lwc/geFormRenderer/__tests__/geFormRenderer.test.js
+++ b/force-app/main/default/lwc/geFormRenderer/__tests__/geFormRenderer.test.js
@@ -31,49 +31,6 @@ describe('c-ge-form-renderer', () => {
     });
 
     describe('render behavior', () => {
-        it('save button is disabled when schedule recurring type is Fixed for Elevate RD', async() => {
-            retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);
-            getAllocationsSettings.mockResolvedValue(allocationsSettingsNoDefaultGAU);
-
-            const element = createElement('c-ge-form-renderer', {is: GeFormRenderer });
-            element.batchId = 'DUMMY_BATCH_ID';
-            element.isElevateCustomer = true;
-            document.body.appendChild(element);
-            await flushPromises();
-
-            element.giftInView = {
-                fields: {
-                    'Recurring_Donation_Recurring_Type__c': 'Fixed'
-                }
-            };
-            await flushPromises();
-
-            const saveButton = element.shadowRoot.querySelector('[data-id="bgeSaveButton"]');
-            expect(saveButton.disabled).toBeTruthy();
-        });
-
-        it('renders make recurring button, when in batch mode and feature is enabled', async () => {
-            retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);
-            getAllocationsSettings.mockResolvedValue(allocationsSettingsNoDefaultGAU);
-            const element = createElement('c-ge-form-renderer', {is: GeFormRenderer });
-
-            const DUMMY_BATCH_ID = 'a0T11000007F8WQEA0';
-
-            element.batchId = DUMMY_BATCH_ID;
-            document.body.appendChild(element);
-            await flushPromises();
-
-            // simulate getting back data for DUMMY_CONTACT_ID
-            getRecord.emit(dataImportBatchRecord, config => {
-                return config.recordId === DUMMY_BATCH_ID;
-            });
-
-            await flushPromises();
-
-            const button = element.shadowRoot.querySelectorAll('[data-id="recurringButton"]');
-            expect(button).toHaveLength(1);
-        });
-
         it('when a form is saved with a possible validation rule error then processing of the donation should be halted',
             async () => {
 
@@ -139,6 +96,85 @@ describe('c-ge-form-renderer', () => {
                 const spinner = element.shadowRoot.querySelector('lightning-spinner');
                 expect(spinner).toBeFalsy();
             });
+
+        it('save button is not disabled when schedule recurring type is Fixed for non-Elevate RD', async() => {
+            retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);
+            getAllocationsSettings.mockResolvedValue(allocationsSettingsNoDefaultGAU);
+
+            const element = createElement('c-ge-form-renderer', {is: GeFormRenderer });
+            element.batchId = 'DUMMY_BATCH_ID';
+
+            Settings.isElevateCustomer = jest.fn(() => true);
+            element.Settings = Settings;
+
+            GeGatewaySettings.isValidElevatePaymentMethod = jest.fn(() => false);
+            element.GeGatewaySettings = GeGatewaySettings;
+
+            document.body.appendChild(element);
+            await flushPromises();
+
+            element.giftInView = {
+                fields: {
+                    'Recurring_Donation_Recurring_Type__c': 'Fixed',
+                    'Payment_Method__c': 'Credit Card'
+                }
+            };
+            await flushPromises();
+
+            const saveButton = element.shadowRoot.querySelector('[data-id="bgeSaveButton"]');
+            expect(saveButton.disabled).toBeFalsy();
+        });
+
+        it('save button is disabled when schedule recurring type is Fixed for Elevate RD', async() => {
+            retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);
+            getAllocationsSettings.mockResolvedValue(allocationsSettingsNoDefaultGAU);
+
+            const element = createElement('c-ge-form-renderer', {is: GeFormRenderer });
+            element.batchId = 'DUMMY_BATCH_ID';
+            element.isElevateCustomer = true;
+
+            Settings.isElevateCustomer = jest.fn(() => true);
+            element.Settings = Settings;
+
+            GeGatewaySettings.isValidElevatePaymentMethod = jest.fn(() => true);
+            element.GeGatewaySettings = GeGatewaySettings;
+
+            document.body.appendChild(element);
+            await flushPromises();
+
+            element.giftInView = {
+                fields: {
+                    'Recurring_Donation_Recurring_Type__c': 'Fixed',
+                    'Payment_Method__c': 'Credit Card'
+                }
+            };
+            await flushPromises();
+
+            const saveButton = element.shadowRoot.querySelector('[data-id="bgeSaveButton"]');
+            expect(saveButton.disabled).toBeTruthy();
+        });
+
+        it('renders make recurring button, when in batch mode and feature is enabled', async () => {
+            retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);
+            getAllocationsSettings.mockResolvedValue(allocationsSettingsNoDefaultGAU);
+            const element = createElement('c-ge-form-renderer', {is: GeFormRenderer });
+
+            const DUMMY_BATCH_ID = 'a0T11000007F8WQEA0';
+
+            element.batchId = DUMMY_BATCH_ID;
+            document.body.appendChild(element);
+            await flushPromises();
+
+            // simulate getting back data for DUMMY_CONTACT_ID
+            getRecord.emit(dataImportBatchRecord, config => {
+                return config.recordId === DUMMY_BATCH_ID;
+            });
+
+            await flushPromises();
+
+            const button = element.shadowRoot.querySelectorAll('[data-id="recurringButton"]');
+            expect(button).toHaveLength(1);
+        });
 
         it('does not render make recurring button, when in batch mode and feature is disabled', async () => {
             retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);

--- a/force-app/main/default/lwc/geFormRenderer/__tests__/geFormRenderer.test.js
+++ b/force-app/main/default/lwc/geFormRenderer/__tests__/geFormRenderer.test.js
@@ -191,6 +191,36 @@ describe('c-ge-form-renderer', () => {
             expect(saveButton.disabled).toBeFalsy();
         });
 
+        it('save button is not disabled when schedule recurring type is Fixed for Elevate RD and widget is not on the form.', async() => {
+            retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);
+            getAllocationsSettings.mockResolvedValue(allocationsSettingsNoDefaultGAU);
+
+            const element = createElement('c-ge-form-renderer', {is: GeFormRenderer });
+            element.batchId = 'DUMMY_BATCH_ID';
+
+            Settings.isElevateCustomer = jest.fn(() => true);
+            element.Settings = Settings;
+
+            GeGatewaySettings.isValidElevatePaymentMethod = jest.fn(() => true);
+            element.GeGatewaySettings = GeGatewaySettings;
+
+            element.hasPaymentWidget = false;
+
+            document.body.appendChild(element);
+            await flushPromises();
+
+            element.giftInView = {
+                fields: {
+                    'Recurring_Donation_Recurring_Type__c': 'Fixed',
+                    'Payment_Method__c': 'Credit Card'
+                }
+            };
+            await flushPromises();
+
+            const saveButton = element.shadowRoot.querySelector('[data-id="bgeSaveButton"]');
+            expect(saveButton.disabled).toBeFalsy();
+        });
+
         it('renders make recurring button, when in batch mode and feature is enabled', async () => {
             retrieveDefaultSGERenderWrapper.mockResolvedValue(mockWrapperWithNoNames);
             getAllocationsSettings.mockResolvedValue(allocationsSettingsNoDefaultGAU);

--- a/force-app/main/default/lwc/geFormRenderer/__tests__/geFormRenderer.test.js
+++ b/force-app/main/default/lwc/geFormRenderer/__tests__/geFormRenderer.test.js
@@ -172,7 +172,8 @@ describe('c-ge-form-renderer', () => {
             element.giftInView = {
                 fields: {
                     'Recurring_Donation_Recurring_Type__c': 'Fixed',
-                    'Payment_Method__c': 'Credit Card'
+                    'Payment_Method__c': 'Credit Card',
+                    'Recurring_Donation_Elevate_Recurring_ID__c': 'DUMMY_RECURRING_ID'
                 }
             };
             await flushPromises();

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.html
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.html
@@ -148,7 +148,6 @@
                                                       title={saveActionLabel}
                                                       onclick={handleSave}
                                                       class='slds-m-left_x-small'
-                                                      disabled={isUpdateActionDisabled}
                                                       data-qa-locator={qaLocatorSaveButton}>
                                     </lightning-button>
                                 </div>

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.html
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.html
@@ -227,7 +227,7 @@
                                               horizontal-align='center'
                                               if:false={isPermissionError}>
                                 <lightning-layout-item size='12'
-                                                       if:true={showPaymentSaveNotice}>
+                                                       if:true={isWidgetEnabled}>
                                     <p class='slds-align_absolute-center slds-p-top_small'>
                                         {CUSTOM_LABELS.geTextPaymentsSaveNotice}
                                     </p>

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.html
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.html
@@ -143,7 +143,7 @@
                                           horizontal-align='center'
                                           if:false={isPermissionError}>
                             <lightning-layout-item size='12'
-                                                   if:true={showPaymentSaveNotice}>
+                                                   if:true={isWidgetEnabled}>
                                 <p class='slds-align_absolute-center slds-p-top_small'>
                                     {CUSTOM_LABELS.geTextPaymentsSaveNotice}
                                 </p>
@@ -224,7 +224,7 @@
                                               horizontal-align='center'
                                               if:false={isPermissionError}>
                                 <lightning-layout-item size='12'
-                                                       if:true={showPaymentSaveNotice}>
+                                                       if:true={isWidgetEnabled}>
                                     <p class='slds-align_absolute-center slds-p-top_small'>
                                         {CUSTOM_LABELS.geTextPaymentsSaveNotice}
                                     </p>

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.html
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.html
@@ -243,7 +243,8 @@
                                                           onclick={handleSave}
                                                           class='slds-m-left_x-small'
                                                           disabled={isUpdateActionDisabled}
-                                                          data-qa-locator={qaLocatorSaveButton}>
+                                                          data-qa-locator={qaLocatorSaveButton}
+                                                          data-id="bgeSaveButton">
                                         </lightning-button>
                                     </div>
                                 </lightning-layout-item>

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -1410,7 +1410,8 @@ export default class GeFormRenderer extends LightningElement{
         return this.getFieldValueFromFormState(STATUS_FIELD) === GIFT_STATUSES.IMPORTED ||
                 this.saveDisabled || (
 
-                this.isElevateCustomer &&
+                Settings.isElevateCustomer &&
+                GeGatewaySettings.isValidElevatePaymentMethod(this.selectedPaymentMethod()) &&
                 this.getFieldValueFromFormState(DATA_IMPORT_RECURRING_TYPE) === RECURRING_TYPE_FIXED
             )
     }

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -206,8 +206,7 @@ export default class GeFormRenderer extends LightningElement{
     @track mappingSet = '';
     @track version = '';
     _isElevateWidgetInDisabledState = false;
-    _hasPaymentWidget = false;
-    latestElevateBatchId = null;
+    @api hasPaymentWidget = false;
     cardholderNamesNotInTemplate = {};
     _openedGiftId;
     currentElevateBatch = new ElevateBatch();
@@ -311,9 +310,8 @@ export default class GeFormRenderer extends LightningElement{
     @track
     _formState = {}
 
-    /** Determines when we show payment related text above the cancel and save buttons */
-    get showPaymentSaveNotice() {
-        return this._hasPaymentWidget && this._isElevateWidgetInDisabledState === false;
+    get isWidgetEnabled() {
+        return this.hasPaymentWidget && this._isElevateWidgetInDisabledState === false;
     }
 
     get title() {
@@ -1120,7 +1118,7 @@ export default class GeFormRenderer extends LightningElement{
 
     shouldTokenizeCard() {
         return Settings.isElevateCustomer()
-            && !!(this.showPaymentSaveNotice)
+            && !!(this.isWidgetEnabled)
             && this.hasChargeableTransactionStatus();
     }
 
@@ -1410,7 +1408,7 @@ export default class GeFormRenderer extends LightningElement{
         return this.getFieldValueFromFormState(STATUS_FIELD) === GIFT_STATUSES.IMPORTED ||
                 this.saveDisabled || (
 
-                Settings.isElevateCustomer() &&
+                this.isWidgetEnabled &&
                 GeGatewaySettings.isValidElevatePaymentMethod(this.selectedPaymentMethod()) &&
                 this.getFieldValueFromFormState(DATA_IMPORT_RECURRING_TYPE) === RECURRING_TYPE_FIXED
             )
@@ -1895,7 +1893,7 @@ export default class GeFormRenderer extends LightningElement{
     }
 
     handleRegisterPaymentWidget() {
-       this._hasPaymentWidget = true;
+       this.hasPaymentWidget = true;
     }
 
     /*******************************************************************************

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -1116,6 +1116,10 @@ export default class GeFormRenderer extends LightningElement{
         return this.formState[apiNameFor(PAYMENT_STATUS)] === this.PAYMENT_TRANSACTION_STATUS_ENUM.EXPIRED;
     }
 
+    isGiftCommitment() {
+        return isNotEmpty(this.formState[apiNameFor(DATA_IMPORT_RECURRING_DONATION_ELEVATE_ID)]);
+    }
+
     shouldTokenizeCard() {
         return Settings.isElevateCustomer()
             && !!(this.isWidgetEnabled)
@@ -1408,7 +1412,7 @@ export default class GeFormRenderer extends LightningElement{
         return this.getFieldValueFromFormState(STATUS_FIELD) === GIFT_STATUSES.IMPORTED ||
                 this.saveDisabled || (
 
-                this.isWidgetEnabled &&
+                (this.isWidgetEnabled || this.isGiftCommitment()) &&
                 GeGatewaySettings.isValidElevatePaymentMethod(this.selectedPaymentMethod()) &&
                 this.getFieldValueFromFormState(DATA_IMPORT_RECURRING_TYPE) === RECURRING_TYPE_FIXED
             )

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -97,6 +97,8 @@ import DATA_IMPORT_RECURRING_DONATION_CARD_EXPIRATION_YEAR
     from '@salesforce/schema/DataImport__c.Recurring_Donation_Card_Expiration_Year__c';
 import DATA_IMPORT_RECURRING_DONATION_CARD_LAST_4
     from '@salesforce/schema/DataImport__c.Recurring_Donation_Card_Last_4__c';
+import DATA_IMPORT_RECURRING_TYPE
+    from '@salesforce/schema/DataImport__c.Recurring_Donation_Recurring_Type__c';
 
 import DATA_IMPORT_ADDITIONAL_OBJECT_FIELD from '@salesforce/schema/DataImport__c.Additional_Object_JSON__c'
 import DATA_IMPORT_ACCOUNT1_IMPORTED_FIELD from '@salesforce/schema/DataImport__c.Account1Imported__c';
@@ -127,7 +129,9 @@ import {
     FAILED, ACH_CONSENT_TYPE,
     COMMITMENT_INACTIVE_STATUS,
     BATCH_COMMITMENT_CREATED_STATUS_REASON,
-    PAYMENT_METHOD_ACH
+    PAYMENT_METHOD_ACH,
+    GIFT_STATUSES,
+    RECURRING_TYPE_FIXED
 } from 'c/geConstants';
 
 
@@ -1403,8 +1407,12 @@ export default class GeFormRenderer extends LightningElement{
     }
 
     get isUpdateActionDisabled() {
-        return this.getFieldValueFromFormState(STATUS_FIELD) === 'Imported' ||
-               this.saveDisabled;
+        return this.getFieldValueFromFormState(STATUS_FIELD) === GIFT_STATUSES.IMPORTED ||
+                this.saveDisabled || (
+
+                this.isElevateCustomer &&
+                this.getFieldValueFromFormState(DATA_IMPORT_RECURRING_TYPE) === RECURRING_TYPE_FIXED
+            )
     }
 
     get cardholderNames() {

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -317,7 +317,7 @@ export default class GeFormRenderer extends LightningElement{
 
     /** Determines when we show payment related text above the cancel and save buttons */
     get isWidgetEnabled() {
-        return this._hasPaymentWidget && this._isElevateWidgetInDisabledState === false;
+        return this.hasPaymentWidget && this._isElevateWidgetInDisabledState === false;
     }
 
     get title() {
@@ -1151,7 +1151,7 @@ export default class GeFormRenderer extends LightningElement{
 
     shouldTokenizeCard() {
         return Settings.isElevateCustomer()
-            && !!(this.isWidgetEnabled)
+            && this.isWidgetEnabled
             && this.hasChargeableTransactionStatus();
     }
 

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -97,6 +97,8 @@ import DATA_IMPORT_RECURRING_DONATION_CARD_EXPIRATION_YEAR
     from '@salesforce/schema/DataImport__c.Recurring_Donation_Card_Expiration_Year__c';
 import DATA_IMPORT_RECURRING_DONATION_CARD_LAST_4
     from '@salesforce/schema/DataImport__c.Recurring_Donation_Card_Last_4__c';
+import DATA_IMPORT_RECURRING_DONATION_ACH_LAST_4
+    from '@salesforce/schema/DataImport__c.Recurring_Donation_ACH_Last_4__c';
 import DATA_IMPORT_RECURRING_TYPE
     from '@salesforce/schema/DataImport__c.Recurring_Donation_Recurring_Type__c';
 
@@ -1065,6 +1067,11 @@ export default class GeFormRenderer extends LightningElement{
                     [apiNameFor(DATA_IMPORT_RECURRING_DONATION_CARD_LAST_4)]:
                         elevateBatchItem.cardLast4,
                 });
+            } else if (this.selectedPaymentMethod() === PAYMENT_METHOD_ACH) {
+                this.updateFormState({
+                    [apiNameFor(DATA_IMPORT_RECURRING_DONATION_ACH_LAST_4)]:
+                        elevateBatchItem.achLast4,
+                });
             }
         }
     }
@@ -1438,8 +1445,10 @@ export default class GeFormRenderer extends LightningElement{
     }
 
     get isUpdateActionDisabled() {
+        let newPaymentInfoRequiredAndNotEntered = this.shouldShowElevateTransactionWarning && 
+            this._isElevateWidgetInDisabledState;
         return this.getFieldValueFromFormState(STATUS_FIELD) === GIFT_STATUSES.IMPORTED ||
-                this.shouldShowElevateTransactionWarning ||
+                newPaymentInfoRequiredAndNotEntered ||
                 this.saveDisabled || (
 
                 (this.isWidgetEnabled || this.isGiftCommitment()) &&

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -298,6 +298,10 @@ export default class GeFormRenderer extends LightningElement{
         });
     }
 
+    isGiftCommitment() {
+        return isNotEmpty(this.formState[apiNameFor(DATA_IMPORT_RECURRING_DONATION_ELEVATE_ID)]);
+    }
+
     loadSelectedDonationFieldValues(record) {
         this.loadSelectedRecordFieldValues(
             apiNameFor(DATA_IMPORT_DONATION_IMPORTED_FIELD), record.Id);
@@ -312,7 +316,7 @@ export default class GeFormRenderer extends LightningElement{
     _formState = {}
 
     /** Determines when we show payment related text above the cancel and save buttons */
-    get showPaymentSaveNotice() {
+    get isWidgetEnabled() {
         return this._hasPaymentWidget && this._isElevateWidgetInDisabledState === false;
     }
 
@@ -1147,7 +1151,7 @@ export default class GeFormRenderer extends LightningElement{
 
     shouldTokenizeCard() {
         return Settings.isElevateCustomer()
-            && !!(this.showPaymentSaveNotice)
+            && !!(this.isWidgetEnabled)
             && this.hasChargeableTransactionStatus();
     }
 
@@ -2913,7 +2917,7 @@ export default class GeFormRenderer extends LightningElement{
         return  this.getFieldValueFromFormState(STATUS_FIELD) !== GIFT_STATUSES.IMPORTED &&
                 (
                     this.hasUnprocessedReadOnlyPaymentStatus(paymentStatus) ||
-                    this.getFieldValueFromFormState(DATA_IMPORT_RECURRING_DONATION_ELEVATE_ID)
+                    !!this.getFieldValueFromFormState(DATA_IMPORT_RECURRING_DONATION_ELEVATE_ID)
                 );
     }
 

--- a/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -1410,7 +1410,7 @@ export default class GeFormRenderer extends LightningElement{
         return this.getFieldValueFromFormState(STATUS_FIELD) === GIFT_STATUSES.IMPORTED ||
                 this.saveDisabled || (
 
-                Settings.isElevateCustomer &&
+                Settings.isElevateCustomer() &&
                 GeGatewaySettings.isValidElevatePaymentMethod(this.selectedPaymentMethod()) &&
                 this.getFieldValueFromFormState(DATA_IMPORT_RECURRING_TYPE) === RECURRING_TYPE_FIXED
             )

--- a/force-app/main/default/lwc/geFormWidget/geFormWidget.js
+++ b/force-app/main/default/lwc/geFormWidget/geFormWidget.js
@@ -10,6 +10,10 @@ import DATA_IMPORT_ACCOUNT_NAME from '@salesforce/schema/DataImport__c.Account1_
 import DATA_IMPORT_PAYMENT_STATUS from '@salesforce/schema/DataImport__c.Payment_Status__c';
 import DATA_IMPORT_PARENT_BATCH_LOOKUP from '@salesforce/schema/DataImport__c.NPSP_Data_Import_Batch__c';
 import DATA_IMPORT_ID from '@salesforce/schema/DataImport__c.Id';
+import DATA_IMPORT_RECURRING_DONATION_ELEVATE_ID
+    from '@salesforce/schema/DataImport__c.Recurring_Donation_Elevate_Recurring_ID__c';
+import DATA_IMPORT_RECURRING_TYPE
+    from '@salesforce/schema/DataImport__c.Recurring_Donation_Recurring_Type__c';
 import DATA_IMPORT_STATUS from '@salesforce/schema/DataImport__c.Status__c';
 
 const ALLOCATION_WIDGET = 'geFormWidgetAllocation';
@@ -42,7 +46,9 @@ export default class GeFormWidget extends LightningElement {
         apiNameFor(DATA_IMPORT_ACCOUNT_NAME),
         apiNameFor(DATA_IMPORT_PAYMENT_STATUS),
         apiNameFor(DATA_IMPORT_STATUS),
-        apiNameFor(DATA_IMPORT_ID)
+        apiNameFor(DATA_IMPORT_ID),
+        apiNameFor(DATA_IMPORT_RECURRING_DONATION_ELEVATE_ID),
+        apiNameFor(DATA_IMPORT_RECURRING_TYPE)
     ];
 
     get giftInViewHasSchedule() {

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/__tests__/geFormWidgetTokenizeCard.test.js
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/__tests__/geFormWidgetTokenizeCard.test.js
@@ -64,6 +64,36 @@ describe('c-ge-form-widget-tokenize-card', () => {
         expect(editPaymentInformationLink).toBeFalsy();
     });
 
+    it('should activate the widget when recurring type is changed from Fixed to Open', async() => {
+        const element = createWidgetElement();
+        element.widgetDataFromState = {
+            'Payment_Method__c': 'Credit Card',
+            'Recurring_Donation_Recurring_Type__c': 'Fixed',
+            'NPSP_Data_Import_Batch__c': 'DUMMY_BATCH_ID'
+        };
+        document.body.appendChild(element);
+        await flushPromises();
+
+        const deactivatedMessage = shadowQuerySelector(element, '[data-id="deactivatedMessage"]');
+        const editPaymentInformationLink = shadowQuerySelector(element, '[data-id="editPaymentInformation"]');
+
+        expect(deactivatedMessage.textContent).toBe(RD2_ElevateRDCannotBeFixedLength);
+        expect(editPaymentInformationLink).toBeFalsy();
+
+        element.widgetDataFromState = {
+            'Payment_Method__c': 'Credit Card',
+            'Recurring_Donation_Recurring_Type__c': 'Open',
+            'NPSP_Data_Import_Batch__c': 'DUMMY_BATCH_ID'
+        };
+        await flushPromises();
+
+        const deactivatedMessageReRendered = shadowQuerySelector(element, '[data-id="deactivatedMessage"]');
+        expect(deactivatedMessageReRendered).toBeFalsy();
+
+        const chargeIFrameContainer = shadowQuerySelector(element, '[data-id="chargeIFrameContainer"]');
+        expect(chargeIFrameContainer).toBeTruthy();
+    });
+
     it('should deactivate the widget in read-only mode when a fixed recurring type gift is loaded', async() => {
         const element = createWidgetElement();
         element.widgetDataFromState = {

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/__tests__/geFormWidgetTokenizeCard.test.js
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/__tests__/geFormWidgetTokenizeCard.test.js
@@ -21,6 +21,8 @@ const PAYMENT_METHOD_FIELD = 'Payment_Method__c';
 const DATA_IMPORT_PARENT_BATCH_LOOKUP = 'NPSP_Data_Import_Batch__c';
 const DATA_IMPORT_PAYMENT_STATUS = 'Payment_Status__c';
 
+import RD2_ElevateRDCannotBeFixedLength from '@salesforce/label/c.RD2_ElevateRDCannotBeFixedLength';
+
 const createWidgetElement = () => {
     let element = createElement(
         'c-ge-form-widget-tokenize-card',
@@ -42,6 +44,79 @@ describe('c-ge-form-widget-tokenize-card', () => {
     beforeEach(() => {
         Settings.isElevateCustomer = jest.fn(() => true);
         clearDOM();
+    });
+
+    it('should deactivate the widget in edit mode when a fixed recurring type gift is loaded', async() => {
+        const element = createWidgetElement();
+        element.widgetDataFromState = {
+            'Payment_Method__c': 'Credit Card',
+            'Recurring_Donation_Recurring_Type__c': 'Fixed',
+            'NPSP_Data_Import_Batch__c': 'DUMMY_BATCH_ID'
+        };
+        document.body.appendChild(element);
+
+        await flushPromises();
+
+        const deactivatedMessage = shadowQuerySelector(element, '[data-id="deactivatedMessage"]');
+        const editPaymentInformationLink = shadowQuerySelector(element, '[data-id="editPaymentInformation"]');
+
+        expect(deactivatedMessage.textContent).toBe(RD2_ElevateRDCannotBeFixedLength);
+        expect(editPaymentInformationLink).toBeFalsy();
+    });
+
+    it('should deactivate the widget in read-only mode when a fixed recurring type gift is loaded', async() => {
+        const element = createWidgetElement();
+        element.widgetDataFromState = {
+            'Payment_Method__c': 'Credit Card',
+            'Recurring_Donation_Recurring_Type__c': 'Open',
+            'NPSP_Data_Import_Batch__c': 'DUMMY_BATCH_ID',
+            'Id': 'DUMMY_RECORD_ID'
+        };
+        document.body.appendChild(element);
+        await flushPromises();
+
+        const dataImportRecord = {
+            'Payment_Card_Last_4__c': '1234',
+            'Payment_Card_Expiration_Month__c': 'testMonth',
+            'Payment_Card_Expiration_Year__c': 'testYear'
+        };
+        const dataImportObjectInfo = {
+          data: {
+              fields: {
+                  'Payment_Card_Last_4__c': 'yes',
+                  'Payment_Card_Expiration_Month__c': 'yes',
+                  'Payment_Card_Expiration_Year__c': 'yes'
+              }
+          }
+        };
+        getObjectInfo.emit(dataImportObjectInfo);
+        await flushPromises();
+
+        getRecord.emit(dataImportRecord, record => {
+            record.recordId = 'DUMMY_RECORD_ID';
+            return record;
+        });
+        await flushPromises();
+
+        const readOnlyLayout = shadowQuerySelector(element, '[data-id="readOnlyLayout"]');
+        expect(readOnlyLayout).toBeTruthy();
+
+        element.widgetDataFromState = {
+            'Payment_Method__c': 'Credit Card',
+            'Recurring_Donation_Recurring_Type__c': 'Fixed',
+            'NPSP_Data_Import_Batch__c': 'DUMMY_BATCH_ID',
+            'Id': 'DUMMY_RECORD_ID'
+        };
+        await flushPromises();
+
+        const deactivatedMessage = shadowQuerySelector(element, '[data-id="deactivatedMessage"]');
+        const editPaymentInformationLink = shadowQuerySelector(element, '[data-id="editPaymentInformation"]');
+
+        expect(deactivatedMessage.textContent).toBe(RD2_ElevateRDCannotBeFixedLength);
+        expect(editPaymentInformationLink).toBeFalsy();
+
+        const readOnlyLayoutReRendered = shadowQuerySelector(element, '[data-id="readOnlyLayout"]');
+        expect(readOnlyLayoutReRendered).toBeFalsy();
     });
 
     it('should not render the iframe and related elements if is not an Elevate customer', async () => {

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
@@ -172,12 +172,14 @@
                                     <span class='slds-content-message'>
                                         {doNotChargeMessage}
                                     </span>
-                                    <lightning-button variant='base'
-                                                        label={CUSTOM_LABELS.geButtonPaymentAlternate}
-                                                        title={CUSTOM_LABELS.geButtonPaymentAlternate}
-                                                        onclick={handleUserEnterPaymentInformation}
-                                                        class='slds-m-left_xx-small'>
-                                    </lightning-button>
+                                    <template if:false={shouldDisplayElevateFixedRecurringTypeWarning}>
+                                        <lightning-button variant='base'
+                                                            label={CUSTOM_LABELS.geButtonPaymentAlternate}
+                                                            title={CUSTOM_LABELS.geButtonPaymentAlternate}
+                                                            onclick={handleUserEnterPaymentInformation}
+                                                            class='slds-m-left_xx-small'>
+                                        </lightning-button>
+                                    </template>
                                 </p>
                             </template>
                         </template>

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
@@ -35,7 +35,8 @@
                                                             icon-position="right"
                                                             onclick={handleUserEditExpired}
                                                             class='slds-button slds-button_base slds-float_right do-not-charge-card-button'
-                                                            data-qa-locator={qaLocatorEditPaymentInformation}>
+                                                            data-qa-locator={qaLocatorEditPaymentInformation}
+                                                            data-id="editPaymentInformation">
                                             </lightning-button>
                                         </template>
                                     </template>
@@ -114,7 +115,7 @@
                         <template if:true={isDeactivated}>
                             <template if:true={isElevateCustomer}>
                                 <p class='fade-in slds-p-vertical_medium'>
-                                    <span class='slds-content-message'>
+                                    <span class='slds-content-message' data-id="deactivatedMessage">
                                         {deactivatedMessage}
                                     </span>
                                 </p>
@@ -122,7 +123,7 @@
                         </template>
 
                         <template if:true={isReadOnly}>
-                            <lightning-layout class="read-only-mode">
+                            <lightning-layout class="read-only-mode" data-id="readOnlyLayout">
                                 <template if:true={showCreditCardReadOnlyFields}>
                                     <lightning-layout-item padding="around-small"
                                                         class='fade-in'

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.html
@@ -80,7 +80,7 @@
                                                  icon={alert.icon}
                                                  message={alert.message}>
                             </c-util-alert-banner>
-                            <div class='iframe-container'>
+                            <div class='iframe-container' data-id="chargeIFrameContainer">
                                 <template if:true={showSpinner}>
                                     <lightning-spinner if:true={isElevateCustomer} alternative-text={CUSTOM_LABELS.geAssistiveSpinner}></lightning-spinner>
                                 </template>

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
@@ -286,8 +286,11 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     }
 
     get deactivatedMessage() {
-        return this.recurringType === RECURRING_TYPE_FIXED ? this.CUSTOM_LABELS.RD2_ElevateRDCannotBeFixedLength :
-                this.CUSTOM_LABELS.geBodyPaymentNotProcessingTransaction
+        return this.recurringType === RECURRING_TYPE_FIXED &&
+                GeGatewaySettings.isValidElevatePaymentMethod(this.paymentMethod()) &&
+                !this.isDoNotCharge ?
+                    this.CUSTOM_LABELS.RD2_ElevateRDCannotBeFixedLength :
+                    this.CUSTOM_LABELS.geBodyPaymentNotProcessingTransaction
                     + ' ' + this.CUSTOM_LABELS.psSelectValidPaymentMethod;
     }
 

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
@@ -16,7 +16,8 @@ import {
     TOKENIZE_ACH_EVENT_ACTION,
     TOKENIZE_CREDIT_CARD_EVENT_ACTION,
     DEFAULT_NAME_ON_CARD,
-    GIFT_STATUSES
+    GIFT_STATUSES,
+    RECURRING_TYPE_FIXED
 } from 'c/geConstants';
 import ElevateWidgetDisplay from './helpers/elevateWidgetDisplay';
 import GeFormService from 'c/geFormService';
@@ -33,7 +34,10 @@ import DATA_IMPORT_STATUS from '@salesforce/schema/DataImport__c.Status__c';
 import DATA_IMPORT_DONATION_DONOR from '@salesforce/schema/DataImport__c.Donation_Donor__c';
 import DATA_IMPORT_ACCOUNT_NAME from '@salesforce/schema/DataImport__c.Account1_Name__c';
 import DATA_IMPORT_PARENT_BATCH_LOOKUP from '@salesforce/schema/DataImport__c.NPSP_Data_Import_Batch__c';
-import DATA_IMPORT_RECURRING_DONATION_STATUS from '@salesforce/schema/DataImport__c.Recurring_Donation_Status__c';
+import DATA_IMPORT_RECURRING_TYPE
+    from '@salesforce/schema/DataImport__c.Recurring_Donation_Recurring_Type__c';
+import DATA_IMPORT_RECURRING_DONATION_ELEVATE_ID
+    from '@salesforce/schema/DataImport__c.Recurring_Donation_Elevate_Recurring_ID__c';
 import DATA_IMPORT_RECURRING_DONATION_ACH_LAST_4
     from '@salesforce/schema/DataImport__c.Recurring_Donation_ACH_Last_4__c';
 import DATA_IMPORT_RECURRING_DONATION_CARD_LAST_4
@@ -282,8 +286,9 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     }
 
     get deactivatedMessage() {
-        return this.CUSTOM_LABELS.geBodyPaymentNotProcessingTransaction
-            + ' ' + this.CUSTOM_LABELS.psSelectValidPaymentMethod;
+        return this.recurringType === RECURRING_TYPE_FIXED ? this.CUSTOM_LABELS.RD2_ElevateRDCannotBeFixedLength :
+                this.CUSTOM_LABELS.geBodyPaymentNotProcessingTransaction
+                    + ' ' + this.CUSTOM_LABELS.psSelectValidPaymentMethod;
     }
 
     get shouldDisplayCardProcessingGuidanceMessage() {
@@ -313,6 +318,10 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
         return this._widgetDataFromState[apiNameFor(DATA_IMPORT_ID)] !== widgetState[apiNameFor(DATA_IMPORT_ID)];
     }
 
+    get recurringType() {
+        return this._widgetDataFromState[apiNameFor(DATA_IMPORT_RECURRING_TYPE)];
+    }
+
     updateDisplayState() {
         if (!Settings.isElevateCustomer()) return;
         if (this.isInBatchGiftEntry()) {
@@ -323,6 +332,15 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     }
 
     updateDisplayStateWhenInBatchGiftEntry() {
+        if (this.recurringType === RECURRING_TYPE_FIXED) {
+            if (this.isReadOnly) {
+                this.display.transitionTo('resetToDeactivated');
+            } else {
+                this.display.transitionTo('deactivated');
+            }
+
+            return;
+        }
         if (this.hasReadOnlyStatus && !this.isValidBatchElevatePaymentMethod()) {
             this.display.transitionTo('resetToDeactivated');
         }
@@ -534,7 +552,7 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
 
     shouldHandleWidgetDataChange() {
         return (this.isInBatchGiftEntry() && (isNotEmpty(
-            this.paymentStatus() || isNotEmpty(this.recurringDonationStatus())))
+            this.paymentStatus() || isNotEmpty(this.recurringDonationId())))
             || isEmpty(this.paymentStatus()));
     }
 
@@ -552,8 +570,8 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
         return this.widgetDataFromState && this.widgetDataFromState[apiNameFor(DATA_IMPORT_PAYMENT_STATUS_FIELD)];
     }
 
-    recurringDonationStatus() {
-        return this.widgetDataFromState && this.widgetDataFromState[apiNameFor(DATA_IMPORT_RECURRING_DONATION_STATUS)];
+    recurringDonationId() {
+        return this.widgetDataFromState && this.widgetDataFromState[apiNameFor(DATA_IMPORT_RECURRING_DONATION_ELEVATE_ID)];
     }
 
     hasValidPaymentMethod() {

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
@@ -36,8 +36,6 @@ import DATA_IMPORT_ACCOUNT_NAME from '@salesforce/schema/DataImport__c.Account1_
 import DATA_IMPORT_PARENT_BATCH_LOOKUP from '@salesforce/schema/DataImport__c.NPSP_Data_Import_Batch__c';
 import DATA_IMPORT_RECURRING_TYPE
     from '@salesforce/schema/DataImport__c.Recurring_Donation_Recurring_Type__c';
-import DATA_IMPORT_RECURRING_DONATION_ELEVATE_ID
-    from '@salesforce/schema/DataImport__c.Recurring_Donation_Elevate_Recurring_ID__c';
 import DATA_IMPORT_RECURRING_DONATION_ACH_LAST_4
     from '@salesforce/schema/DataImport__c.Recurring_Donation_ACH_Last_4__c';
 import DATA_IMPORT_RECURRING_DONATION_CARD_LAST_4

--- a/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
+++ b/force-app/main/default/lwc/geFormWidgetTokenizeCard/geFormWidgetTokenizeCard.js
@@ -242,7 +242,9 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     }
 
     get doNotChargeMessage() {
-        return this.CUSTOM_LABELS.geBodyPaymentNotProcessingTransaction;
+        return this.shouldDisplayElevateFixedRecurringTypeWarning ?
+            this.CUSTOM_LABELS.RD2_ElevateRDCannotBeFixedLength :
+            this.CUSTOM_LABELS.geBodyPaymentNotProcessingTransaction;
     }
 
     get tokenizeCardPageUrl() {
@@ -286,12 +288,15 @@ export default class geFormWidgetTokenizeCard extends LightningElement {
     }
 
     get deactivatedMessage() {
-        return this.recurringType === RECURRING_TYPE_FIXED &&
-                GeGatewaySettings.isValidElevatePaymentMethod(this.paymentMethod()) &&
-                !this.isDoNotCharge ?
+        return this.shouldDisplayElevateFixedRecurringTypeWarning ?
                     this.CUSTOM_LABELS.RD2_ElevateRDCannotBeFixedLength :
                     this.CUSTOM_LABELS.geBodyPaymentNotProcessingTransaction
                     + ' ' + this.CUSTOM_LABELS.psSelectValidPaymentMethod;
+    }
+
+    get shouldDisplayElevateFixedRecurringTypeWarning() {
+        return this.recurringType === RECURRING_TYPE_FIXED &&
+            GeGatewaySettings.isValidElevatePaymentMethod(this.paymentMethod());
     }
 
     get shouldDisplayCardProcessingGuidanceMessage() {

--- a/force-app/main/default/lwc/geGiftEntryFormApp/__tests__/geGiftEntryFormApp.test.js
+++ b/force-app/main/default/lwc/geGiftEntryFormApp/__tests__/geGiftEntryFormApp.test.js
@@ -31,7 +31,6 @@ import DATA_IMPORT_BATCH_OBJECT from '@salesforce/schema/DataImportBatch__c';
 import OPPORTUNITY_OBJECT from '@salesforce/schema/Opportunity';
 import FAILURE_INFORMATION from '@salesforce/schema/DataImport__c.FailureInformation__c';
 import accountDonorSelectionMismatch from '@salesforce/label/c.geErrorDonorMismatch';
-import { fireEvent } from '../../pubsubNoPageRef/pubsubNoPageRef';
 
 const PROCESSING_BATCH_MESSAGE = 'c.geProcessingBatch';
 
@@ -257,9 +256,10 @@ describe('c-ge-gift-entry-form-app', () => {
             pubSub.fireEvent({}, 'widgetStateChange', {state: 'readOnly'});
             await flushPromises();
             
-            const saveButton = shadowQuerySelector(geFormRenderer, '[data-id="formSaveButton"]');
+            const saveButton = shadowQuerySelector(geFormRenderer, '[data-id="bgeSaveButton"]');
             expect(saveButton.disabled).toBe(true);
         });
+
         it('should disable update button when widget is read-only with an editable status for one-time gift', async() => {
             const formApp = setupForBatchMode({gifts: [{fields: {'Id': 'DUMMY_RECORD_ID',
                                                                  'Payment_Status__c': 'AUTHORIZED'}}], totals: { TOTAL: 1 }});
@@ -280,7 +280,7 @@ describe('c-ge-gift-entry-form-app', () => {
             pubSub.fireEvent({}, 'widgetStateChange', {state: 'readOnly'});
             await flushPromises();
             
-            const saveButton = shadowQuerySelector(geFormRenderer, '[data-id="formSaveButton"]');
+            const saveButton = shadowQuerySelector(geFormRenderer, '[data-id="bgeSaveButton"]');
             expect(saveButton.disabled).toBe(true);
         });
 

--- a/force-app/main/default/lwc/geGiftEntryFormApp/geGiftEntryFormApp.js
+++ b/force-app/main/default/lwc/geGiftEntryFormApp/geGiftEntryFormApp.js
@@ -794,7 +794,7 @@ export default class GeGiftEntryFormApp extends NavigationMixin(LightningElement
         const schedule = event.detail;
         this.gift.addSchedule(schedule);
         this.giftInView = this.gift.state();
-        fireEvent(this.pageRef, 'geModalCloseEvent', {})
+        fireEvent(this, 'geModalCloseEvent', {});
     }
 
     handleRemoveSchedule() {

--- a/force-app/main/default/lwc/geLabelService/geLabelService.js
+++ b/force-app/main/default/lwc/geLabelService/geLabelService.js
@@ -249,7 +249,8 @@ import geWarningFormFieldsModalDeleteSection from '@salesforce/label/c.geWarning
 import labelBooleanFalse from '@salesforce/label/c.labelBooleanFalse';
 import labelBooleanTrue from '@salesforce/label/c.labelBooleanTrue';
 import psSelectValidPaymentMethod from '@salesforce/label/c.psSelectValidPaymentMethod';
-import recurringDonations from '@salesforce/label/c.stgNavRecurringDonations'
+import recurringDonations from '@salesforce/label/c.stgNavRecurringDonations';
+import RD2_ElevateRDCannotBeFixedLength from '@salesforce/label/c.RD2_ElevateRDCannotBeFixedLength';
 
 class GeLabelService {
 
@@ -360,6 +361,7 @@ class GeLabelService {
         geBodyMatchingSelectRecord,
         geBodyMatchingUpdatingDonation,
         geBodyPaymentNotProcessingTransaction,
+        RD2_ElevateRDCannotBeFixedLength,
         geBodyPaymentProcessedDuringBatchProcessing,
         geBodyTemplateInfoLeftCol,
         geBodyTemplatesTabDescription,


### PR DESCRIPTION
Added a validation to not allow Fixed recurring type schedules to be entered for Elevate connected curring gifts in batch gift entry

[W-11757404](https://gus.lightning.force.com/a07EE000016WU5WYAW)

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
