### PR TITLE
W-17048425 - Donation Amount field on DI record gets cleared out after Batch processing

### DIFF
--- a/force-app/main/default/classes/BDI_DataImportService.cls
+++ b/force-app/main/default/classes/BDI_DataImportService.cls
@@ -626,9 +626,9 @@ global with sharing class BDI_DataImportService {
             if (apexJobId != null && listDI.size() > 0) {
                 List<DataImportBatch__c> listBatch = [SELECT Name, Batch_Number__c, Batch_Status__c, Batch_Defaults__c, 
                                             Form_Template__c, RequireTotalMatch__c, Expected_Count_of_Gifts__c, 
-                                            Expected_Total_Batch_Amount__c, Batch_Table_Columns__c, LastModifiedDate 
+                                            Expected_Total_Batch_Amount__c, Batch_Table_Columns__c, LastModifiedDate, GiftBatch__c 
                                             FROM DataImportBatch__c WHERE Id= :listDI[0].NPSP_Data_Import_Batch__c LIMIT 1];
-                if (listBatch.size() > 0 ) {
+                if (listBatch.size() > 0 && listBatch[0].GiftBatch__c) {
                     GiftBatch giftBatch = new GiftBatch(listBatch[0]);
                     Boolean firstInstallmentPaid = giftBatch.shouldPayFirstInstallment();
 

--- a/force-app/main/default/classes/GiftEntryProcessorQueue_TEST.cls
+++ b/force-app/main/default/classes/GiftEntryProcessorQueue_TEST.cls
@@ -46,7 +46,7 @@ private class GiftEntryProcessorQueue_TEST {
             BDI_MappingServiceAdvanced.DEFAULT_DATA_IMPORT_FIELD_MAPPING_SET_NAME;
         UTIL_CustomSettingsFacade.setDataImportSettings(dataImportSettings);
 
-        DataImportBatch__c giftBatch = new DataImportBatch__c();
+        DataImportBatch__c giftBatch = new DataImportBatch__c(GiftBatch__c = true);
         insert giftBatch;
 
         List<DataImport__c> giftsToInsert = new List<DataImport__c>();


### PR DESCRIPTION
# Critical Changes

# Changes
GUS : [W-17048425](https://gus.lightning.force.com/a07EE000023tcvZYAQ)

Changes in :

- BDI_DataImportService.cls : Check added to differentiate between a DI batch that is being processed, based on whether it was created with or without Gift Entry.

# Issues Closed

# Community Ideas Delivered

# Features Intended for Future Release

# Features for Elevate Customers

# New Metadata

# Deleted Metadata
