### PR TITLE
W-12536493 - Fix Gift Entry accessibility issue with ‘Add Allocation’ button

### DIFF
--- a/force-app/main/default/lwc/utilCommon/utilCommon.js
+++ b/force-app/main/default/lwc/utilCommon/utilCommon.js
@@ -638,7 +638,7 @@ const nonePicklistOption = () => {
     return createPicklistOption(commonLabelNone, commonLabelNone);
 }
 
-const asyncInterval = async (callback, milliseconds, maxNumberOfIntervals = 5) => {
+const asyncInterval = async (callback, milliseconds, maxNumberOfIntervals = 20) => {
     return new Promise((resolve, reject) => {
         const intervalId = setInterval(async () => {
             if (await callback()) {


### PR DESCRIPTION
# Critical Changes

GUS [W-12536493](https://gus.lightning.force.com/a07EE00001LCuRnYAL)

Updated  
utilCommon.js : Updated the maxNumberOfIntervals from 5 to 20 so that it will continue to call focusOnGauLookup function to focus the gau-lookup field of the newly added row through add allocation button.

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
