### PR TITLE
W-12632596 - Fix unit test for Recurring Donation Pause

### DIFF
--- a/force-app/main/default/classes/RD2_ApiService_TEST.cls
+++ b/force-app/main/default/classes/RD2_ApiService_TEST.cls
@@ -515,7 +515,7 @@ private class RD2_ApiService_TEST {
     private static void shouldReturnErrorForPauseWhenEndDateIsMoreThanTwelveMonthsAfterStartDate() {
         npe03__Recurring_Donation__c rd = rdGateway.getRecords()[0];
         RD2_ApiService.PauseObject pauseObject = createPauseObjectWithDetail(
-            Date.today(), Date.today().addDays(367), 'Vacation');
+            Date.today(), Date.today().addYears(1).addDays(2), 'Vacation');
 
         new RD2_ApiService().isValidPauseData(rd.Id, pauseObject, new RD2_RecurringDonation(rd));
 


### PR DESCRIPTION
WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001MKoUGYA1/view

- Changing the test setup for this unit test to use .addyear() and .addDay() instead of a fixed number of days that it works with leap years.

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
