### PR TITLE
W-15046973 Fix error on adding formula field to GAU allocations fieldset

### DIFF
--- a/force-app/main/default/classes/ALLO_ManageAllocations_CTRL.cls
+++ b/force-app/main/default/classes/ALLO_ManageAllocations_CTRL.cls
@@ -93,6 +93,10 @@ public with sharing class ALLO_ManageAllocations_CTRL {
         objectFields.add(Allocation__c.General_Accounting_Unit__c.getDescribe().getSobjectField());
 
         for(Schema.FieldSetMember additionalField : additionalAllocationFields) {
+            Schema.DescribeFieldResult fieldResult = additionalField.getSObjectField().getDescribe();
+            if (fieldResult.isCalculated() || !fieldResult.permissionable || additionalField.getFieldPath().contains('__r')) {
+                continue;
+            }
             objectFields.add(additionalField.getSObjectField());
         }
 


### PR DESCRIPTION

# Critical Changes
GUS [W-15046973](https://gus.lightning.force.com/a07EE00001kBJnXYAW)

Updated

- ALLO_ManageAllocations_CTRL.cls : 
Before checking access, fields in the GAU Allocations fieldset are checked for formula field type and permissionability.

# Changes

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
