### PR TITLE
Change Payment Method/Other attribute value throwing error for elevate connected RD "Missing Authentication Token"

### DIFF
--- a/force-app/main/default/classes/PS_CommitmentRequest_TEST.cls
+++ b/force-app/main/default/classes/PS_CommitmentRequest_TEST.cls
@@ -333,7 +333,7 @@ private with sharing class PS_CommitmentRequest_TEST {
         Test.stopTest();
 
         final String expectedEndpoint = PS_IntegrationServiceConfig_TEST.testBaseUrl
-            + PS_Request.ENDPOINT_COMMITMENT+'/'+commitmentId;
+            + PS_Request.ENDPOINT_COMMITMENT;
         System.assertEquals(expectedEndpoint, request.getEndpoint(), 'Endpoint should match');
 
         System.assertEquals(UTIL_Http.Method.PATCH.name(), request.getMethod(), 'The HttpRequest method should match');

--- a/force-app/main/default/classes/PS_Request.cls
+++ b/force-app/main/default/classes/PS_Request.cls
@@ -274,9 +274,6 @@ public inherited sharing class PS_Request {
             } else if (endpoint == ElevateEndpoint.COMMITMENT) {
                 value = ENDPOINT_COMMITMENT;
 
-                if (String.isNotBlank(commitmentId)) {
-                    value += '/' + commitmentId;
-                }
             } else if (endpoint == ElevateEndpoint.COMMITMENT_PAUSE) {
                 value = String.format(
                     ENDPOINT_COMMITMENT_PAUSE,

--- a/force-app/main/default/classes/PS_Request_TEST.cls
+++ b/force-app/main/default/classes/PS_Request_TEST.cls
@@ -107,7 +107,7 @@ private with sharing class PS_Request_TEST {
     }
 
     /**
-    * @description Verifies Cancel Commitment HttpRequest
+    * @description Verifies Get Commitment HttpRequest
     */
     @isTest
     private static void shouldCreateHttpRequestWhenCommitmentEndpointWithId() {
@@ -123,7 +123,7 @@ private with sharing class PS_Request_TEST {
 
         final String jsonRequestBody = '';
         final String expectedEndpoint = PS_IntegrationServiceConfig_TEST.testBaseUrl
-            + PS_Request.ENDPOINT_COMMITMENT + '/' + COMMITMENT_ID;
+            + PS_Request.ENDPOINT_COMMITMENT;
 
         assertRequest(request, expectedEndpoint, UTIL_Http.Method.GET, jsonRequestBody);
     }


### PR DESCRIPTION
Fix a bug causing a "Missing Authentication Token" error to be thrown when updating any schedule information for an existing Elevate-connected recurring donation

[W-11999572](https://gus.lightning.force.com/a07EE00001BMMjEYAX)

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
