### PR TITLE
Fixing Elevate Commitment GET requests

### DIFF
--- a/force-app/main/default/classes/PS_CommitmentRequest.cls
+++ b/force-app/main/default/classes/PS_CommitmentRequest.cls
@@ -321,7 +321,7 @@ public inherited sharing class PS_CommitmentRequest {
 
     private Map<String, Object> getElevateCommitment(String commitmentId) {
         HttpRequest commitmentGetRequest = buildRequest(commitmentId, UTIL_Http.Method.GET,
-            PS_Request.ElevateEndpoint.COMMITMENT);
+            PS_Request.ElevateEndpoint.COMMITMENT_GET);
         UTIL_Http.Response response = requestService.sendRequest(commitmentGetRequest);
 
         Map<String, Object> responseBody = (Map<String, Object>) JSON.deserializeUntyped(response.body);

--- a/force-app/main/default/classes/PS_Request.cls
+++ b/force-app/main/default/classes/PS_Request.cls
@@ -41,6 +41,7 @@ public inherited sharing class PS_Request {
         REFUND,
         TRANSACTIONS,
         COMMITMENT,
+        COMMITMENT_GET,
         COMMITMENT_PAUSE,
         COMMITMENT_CANCEL,
         COMMITMENT_UPDATE_BULK,
@@ -83,6 +84,7 @@ public inherited sharing class PS_Request {
     public static String ENDPOINT_REFUND = '/v1/payments/verified/refund';
     public static String ENDPOINT_TRANSACTIONS = '/v1/payments/verified/transactions/{0}';
     public static String ENDPOINT_COMMITMENT = '/v1/payments/verified/commitments';
+    public static String ENDPOINT_COMMITMENT_GET = '/v1/payments/verified/commitments/{0}';
     public static String ENDPOINT_COMMITMENT_CANCEL = '/v1/payments/verified/commitments/{0}/cancel';
     public static String ENDPOINT_COMMITMENT_UPDATE_BULK = '/v1/payments/verified/commitments/update/bulk';
     public static String ENDPOINT_CREATE_ELEVATE_BATCH = '/v1/payments/verified/batch';
@@ -273,7 +275,13 @@ public inherited sharing class PS_Request {
                 );
             } else if (endpoint == ElevateEndpoint.COMMITMENT) {
                 value = ENDPOINT_COMMITMENT;
-
+            } else if (endpoint == ElevateEndpoint.COMMITMENT_GET) {
+                value = String.format(
+                    ENDPOINT_COMMITMENT_GET,
+                    new String[]{
+                        commitmentId
+                    }
+                );
             } else if (endpoint == ElevateEndpoint.COMMITMENT_PAUSE) {
                 value = String.format(
                     ENDPOINT_COMMITMENT_PAUSE,
@@ -458,6 +466,7 @@ public inherited sharing class PS_Request {
         private Boolean isCommitmentEndpoint () {
             return endpoint == ElevateEndpoint.COMMITMENT
                     || endpoint == ElevateEndpoint.COMMITMENT_CANCEL
+                    || endpoint == ElevateEndpoint.COMMITMENT_GET
                     || endpoint == ElevateEndpoint.COMMITMENT_UPDATE_BULK
                     || endpoint == ElevateEndpoint.COMMITMENT_PAUSE;
         }

--- a/force-app/main/default/classes/PS_Request_TEST.cls
+++ b/force-app/main/default/classes/PS_Request_TEST.cls
@@ -116,14 +116,14 @@ private with sharing class PS_Request_TEST {
         Test.startTest();
         HttpRequest request = new PS_Request.Builder()
             .withMethod(UTIL_Http.Method.GET)
-            .withEndpoint(PS_Request.ElevateEndpoint.COMMITMENT)
+            .withEndpoint(PS_Request.ElevateEndpoint.COMMITMENT_GET)
             .withCommitmentId(COMMITMENT_ID)
             .build();
         Test.stopTest();
 
         final String jsonRequestBody = '';
         final String expectedEndpoint = PS_IntegrationServiceConfig_TEST.testBaseUrl
-            + PS_Request.ENDPOINT_COMMITMENT;
+            + PS_Request.ENDPOINT_COMMITMENT + '/' + COMMITMENT_ID;
 
         assertRequest(request, expectedEndpoint, UTIL_Http.Method.GET, jsonRequestBody);
     }
@@ -144,6 +144,7 @@ private with sharing class PS_Request_TEST {
 
             } else if (endpoint == PS_Request.ElevateEndpoint.COMMITMENT
                 || endpoint == PS_Request.ElevateEndpoint.COMMITMENT_CANCEL
+                || endpoint == PS_Request.ElevateEndpoint.COMMITMENT_GET
                 || endpoint == PS_Request.ElevateEndpoint.COMMITMENT_PAUSE
                 || endpoint == PS_Request.ElevateEndpoint.COMMITMENT_UPDATE_BULK) {
 

--- a/force-app/main/default/classes/RD2_CancelCommitmentService.cls
+++ b/force-app/main/default/classes/RD2_CancelCommitmentService.cls
@@ -129,9 +129,9 @@ public without sharing class RD2_CancelCommitmentService {
                 request = PS_CommitmentRequest.buildRequest(closedRecord.rd.CommitmentId__c,
                     UTIL_Http.Method.POST, PS_Request.ElevateEndpoint.COMMITMENT_CANCEL);
             }
-            else if (getRequestType(closedRecord) == PS_Request.ElevateEndpoint.COMMITMENT) {
+            else if (getRequestType(closedRecord) == PS_Request.ElevateEndpoint.COMMITMENT_GET) {
                 request = PS_CommitmentRequest.buildRequest(closedRecord.rd.CommitmentId__c,
-                    UTIL_Http.Method.GET, PS_Request.ElevateEndpoint.COMMITMENT);
+                    UTIL_Http.Method.GET, PS_Request.ElevateEndpoint.COMMITMENT_GET);
             }
             response = requestService.sendRequest(request);
 
@@ -152,7 +152,7 @@ public without sharing class RD2_CancelCommitmentService {
         PS_Request.ElevateEndpoint requestType = PS_Request.ElevateEndpoint.COMMITMENT_CANCEL;
 
         if (hasPreviousTimeoutOrConflict(closedRecord)) {
-            requestType = PS_Request.ElevateEndpoint.COMMITMENT;
+            requestType = PS_Request.ElevateEndpoint.COMMITMENT_GET;
         }
 
         return requestType;


### PR DESCRIPTION
[W-11999572](https://gus.lightning.force.com/a07EE00001BMMjEYAX)
- Fixed Commitment `GET` requests by including the Id in the endpoint.
- We previously removed this Id, but it should only be removed for `POST` and `PATCH` Commitment requests.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
