### PR TITLE
NPSP Potential Duplicates

### DIFF
--- a/force-app/main/default/classes/CON_ContactMerge_CTRL.cls
+++ b/force-app/main/default/classes/CON_ContactMerge_CTRL.cls
@@ -185,6 +185,12 @@ public with sharing class CON_ContactMerge_CTRL {
     public Map<Id, Integer> contactCountByDuplicateRecordSetId { get; set; }
 
     /***********************************************************************************************
+     * @description A Set of Contact Ids passed into Contact Merge that can be used to 
+     * return search results
+     */
+    private Set<Id> contactIdsToSearch;
+
+    /***********************************************************************************************
     * @description Checks whether there are more records to display on next page in pagination  
     * implemented on Duplicate Record Set diplay page.
     */
@@ -466,6 +472,25 @@ public with sharing class CON_ContactMerge_CTRL {
                 //if we got any ids, use to try and enter the merge selected records page
                 if (mergeIds != null) {
                     loadMergeCandidates(mergeIds);
+                    if(!ApexPages.hasMessages()) {
+                        showDRSButton = false;
+                        showContactSearch = true;
+                    }
+                }
+            }
+            catch(StringException e){
+                ApexPages.addMessages(e);
+            }
+        }
+        //otherwise, check for a searchIds parameter, which should contain a comma separated list 
+        //of Ids to search
+        else if(ApexPages.CurrentPage().getParameters().containsKey('searchIds') && 
+            ApexPages.CurrentPage().getParameters().get('searchIds') != '') {
+            try {
+                contactIdsToSearch = new set<Id>((list<Id>)ApexPages.CurrentPage().getParameters()
+                    .get('searchIds').split(','));
+                if (contactIdsToSearch != null) {
+                    search();
                     if(!ApexPages.hasMessages()) {
                         showDRSButton = false;
                         showContactSearch = true;
@@ -917,6 +942,8 @@ public with sharing class CON_ContactMerge_CTRL {
             //build the SOSL query and execute - NOTE: * wildcard will only have effect at the
             //middle or end of the search term
             return mergeSelector.selectContactsByName(searchText);
+        } else if(contactIdsToSearch != null) {
+            return mergeSelector.selectContactsById(contactIdsToSearch);
         } else {
             return mergeSelector.selectDuplicateRecordSetById(drsRecordId, driFieldNames);
         }

--- a/force-app/main/default/classes/CON_ContactMerge_CTRL.cls
+++ b/force-app/main/default/classes/CON_ContactMerge_CTRL.cls
@@ -490,9 +490,9 @@ public with sharing class CON_ContactMerge_CTRL {
                 contactIdsToSearch = new set<Id>((list<Id>)ApexPages.CurrentPage().getParameters()
                     .get('searchIds').split(','));
                 if (contactIdsToSearch != null) {
+                    loadMergePage = true;
                     search();
                     if(!ApexPages.hasMessages()) {
-                        showDRSButton = false;
                         showContactSearch = true;
                     }
                 }

--- a/force-app/main/default/classes/PotentialDuplicates.cls
+++ b/force-app/main/default/classes/PotentialDuplicates.cls
@@ -1,29 +1,39 @@
 public with sharing class PotentialDuplicates {
 
-    private static final String DUPLICATE_COUNT_KEY = 'duplicateCount';
+    private static final String SET_OF_MATCHES_KEY = 'setOfMatches';
 
     @AuraEnabled
     public static Map<String, Object> getDuplicates(Id recordId) {
-        Map<String, Object> duplicateCount = new Map<String, Object>{ DUPLICATE_COUNT_KEY => 0 };
+        Map<String, Object> returnParams = new Map<String, Object>{ SET_OF_MATCHES_KEY => null };
 
         try {
-            duplicateCount.put(DUPLICATE_COUNT_KEY, getDuplicateCount(recordId));
+            returnParams.put(SET_OF_MATCHES_KEY, getDuplicateList(recordId));
         }
         catch (Exception e) {
         }
 
-        return duplicateCount;
+        return returnParams;
     }
 
-    private static Integer getDuplicateCount(Id recordId) {
-        Integer duplicateCount = 0;
+    private static String getDuplicateList(Id recordId) {
+        String strSetOfMatches = '';
 
-        List<Datacloud.FindDuplicatesResult> duplicateResults =
+        Set<String> setOfMatchIds = new Set<String>();
+        List<Datacloud.FindDuplicatesResult> results =
                 Datacloud.FindDuplicatesByIds.findDuplicatesByIds(new List<Id>{recordId});
-        if (duplicateResults?.size() > 0) {
-            duplicateCount = duplicateResults[0].getDuplicateResults()[0].getMatchResults()[0].size;
+        for (Datacloud.FindDuplicatesResult findDupeResult : results) {
+            for (Datacloud.DuplicateResult dupeResult : findDupeResult.getDuplicateResults()) {
+                for (Datacloud.MatchResult matchResult : dupeResult.getMatchResults()) {
+                    for (Datacloud.MatchRecord matchRecord : matchResult.getMatchRecords()) {
+                        setOfMatchIds.add(matchRecord.getRecord().Id);
+                    }
+                }
+            }
+        }
+        for (String matchId : setOfMatchIds) {
+            strSetOfMatches += (strSetOfMatches == '' ? '' : ',') + matchId;
         }
 
-        return duplicateCount;
+        return strSetOfMatches;
     }
 }

--- a/force-app/main/default/classes/PotentialDuplicates.cls
+++ b/force-app/main/default/classes/PotentialDuplicates.cls
@@ -1,0 +1,29 @@
+public with sharing class PotentialDuplicates {
+
+    private static final String DUPLICATE_COUNT_KEY = 'duplicateCount';
+
+    @AuraEnabled
+    public static Map<String, Object> getDuplicates(Id recordId) {
+        Map<String, Object> duplicateCount = new Map<String, Object>{ DUPLICATE_COUNT_KEY => 0 };
+
+        try {
+            duplicateCount.put(DUPLICATE_COUNT_KEY, getDuplicateCount(recordId));
+        }
+        catch (Exception e) {
+        }
+
+        return duplicateCount;
+    }
+
+    private static Integer getDuplicateCount(Id recordId) {
+        Integer duplicateCount = 0;
+
+        List<Datacloud.FindDuplicatesResult> duplicateResults =
+                Datacloud.FindDuplicatesByIds.findDuplicatesByIds(new List<Id>{recordId});
+        if (duplicateResults?.size() > 0) {
+            duplicateCount = duplicateResults[0].getDuplicateResults()[0].getMatchResults()[0].size;
+        }
+
+        return duplicateCount;
+    }
+}

--- a/force-app/main/default/classes/PotentialDuplicates.cls-meta.xml
+++ b/force-app/main/default/classes/PotentialDuplicates.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>53.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/PotentialDuplicates.cls-meta.xml
+++ b/force-app/main/default/classes/PotentialDuplicates.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PotentialDuplicates_TEST.cls
+++ b/force-app/main/default/classes/PotentialDuplicates_TEST.cls
@@ -1,0 +1,53 @@
+@IsTest(IsParallel=false)
+private with sharing class PotentialDuplicates_TEST {
+
+    @TestSetup
+    private static void setUp() {
+
+    }
+
+    @IsTest
+    private static void shouldReturnZeroWhenNoDuplicatesAreFound() {
+
+    }
+
+    @IsTest
+    private static void shouldReturnZeroWhenNoMatchingRulesAreActive() {
+
+    }
+
+    @IsTest
+    private static void shouldReturnOneWhenOneDuplicateIsFound() {
+
+    }
+
+    @IsTest
+    private static void shouldReturnTwoWhenTwoDuplicatesAreFound() {
+
+    }
+
+    @IsTest
+    private static void shouldDisplayToastWhenToastIsConfigured() {
+
+    }
+
+    @IsTest
+    private static void shouldNotDisplayToastWhenToastIsNotConfigured() {
+
+    }
+
+    @IsTest
+    private static void shouldDisplayCardWhenCardIsConfigured() {
+
+    }
+
+    @IsTest
+    private static void shouldNotDisplayCardWhenCardIsNotConfigured() {
+
+    }
+
+    @IsTest
+    private static void shouldDisplayErrorMessageWhenExceptionEncountered() {
+
+    }
+}

--- a/force-app/main/default/classes/PotentialDuplicates_TEST.cls
+++ b/force-app/main/default/classes/PotentialDuplicates_TEST.cls
@@ -1,53 +1,28 @@
 @IsTest(IsParallel=false)
 private with sharing class PotentialDuplicates_TEST {
 
-    @TestSetup
-    private static void setUp() {
-
+    @IsTest
+    private static void shouldReturnNullWhenNoDuplicatesAreFound() {
+        Id recordId = UTIL_UnitTestData_TEST.mockId(Contact.getSObjectType());
+        Map<String, Object> data = PotentialDuplicates.getDuplicates(recordId);
+        System.assertEquals('', data.get('setOfMatches'),
+            'There should be no duplicates');
     }
 
     @IsTest
-    private static void shouldReturnZeroWhenNoDuplicatesAreFound() {
+    private static void shouldReturnIdsWhenDuplicatesAreFound() {
+        List<Contact> contactList = UTIL_UnitTestData_TEST.getContacts(3);
+        for(Contact c : contactList) {
+            c.FirstName = 'Test';
+            c.LastName = 'LastName';
+            c.Email = 'tester@example.com';
+        }
+        insert contactList;
 
-    }
-
-    @IsTest
-    private static void shouldReturnZeroWhenNoMatchingRulesAreActive() {
-
-    }
-
-    @IsTest
-    private static void shouldReturnOneWhenOneDuplicateIsFound() {
-
-    }
-
-    @IsTest
-    private static void shouldReturnTwoWhenTwoDuplicatesAreFound() {
-
-    }
-
-    @IsTest
-    private static void shouldDisplayToastWhenToastIsConfigured() {
-
-    }
-
-    @IsTest
-    private static void shouldNotDisplayToastWhenToastIsNotConfigured() {
-
-    }
-
-    @IsTest
-    private static void shouldDisplayCardWhenCardIsConfigured() {
-
-    }
-
-    @IsTest
-    private static void shouldNotDisplayCardWhenCardIsNotConfigured() {
-
-    }
-
-    @IsTest
-    private static void shouldDisplayErrorMessageWhenExceptionEncountered() {
-
+        Map<String, Object> data = PotentialDuplicates.getDuplicates(contactList[0].Id);
+        String setOfMatches = (String)data.get('setOfMatches');
+        System.assertNotEquals('', setOfMatches, 'Duplicate Ids should be returned');
+        Integer numberOfMatches = setOfMatches.split(',').size();
+        System.assertEquals(2, numberOfMatches, 'There should be 2 duplicates returned');
     }
 }

--- a/force-app/main/default/classes/PotentialDuplicates_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PotentialDuplicates_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>53.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/PotentialDuplicates_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/PotentialDuplicates_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>53.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -12699,6 +12699,30 @@ If preferred, you can disable Gift Entry and instead use older Batch Gift Entry 
         <value>A written off Payment must have a Payment Date.</value>
     </labels>
     <labels>
+        <fullName>potentialDuplicatesFoundNone</fullName>
+        <categories>Potential Duplicates</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>No duplicates found</shortDescription>
+        <value>We found no potential duplicates of this Contact.</value>
+    </labels>
+    <labels>
+        <fullName>potentialDuplicatesFoundOne</fullName>
+        <categories>Potential Duplicates</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>One potential duplicate found</shortDescription>
+        <value>We found 1 potential duplicate of this Contact.</value>
+    </labels>
+    <labels>
+        <fullName>potentialDuplicatesFoundMultiple</fullName>
+        <categories>Potential Duplicates</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Number of potential duplicates found</shortDescription>
+        <value>We found {0} potential duplicates of this Contact.</value>
+    </labels>
+    <labels>
         <fullName>psACH</fullName>
         <categories>Payment Gateway Management</categories>
         <language>en_US</language>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -16420,4 +16420,12 @@ Note: The NPSP Settings tab is visible in the Nonprofit Success Pack application
         <shortDescription>Label for modifications on Recurring Donations</shortDescription>
         <value>Update Recurring Donation</value>
     </labels>
+    <labels>
+        <fullName>viewDuplicates</fullName>
+        <categories>Potential Duplicates</categories>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Label for View Duplicates link</shortDescription>
+        <value>View Duplicates</value>
+    </labels>
 </CustomLabels>

--- a/force-app/main/default/lwc/potentialDuplicates/__tests__/potentialDuplicates.test.js
+++ b/force-app/main/default/lwc/potentialDuplicates/__tests__/potentialDuplicates.test.js
@@ -1,37 +1,79 @@
 import { createElement } from 'lwc';
 import PotentialDuplicates from 'c/potentialDuplicates';
+import getDuplicates from '@salesforce/apex/PotentialDuplicates.getDuplicates';
 import lblPotentialDuplicatesFoundNone from '@salesforce/label/c.potentialDuplicatesFoundNone';
 import lblPotentialDuplicatesFoundOne from '@salesforce/label/c.potentialDuplicatesFoundOne';
 import lblPotentialDuplicatesFoundMultiple from '@salesforce/label/c.potentialDuplicatesFoundMultiple';
+import lblViewDuplicates from '@salesforce/label/c.viewDuplicates';
 
-const createComponentForTest = (config = {}) => {
+jest.mock('@salesforce/apex/PotentialDuplicates.getDuplicates',
+    () => ({ default : jest.fn() }),
+    { virtual: true }
+);
+
+const createComponentForTest = () => {
     const el = createElement('c-potential-duplicates', {
         is: PotentialDuplicates
     });
-    Object.assign(el, config);
+    Object.assign(el);
+    el.recordId = 'fakeId';
     el.displayCard = true;
     document.body.appendChild(el);
     return el;
 };
 
-describe('c-potential-duplicates', () => {
-    it('renders the component with no link', () => {
-       const component = createComponentForTest();
+describe('Potential Duplicates Component', () => {
 
-    //    const duplicateLink = component.shadowRoot.querySelector('data-qa-locator="viewDuplicatesURL"');
-       const heading = component.shadowRoot.querySelector('h1');
-       expect(heading.textContent).toBe(lblPotentialDuplicatesFoundNone);
-       const duplicateLink = component.shadowRoot.querySelector('[data-qa-locator="viewDuplicatesURL"]');
-       expect(duplicateLink).toBeFalsy();
+    afterEach(() => {
+        clearDOM();
+        jest.clearAllMocks();
     });
-    it('renders the component with a duplicate link', () => {
-        
-        // TODO: Mock getDuplicates to return a string
-        const component = createComponentForTest();
- 
-        const heading = component.shadowRoot.querySelector('h1');
+
+    it('renders the component with no link', async () => {
+        getDuplicates.mockResolvedValue({});
+        const el = createComponentForTest();
+        await flushPromises();
+
+        const heading = el.shadowRoot.querySelector('h1');
+        expect(heading.textContent).toBe(lblPotentialDuplicatesFoundNone);
+        const duplicateLink = el.shadowRoot.querySelector('[data-qa-locator="viewDuplicatesURL"]');
+        expect(duplicateLink).toBeFalsy();
+    });
+
+    it('renders the component with a duplicate link', async () => {
+        getDuplicates.mockResolvedValue({"setOfMatches" : "anotherId"});
+        const el = createComponentForTest();
+        await flushPromises();
+
+        expect(getDuplicates).toHaveBeenCalled();
+        const heading = el.shadowRoot.querySelector('h1');
         expect(heading.textContent).toBe(lblPotentialDuplicatesFoundOne);
-        const duplicateLink = component.shadowRoot.querySelector('[data-qa-locator="viewDuplicatesURL"]');
-        expect(duplicateLink).toBeTruthy();
+        const duplicateLink = el.shadowRoot.querySelector('[data-qa-locator="viewDuplicatesURL"] a');
+        expect(duplicateLink).not.toBeNull();
+        expect(duplicateLink.textContent).toBe(lblViewDuplicates);
      });
+
+     it('text changes for multiple duplicates', async () => {
+        getDuplicates.mockResolvedValue({"setOfMatches" : "anotherId,moreIds,lastId"});
+        const el = createComponentForTest();
+        await flushPromises();
+
+        expect(getDuplicates).toHaveBeenCalled();
+        const heading = el.shadowRoot.querySelector('h1');
+        expect(heading.textContent).toBe(lblPotentialDuplicatesFoundMultiple);
+        const duplicateLink = el.shadowRoot.querySelector('[data-qa-locator="viewDuplicatesURL"] a');
+        expect(duplicateLink).not.toBeNull();
+        expect(duplicateLink.textContent).toBe(lblViewDuplicates);
+     });
+
+     it('renders an error when callout fails', async () => {
+        getDuplicates.mockRejectedValue({"status" : "fail", "body" : {"message" : "test"}});
+        const el = createComponentForTest();
+        await flushPromises();
+
+        const heading = el.shadowRoot.querySelector('h1');
+        expect(heading.textContent).toBe(lblPotentialDuplicatesFoundNone);
+        const error = el.shadowRoot.querySelector('[data-qa-locator="error"]');
+        expect(error).not.toBeNull();
+    });
 })

--- a/force-app/main/default/lwc/potentialDuplicates/__tests__/potentialDuplicates.test.js
+++ b/force-app/main/default/lwc/potentialDuplicates/__tests__/potentialDuplicates.test.js
@@ -1,0 +1,37 @@
+import { createElement } from 'lwc';
+import PotentialDuplicates from 'c/potentialDuplicates';
+import lblPotentialDuplicatesFoundNone from '@salesforce/label/c.potentialDuplicatesFoundNone';
+import lblPotentialDuplicatesFoundOne from '@salesforce/label/c.potentialDuplicatesFoundOne';
+import lblPotentialDuplicatesFoundMultiple from '@salesforce/label/c.potentialDuplicatesFoundMultiple';
+
+const createComponentForTest = (config = {}) => {
+    const el = createElement('c-potential-duplicates', {
+        is: PotentialDuplicates
+    });
+    Object.assign(el, config);
+    el.displayCard = true;
+    document.body.appendChild(el);
+    return el;
+};
+
+describe('c-potential-duplicates', () => {
+    it('renders the component with no link', () => {
+       const component = createComponentForTest();
+
+    //    const duplicateLink = component.shadowRoot.querySelector('data-qa-locator="viewDuplicatesURL"');
+       const heading = component.shadowRoot.querySelector('h1');
+       expect(heading.textContent).toBe(lblPotentialDuplicatesFoundNone);
+       const duplicateLink = component.shadowRoot.querySelector('[data-qa-locator="viewDuplicatesURL"]');
+       expect(duplicateLink).toBeFalsy();
+    });
+    it('renders the component with a duplicate link', () => {
+        
+        // TODO: Mock getDuplicates to return a string
+        const component = createComponentForTest();
+ 
+        const heading = component.shadowRoot.querySelector('h1');
+        expect(heading.textContent).toBe(lblPotentialDuplicatesFoundOne);
+        const duplicateLink = component.shadowRoot.querySelector('[data-qa-locator="viewDuplicatesURL"]');
+        expect(duplicateLink).toBeTruthy();
+     });
+})

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.css
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.css
@@ -1,0 +1,3 @@
+.wrapped-content{
+    text-wrap: wrap;
+}

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.html
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.html
@@ -1,0 +1,19 @@
+<template>
+    <template lwc:if={isEnabled}>
+
+        <lightning-card variant="narrow" icon-name="standard:merge">
+            <h1 slot="title" class="wrapped-content">{lblTitle}</h1>
+
+            <div class="slds-m-around_xxx-small" lwc:if={viewDuplicatesURL} data-qa-locator="viewDuplicatesURL">
+                <a href={viewDuplicatesURL} target="_self">View Duplicates</a>
+            </div>
+
+            <div class="slds-m-around_medium" lwc:if={error} data-qa-locator="error">
+                <span class="slds-text-color_error">{error}</span>
+            </div>
+
+        </lightning-card>
+
+
+    </template>
+</template>

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.html
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.html
@@ -1,19 +1,13 @@
 <template>
-    <template lwc:if={isEnabled}>
-
+    <template lwc:if={displayCard}>
         <lightning-card variant="narrow" icon-name="standard:merge">
             <h1 slot="title" class="wrapped-content">{lblTitle}</h1>
-
-            <div class="slds-m-around_xxx-small" lwc:if={viewDuplicatesURL} data-qa-locator="viewDuplicatesURL">
-                <a href={viewDuplicatesURL} target="_self">View Duplicates</a>
-            </div>
-
-            <div class="slds-m-around_medium" lwc:if={error} data-qa-locator="error">
+            <p class="slds-m-around_medium" lwc:if={viewDuplicatesURL} data-qa-locator="viewDuplicatesURL">
+                <a onclick={navigateToContactMerge}>View Duplicates</a>
+            </p>
+            <p class="slds-m-around_medium" lwc:if={error} data-qa-locator="error">
                 <span class="slds-text-color_error">{error}</span>
-            </div>
-
+            </p>
         </lightning-card>
-
-
     </template>
 </template>

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.html
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.html
@@ -2,10 +2,10 @@
     <template lwc:if={displayCard}>
         <lightning-card variant="narrow" icon-name="standard:merge">
             <h1 slot="title" class="wrapped-content">{lblTitle}</h1>
-            <p class="slds-m-around_medium" lwc:if={viewDuplicatesURL} data-qa-locator="viewDuplicatesURL">
-                <a onclick={navigateToContactMerge}>View Duplicates</a>
+            <p class="slds-var-m-left_xx-large" lwc:if={viewDuplicatesURL} data-qa-locator="viewDuplicatesURL">
+                <a class="slds-var-m-left_xx-small" onclick={navigateToContactMerge}>{lblViewDuplicatesLink}</a>
             </p>
-            <p class="slds-m-around_medium" lwc:if={error} data-qa-locator="error">
+            <p class="slds-var-m-left_xx-large" lwc:if={error} data-qa-locator="error">
                 <span class="slds-text-color_error">{error}</span>
             </p>
         </lightning-card>

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
@@ -1,4 +1,4 @@
-import { LightningElement, api, wire, track } from 'lwc';
+import { LightningElement, api, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import { showToast } from 'c/utilCommon';
 
@@ -38,8 +38,8 @@ export default class PotentialDuplicates extends NavigationMixin(LightningElemen
     handleDuplicates(response) {
         this.duplicateCount = 0;
         if (response && response.setOfMatches) {
-            this.duplicateCount = response.setOfMatches.split(',').length;
             this.duplicateIdsParam = this.recordId + ',' + response.setOfMatches;
+            this.duplicateCount = response.setOfMatches.split(',').length;
         }
         this.generateDuplicatesURL();
         this.updateTitle();

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
@@ -11,7 +11,7 @@ import lblPotentialDuplicatesFoundMultiple from '@salesforce/label/c.potentialDu
 
 import getDuplicates from '@salesforce/apex/PotentialDuplicates.getDuplicates';
 
-export default class PotentialDuplicates extends LightningElement {
+export default class PotentialDuplicates extends NavigationMixin(LightningElement) {
 
     @api recordId;
     @api displayCard;
@@ -43,10 +43,10 @@ export default class PotentialDuplicates extends LightningElement {
     }
 
     handleDuplicates(response) {
-        console.log('handleDuplicates');
         this.duplicateCount = 0;
-        if (response && response.duplicateCount) {
-            this.duplicateCount = response.duplicateCount;
+        if (response && response.setOfMatches) {
+            this.duplicateCount = response.setOfMatches.split(',').length;
+            this.duplicateIdsParam = this.recordId + ',' + response.setOfMatches;
         }
         this.updateTitle();
         this.handleToast();
@@ -88,11 +88,22 @@ export default class PotentialDuplicates extends LightningElement {
 
     generateDuplicatesURL() {
         if (this.duplicateCount > 0) {
-            this.viewDuplicatesURL = "/lightning/n/Contact_Merge?npsp__searchDuplicateId=" + this.recordId;
+            this.viewDuplicatesURL = "/apex/CON_ContactMerge?searchIds=" + this.duplicateIdsParam;
         }
         else {
             this.viewDuplicatesURL = '';
         }
+    }
+
+    navigateToContactMerge() {
+        this[NavigationMixin.GenerateUrl]({
+            type: 'standard__webPage',
+            attributes: {
+                url: this.viewDuplicatesURL
+            }
+        }).then(generatedUrl => {
+            window.location.assign(generatedUrl);
+        });
     }
 
     get viewDuplicatesURL() {

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
@@ -1,0 +1,103 @@
+import { LightningElement, api, wire, track } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import { NavigationMixin } from 'lightning/navigation';
+import { showToast } from 'c/utilCommon';
+
+import FIELD_NAME from '@salesforce/schema/Contact.Name';
+
+import lblPotentialDuplicatesFoundNone from '@salesforce/label/c.potentialDuplicatesFoundNone';
+import lblPotentialDuplicatesFoundOne from '@salesforce/label/c.potentialDuplicatesFoundOne';
+import lblPotentialDuplicatesFoundMultiple from '@salesforce/label/c.potentialDuplicatesFoundMultiple';
+
+import getDuplicates from '@salesforce/apex/PotentialDuplicates.getDuplicates';
+
+export default class PotentialDuplicates extends LightningElement {
+
+    @api recordId;
+    @api displayCard;
+    @api displayToast;
+
+    @track isEnabled = true;
+    @track duplicateCount;
+    @track error;
+    @track lblTitle = lblPotentialDuplicatesFoundNone;
+    @track viewDuplicatesURL;
+
+    @wire(getRecord, {
+        recordId: '$recordId',
+        fields: [ FIELD_NAME ]
+    })
+    wireRecordChange() {
+        if (this.recordId) {
+            console.log('wireRecordChange');
+            getDuplicates({ recordId: this.recordId })
+                .then(response => {
+                    this.handleDuplicates(response);
+                    this.error = null;
+                })
+                .catch(error => {
+                    this.schedules = null;
+                    this.error = this.handleError(error);
+                });
+        }
+    }
+
+    handleDuplicates(response) {
+        console.log('handleDuplicates');
+        this.duplicateCount = 0;
+        if (response && response.duplicateCount) {
+            this.duplicateCount = response.duplicateCount;
+        }
+        this.updateTitle();
+        this.handleToast();
+    }
+
+    handleError(error) {
+        if (error && error.status && error.body) {
+            return error.body.message;
+        } else if (error && error.name && error.message) {
+            return error.message;
+        } else {
+            return "";
+        }
+    }
+
+    handleToast() {
+        let messageData = [{
+            "url": this.viewDuplicatesURL,
+            "label": "View Duplicates",
+        }];
+        showToast("", this.lblTitle + " {0}", "info", "sticky", messageData);
+    }
+
+    updateTitle() {
+        switch (this.duplicateCount) {
+            case 0:
+                this.lblTitle = lblPotentialDuplicatesFoundNone;
+                break;
+            case 1:
+                this.lblTitle = lblPotentialDuplicatesFoundOne;
+                break;
+            default:
+                this.lblTitle = lblPotentialDuplicatesFoundMultiple.replace("{0}", this.duplicateCount.toString());
+        }
+        this.generateDuplicatesURL();
+    }
+
+    generateDuplicatesURL() {
+        if (this.duplicateCount > 0) {
+            this.viewDuplicatesURL = "/lightning/n/Contact_Merge?npsp__searchDuplicateId=0039A00000J8yYQQAZ";
+        }
+        else {
+            this.viewDuplicatesURL = '';
+        }
+    }
+
+    get viewDuplicatesURL() {
+        return this.viewDuplicatesURL;
+    }
+
+    get lblTitle() {
+        return this.lblTitle;
+    }
+}

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
@@ -86,7 +86,7 @@ export default class PotentialDuplicates extends LightningElement {
 
     generateDuplicatesURL() {
         if (this.duplicateCount > 0) {
-            this.viewDuplicatesURL = "/lightning/n/Contact_Merge?npsp__searchDuplicateId=0039A00000J8yYQQAZ";
+            this.viewDuplicatesURL = "/lightning/n/Contact_Merge?npsp__searchDuplicateId=" + this.recordId;
         }
         else {
             this.viewDuplicatesURL = '';

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
@@ -1,6 +1,6 @@
 import { LightningElement, api, track } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
-import { showToast } from 'c/utilCommon';
+import { getCurrentNamespace, showToast } from 'c/utilCommon';
 
 import lblPotentialDuplicatesFoundNone from '@salesforce/label/c.potentialDuplicatesFoundNone';
 import lblPotentialDuplicatesFoundOne from '@salesforce/label/c.potentialDuplicatesFoundOne';
@@ -80,7 +80,10 @@ export default class PotentialDuplicates extends NavigationMixin(LightningElemen
 
     generateDuplicatesURL() {
         if (this.duplicateCount > 0) {
-            this.viewDuplicatesURL = "/apex/CON_ContactMerge?searchIds=" + this.duplicateIdsParam;
+            const contactMerge = 'CON_ContactMerge';
+            const namespace = getCurrentNamespace();
+            const contactMergePage = namespace ? `${namespace}__${contactMerge}` : contactMerge;
+            this.viewDuplicatesURL = "/apex/" + contactMergePage + "?searchIds=" + this.duplicateIdsParam;
         }
         else {
             this.viewDuplicatesURL = "";

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
@@ -63,11 +63,13 @@ export default class PotentialDuplicates extends LightningElement {
     }
 
     handleToast() {
-        let messageData = [{
-            "url": this.viewDuplicatesURL,
-            "label": "View Duplicates",
-        }];
-        showToast("", this.lblTitle + " {0}", "info", "sticky", messageData);
+        if (this.duplicateCount > 0) {
+            let messageData = [{
+                "url": this.viewDuplicatesURL,
+                "label": "View Duplicates",
+            }];
+            showToast("", this.lblTitle + " {0}", "info", "sticky", messageData);
+        }
     }
 
     updateTitle() {

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js
@@ -1,9 +1,6 @@
 import { LightningElement, api, wire, track } from 'lwc';
-import { getRecord } from 'lightning/uiRecordApi';
 import { NavigationMixin } from 'lightning/navigation';
 import { showToast } from 'c/utilCommon';
-
-import FIELD_NAME from '@salesforce/schema/Contact.Name';
 
 import lblPotentialDuplicatesFoundNone from '@salesforce/label/c.potentialDuplicatesFoundNone';
 import lblPotentialDuplicatesFoundOne from '@salesforce/label/c.potentialDuplicatesFoundOne';
@@ -25,11 +22,7 @@ export default class PotentialDuplicates extends NavigationMixin(LightningElemen
     lblViewDuplicatesLink = lblViewDuplicates;
     viewDuplicatesURL;
 
-    @wire(getRecord, {
-        recordId: '$recordId',
-        fields: [ FIELD_NAME ]
-    })
-    wireRecordChange() {
+    connectedCallback() {
         if (this.recordId) {
             getDuplicates({ recordId: this.recordId })
                 .then(response => {
@@ -48,6 +41,7 @@ export default class PotentialDuplicates extends NavigationMixin(LightningElemen
             this.duplicateCount = response.setOfMatches.split(',').length;
             this.duplicateIdsParam = this.recordId + ',' + response.setOfMatches;
         }
+        this.generateDuplicatesURL();
         this.updateTitle();
         this.handleToast();
     }
@@ -82,7 +76,6 @@ export default class PotentialDuplicates extends NavigationMixin(LightningElemen
             default:
                 this.lblTitle = lblPotentialDuplicatesFoundMultiple.replace("{0}", this.duplicateCount.toString());
         }
-        this.generateDuplicatesURL();
     }
 
     generateDuplicatesURL() {

--- a/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js-meta.xml
+++ b/force-app/main/default/lwc/potentialDuplicates/potentialDuplicates.js-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <description>Warns of potential duplicates as a result of Contact creation or edit.</description>
+    <isExposed>true</isExposed>
+    <masterLabel>NPSP Potential Duplicates</masterLabel>
+    <targets>
+        <target>lightning__RecordPage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>Contact</object>
+            </objects>
+            <property name="displayCard" type="Boolean" default="true" label="Display number of potential duplicates in card"/>
+            <property name="displayToast" type="Boolean" default="true" label="Display number of potential duplicates in toast message"/>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/force-app/main/selector/ContactMergeSelector.cls
+++ b/force-app/main/selector/ContactMergeSelector.cls
@@ -68,6 +68,16 @@ public with sharing class ContactMergeSelector {
         set;
     }
 
+    public List<SObject> selectContactsById(Set<Id> contactIds) {
+        String queryString = new UTIL_Query()
+            .withFrom(Contact.SObjectType)
+            .withSelectFields(listStrContactField)
+            .withWhere('Id IN :contactIds')
+            .build();
+
+        return Database.query(queryString);
+    }
+
     public List<SObject> selectContactsByName(String name) {
         UTIL_Finder finder = new UTIL_Finder(Contact.SObjectType);
         finder.withSelectFields(listStrContactField)


### PR DESCRIPTION
# Critical Changes

# Changes
Created NPSP Potential Duplicates component as a replacement for the standard Potential Duplicates component on the Contact page. Directs user to the NPSP Contact Merge page to review, select, and merge potential duplicate contacts.

# Issues Closed

# Community Ideas Delivered
[Potential Duplicates View Link doesn't point to the NPSP Merge Tool](https://ideas.salesforce.com/s/idea/a0B8W00000GdkqjUAB/potential-duplicates-view-link-doesnt-point-to-the-npsp-merge-tool)

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata
- Apex Classes
  - PotentialDuplicates
  - PotentialDuplicates_TEST
- LWC
  - potentialDuplicates.css
  - potentialDuplicates.html
  - potentialDuplicates.js
- Labels
  - potentialDuplicatesFoundNone
  - potentialDuplicatesFoundOne
  - potentialDuplicatesFoundMultiple

# Deleted Metadata
