### PR TITLE
@W-14204419 - Update RD2 preflight class_path to work-around installer errors

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -232,7 +232,7 @@ tasks:
 
     is_rd2_enabled:
         description: This preflight check ensures that Enhanced Recurring Donations is enabled
-        class_path: tasks.is_rd2_enabled
+        class_path: tasks.check_rd2_enablement.is_rd2_enabled
         group: NPSP
 
     robot:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,1 +1,0 @@
-from .check_rd2_enablement import is_rd2_enabled


### PR DESCRIPTION
A recent change to CumulusCI resulted in a regression for certain custom tasks. Before this commit:

```console
$ cci task run is_rd2_enabled
Error: module 'tasks' has no attribute 'is_rd2_enabled'

Run this command for more information about debugging errors: cci error --help
```

This resulted in an error when running preflight checks for the `enhanced-recurring-donations` plan in MetaDeploy. After:

```console
$ cci task run is_rd2_enabled
is_rd2_enabled

  Description: This preflight check ensures that Enhanced Recurring Donations is enabled

  Class: tasks.check_rd2_enablement.is_rd2_enabled
[...]
```

# Critical Changes

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
