### PR TITLE
W-12250612 - Fixed issue with BDI matching when using Dupe Mgmt

### DIFF
--- a/force-app/main/default/classes/BDI_ContactService.cls
+++ b/force-app/main/default/classes/BDI_ContactService.cls
@@ -355,12 +355,14 @@ public with sharing class BDI_ContactService {
         Boolean modelIsOneToOne = CAO_Constants.isOneToOne();
 
         for (DataImport__c di : bdi.listDI) {
+
             // skip di's that already have an error
             if (di.Status__c == BDI_DataImport_API.bdiFailed)
                 continue;
             List<String> listDiKey = listDIKeyCx(di, strCx);
+
             Contact con = ContactFromDiKeys(listDiKey);
-            
+
             Boolean bothContactsSpecified = (strCx == 'Contact1' && isContactSpecified(di, 'Contact2')) || 
                 (strCx == 'Contact2' && isContactSpecified(di, 'Contact1'));
 
@@ -371,6 +373,7 @@ public with sharing class BDI_ContactService {
                     && (con.Account.npe01__SYSTEM_AccountType__c != CAO_Constants.HH_ACCOUNT_TYPE);
                 Boolean usingAdvAccountOneToOne = usingAdv && contactAndAccountExist
                     && (con.Account.npe01__SYSTEM_AccountType__c == CAO_Constants.ONE_TO_ONE_ORGANIZATION_TYPE);
+
                 // Only Contacts with Household Accounts are allowed, unless Advancement is installed, 
                 // where One-to-one Accounts (Administrative in HEDA) are also valid
                 if (accountIsNotHousehold && !usingAdvAccountOneToOne) {
@@ -791,7 +794,12 @@ public with sharing class BDI_ContactService {
             listFName.add(con.Firstname.toLowerCase());
             addedToken = true;
         }
-        if (!addedToken || !isFirstnameInContactMatchRules)
+
+        // Only add a blank space to the matching set if the field was null, or if the field wasn't in the matching
+        // method name AND Contact Duplicate Rules matching is not enabled.  This is because adding a blank space 
+        // allows it to make a match without the value from this field, which we do not want for internal matching when
+        // Contact Duplicate Rules (aka Duplicate Management) is the selected matching method.
+        if (!addedToken || (!isFirstnameInContactMatchRules && !isDuplicateManagement))
             listFName.add('');
 
         addedToken = false;
@@ -799,7 +807,7 @@ public with sharing class BDI_ContactService {
             listLName.add(con.Lastname.toLowerCase());
             addedToken = true;
         }
-        if (!addedToken || !isLastnameInContactMatchRules)
+        if (!addedToken || (!isLastnameInContactMatchRules && !isDuplicateManagement))
             listLName.add('');
 
         addedToken = false;
@@ -819,7 +827,7 @@ public with sharing class BDI_ContactService {
             listEmail.add(con.npe01__AlternateEmail__c.toLowerCase());
             addedToken = true;
         }
-        if (!addedToken || !isEmailInContactMatchRules)
+        if (!addedToken || (!isEmailInContactMatchRules && !isDuplicateManagement))
             listEmail.add('');
 
         addedToken = false;
@@ -847,7 +855,7 @@ public with sharing class BDI_ContactService {
             listPhone.add(con.npe01__WorkPhone__c);
             addedToken = true;
         }
-        if (!addedToken || !isPhoneInContactMatchRules)
+        if (!addedToken || (!isPhoneInContactMatchRules && !isDuplicateManagement))
             listPhone.add('');
 
         Set<String> setDiKey = new Set<String>();
@@ -917,7 +925,12 @@ public with sharing class BDI_ContactService {
             listFName.add(String.valueOf(di.get(strCx + '_Firstname__c')).toLowerCase());
             addedToken = true;
         }
-        if (!isFirstnameInContactMatchRules || !addedToken) {
+
+        // Only add a blank space to the matching set if the field was null, or if the field wasn't in the matching
+        // method name AND Contact Duplicate Rules matching is not enabled.  This is because adding a blank space 
+        // allows it to make a match without the value from this field, which we do not want for internal matching when
+        // Contact Duplicate Rules (aka Duplicate Management) is the selected matching method.
+        if ((!isFirstnameInContactMatchRules && !isDuplicateManagement)  || !addedToken) {
             listFName.add('');
         }
 
@@ -926,7 +939,7 @@ public with sharing class BDI_ContactService {
             listLName.add(String.valueOf(di.get(strCx + '_Lastname__c')).toLowerCase());
             addedToken = true;
         }
-        if (!isLastnameInContactMatchRules || !addedToken) {
+        if ((!isLastnameInContactMatchRules && !isDuplicateManagement) || !addedToken) {
             listLName.add('');
         }
 
@@ -943,7 +956,7 @@ public with sharing class BDI_ContactService {
             listEmail.add(String.valueOf(di.get(strCx + '_Alternate_Email__c')).toLowerCase());
             addedToken = true;
         }
-        if (!isEmailInContactMatchRules || !addedToken) {
+        if ((!isEmailInContactMatchRules && !isDuplicateManagement) || !addedToken) {
             listEmail.add('');
         }
 
@@ -964,7 +977,7 @@ public with sharing class BDI_ContactService {
             listPhone.add(String.valueOf(di.get(strCx + '_Work_Phone__c')));
             addedToken = true;
         }
-        if (!isPhoneInContactMatchRules || !addedToken) {
+        if ((!isPhoneInContactMatchRules && !isDuplicateManagement) || !addedToken) {
             listPhone.add('');
         }
 

--- a/force-app/main/default/classes/BDI_ContactService_TEST.cls
+++ b/force-app/main/default/classes/BDI_ContactService_TEST.cls
@@ -132,7 +132,38 @@ private with sharing class BDI_ContactService_TEST {
             Home_Street__c = '300 Fake Blvd',
             Home_Zip_Postal_Code__c = '94105');
 
-        DataImport__c[] diList = new DataImport__c[]{testDi1,testDi2,testDi3};
+        // This record will test that it doesn't just match part of the contact data
+        DataImport__c testDi4 = new DataImport__c(
+            Contact1_Firstname__c = 'match1',
+            Contact1_Lastname__c = 'noMatch1',
+            Home_City__c = 'Fakeville',
+            Home_Country__c = 'United States',
+            Home_State_Province__c = 'California',
+            Home_Street__c = '300 Fake Blvd',
+            Home_Zip_Postal_Code__c = '94105');
+        
+        DataImport__c testDi5 = new DataImport__c(
+            Contact1_Firstname__c = 'FirstInternalMatch1',
+            Contact1_Lastname__c = 'LastInternalMatch1',
+            Contact1_Personal_Email__c = 'FirstInternalMatch1@fake.com',
+            Home_City__c = 'Fakeville',
+            Home_Country__c = 'United States',
+            Home_State_Province__c = 'California',
+            Home_Street__c = '300 Fake Blvd',
+            Home_Zip_Postal_Code__c = '94105');
+
+
+        DataImport__c testDi6 = new DataImport__c(
+            Contact1_Firstname__c = 'FirstInternalMatch1',
+            Contact1_Lastname__c = 'LastInternalMatch1',
+            Contact1_Personal_Email__c = 'FirstInternalMatch1@fake.com',
+            Home_City__c = 'Fakeville',
+            Home_Country__c = 'United States',
+            Home_State_Province__c = 'California',
+            Home_Street__c = '300 Fake Blvd',
+            Home_Zip_Postal_Code__c = '94105');
+
+        DataImport__c[] diList = new DataImport__c[]{testDi1,testDi2,testDi3,testDi4,testDi5,testDi6};
         insert diList;
 
         // Instantiate the Data Import and Contact services so we can test the Contact Service in isolation
@@ -175,10 +206,12 @@ private with sharing class BDI_ContactService_TEST {
         contService.dupeMgmtUtil = dupeMgmt;
 
         Test.startTest();
+        // Run the tests with dry run turned on first.
         contService.importContactsAndHouseholds();
-        Test.stopTest();
+        
 
-        // Confirm that the Import Status and Imported Fields for each DI are updated appropriately.
+        // Confirm that the Import Status and Imported Fields for each DI are updated appropriately
+        // for Dry run
         System.assertEquals(matchCont1.Id, testDi1.Contact1Imported__c);
         System.assert(testDi1.Contact1ImportStatus__c.contains(match1c.duplicateRuleName));
 
@@ -189,14 +222,87 @@ private with sharing class BDI_ContactService_TEST {
         System.assert(testDi2.Contact1ImportStatus__c.contains(match1c.duplicateRuleName));
 
         System.assertEquals(null, testDi2.Contact2Imported__c);
-        System.assertEquals(diService.statusMatchedNew(), testDi2.Contact2ImportStatus__c);
+        System.assertEquals(System.Label.bdiDryRunNoMatch, testDi2.Contact2ImportStatus__c);
 
         System.assertEquals(null, testDi3.Contact1Imported__c);
-        System.assertEquals(diService.statusMatchedNew(), testDi3.Contact1ImportStatus__c);
+        System.assertEquals(System.Label.bdiDryRunNoMatch, testDi3.Contact1ImportStatus__c);
 
         System.assertEquals(null, testDi3.Contact2Imported__c);
-        System.assertEquals(diService.statusMatchedNew(), testDi3.Contact2ImportStatus__c);
+        System.assertEquals(System.Label.bdiDryRunNoMatch, testDi3.Contact2ImportStatus__c);
+
+        System.assertEquals(null, testDi4.Contact1Imported__c);
+        System.assertEquals(System.Label.bdiDryRunNoMatch,testDi4.Contact1ImportStatus__c);
+
+        System.assertEquals(null, testDi5.Contact1Imported__c);
+        System.assertEquals(System.Label.bdiDryRunNoMatch,testDi5.Contact1ImportStatus__c);
+
+        System.assertEquals(null, testDi6.Contact1Imported__c);
+        System.assertEquals(System.Label.bdiDryRunNoMatch,testDi6.Contact1ImportStatus__c);
+
         
+        // Now re-run the same records in normal mode (no dry run).  
+        
+        // Reset the status and Imported fields to simulate them not having already been matched.
+        for (DataImport__c di: diList) {
+            di.Contact1Imported__c = null;
+            di.Contact1ImportStatus__c = null;
+            di.Contact2Imported__c = null;
+            di.Contact2ImportStatus__c = null;
+        }
+        
+        BDI_DataImportService diService2 = new BDI_DataImportService(false,mapService);
+        diService2.listDI = diList;
+        diService2.injectDataImportSettings(dis);
+        BDI_ContactService contService2 = new BDI_ContactService(diService2);
+        contService2.dupeMgmtUtil = dupeMgmt;
+
+        contService2.importContactsAndHouseholds();
+
+        Set<Id> existingContSet = new Set<Id>{matchCont1.Id,matchCont2.Id};
+
+        // DI contact should match on existing contact record
+        System.assertEquals(matchCont1.Id, testDi1.Contact1Imported__c);
+        System.assert(testDi1.Contact1ImportStatus__c.contains(match1c.duplicateRuleName));
+
+        // DI contact should match on existing contact record
+        System.assertEquals(matchCont2.Id, testDi1.Contact2Imported__c);
+        System.assert(testDi1.Contact2ImportStatus__c.contains(match2.duplicateRuleName));
+
+        // DI contact should match on existing contact record
+        System.assertEquals(matchCont1.Id, testDi2.Contact1Imported__c);
+        System.assert(testDi2.Contact1ImportStatus__c.contains(match1c.duplicateRuleName));
+        
+        // DI should create contact since it doesn't match
+        System.assertNotEquals(null, testDi2.Contact2Imported__c);
+        System.assert(!existingContSet.contains(testDi2.Contact2Imported__c));
+        System.assertEquals(System.Label.bdiCreated, testDi2.Contact2ImportStatus__c);
+
+        // DI should create contact since it doesn't match
+        System.assertNotEquals(null, testDi3.Contact1Imported__c);
+        System.assert(!existingContSet.contains(testDi3.Contact1Imported__c));
+        System.assertEquals(System.Label.bdiCreated, testDi3.Contact1ImportStatus__c);
+
+        // DI should create contact since it doesn't match
+        System.assertNotEquals(null, testDi3.Contact2Imported__c);
+        System.assert(!existingContSet.contains(testDi3.Contact2Imported__c));
+        System.assertEquals(System.Label.bdiCreated, testDi3.Contact2ImportStatus__c);
+        
+        // DI should create contact since it doesn't match
+        System.assertNotEquals(null, testDi4.Contact1Imported__c);
+        System.assert(!existingContSet.contains(testDi4.Contact1Imported__c));
+        System.assertEquals(System.Label.bdiCreated,testDi4.Contact1ImportStatus__c);
+        
+        // DI should create contact since it doesn't match
+        System.assertNotEquals(null, testDi5.Contact1Imported__c);
+        System.assert(!existingContSet.contains(testDi5.Contact1Imported__c));
+        System.assertEquals(System.Label.bdiCreated,testDi5.Contact1ImportStatus__c);
+        
+        // Confirm that the contact in the second identical DI is marked as matched,
+        // and has the same id as the first identical DI.
+        System.assertEquals(testDi5.Contact1Imported__c, testDi6.Contact1Imported__c);
+        System.assertEquals(System.Label.bdiMatched,testDi6.Contact1ImportStatus__c);
+
+        Test.stopTest();
     }
 
     /**


### PR DESCRIPTION
WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001HsNBvYAN/view

This fixes incorrect internal matches with BDI matching when using the 'Contact Duplicate Rules' (aka Duplicate Management) option.  Essentially if you had two Data Import records with any one of the 4 pieces of contact information used for matching (first name, last name, email, phone) matching, then it would match the two records together incorrectly and only create one new contact.  It should only match internally like that if all the pieces of contact information match.

The cause of the issue was that because the Contact matching rule name didn't include the name of any of the fields used for matching, it was creating a key for matching for each field with just the field populated and all others blank.  This meant that if any of these contact fields matched, the whole contact would be matched (which is very problematic for things like first name).

The fix was to basically make sure that if Duplicate Management was enabled, then it should never include a blank value unless the contact field was actually blank.

Also updated the test class to test the partial contact match scenario and the exact internal duplicate match scenario.  Also added tests for non-dry run scenarios.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
